### PR TITLE
QA: Deposit modal fixes

### DIFF
--- a/packages/mixer/src/components/DepositConfirm/DepositConfirm.tsx
+++ b/packages/mixer/src/components/DepositConfirm/DepositConfirm.tsx
@@ -38,7 +38,6 @@ const DepositInfoWrapper = styled.div`
 
   .deposit-modal-alert-caption {
     font-family: ${FontFamilies.AvenirNext};
-    color: #7c7b86;
     text-align: center;
   }
 `;
@@ -181,12 +180,12 @@ export const DepositConfirm: React.FC<DepositInfoProps> = ({ mixerId, onClose, o
 
           <SpaceBox height={16} />
 
-          <Typography variant={'h4'} className={'deposit-modal-alert-header'} color={'textPrimary'}>
+          <Typography variant={'h3'} className={'deposit-modal-alert-header'} color={'textPrimary'}>
             Not so fast! <b>Back up your note.</b>
           </Typography>
           <SpaceBox height={8} />
-          <Typography variant={'body2'} className={'deposit-modal-alert-caption'}>
-            Please backup your note. If you lose this. <br /> you won't get your deposit back.
+          <Typography variant={'body1'} className={'deposit-modal-alert-caption'} color={'textPrimary'}>
+            Please backup your note. If you lose this,<br /> you won't get your deposit back.
           </Typography>
         </header>
 
@@ -221,7 +220,7 @@ export const DepositConfirm: React.FC<DepositInfoProps> = ({ mixerId, onClose, o
             setBackupConfirmation((v) => !v);
           }}
           control={<Checkbox color={'primary'} />}
-          label={<Typography color={'primary'}>I confirm,I backed up the note</Typography>}
+          label={<Typography color={'textPrimary'}>I confirm,I backed up the note</Typography>}
         />
 
         <SpaceBox height={8} />

--- a/packages/react-environment/src/api-providers/polkadot/polkadot-transaction.ts
+++ b/packages/react-environment/src/api-providers/polkadot/polkadot-transaction.ts
@@ -4,6 +4,7 @@ import { uniqueId } from 'lodash';
 import { ApiPromise, SubmittableResult } from '@polkadot/api';
 import { SubmittableExtrinsic } from '@polkadot/api/submittable/types';
 import { web3FromAddress } from '@polkadot/extension-dapp';
+import React from 'react';
 
 type MethodPath = {
   section: string;
@@ -23,11 +24,11 @@ type PolkadotTXEvents = {
   finalize: PolkadotTXEventsPayload;
   inBlock: PolkadotTXEventsPayload;
   extrinsicSuccess: PolkadotTXEventsPayload;
-  loading: PolkadotTXEventsPayload;
+  loading: PolkadotTXEventsPayload<JSX.Element>;
 };
 
 export type NotificationConfig = {
-  loading?: (data: PolkadotTXEventsPayload) => void;
+  loading?: (data: PolkadotTXEventsPayload<JSX.Element>) => void;
   finalize?: (data: PolkadotTXEventsPayload) => void;
   failed?: (data: PolkadotTXEventsPayload<string>) => void;
 };
@@ -57,7 +58,7 @@ export class PolkadotTx<P extends Array<any>> extends EventBus<PolkadotTXEvents>
       nonce: accountInfo.nonce.toNumber(),
     });
     this.emitWithPayload('beforeSend', undefined);
-    this.emitWithPayload('loading', undefined);
+    this.emitWithPayload('loading', React.createElement('div'));
 
     await this.send(txResults);
 

--- a/packages/react-environment/src/api-providers/web3/web3-mixer-deposit.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-mixer-deposit.ts
@@ -5,13 +5,23 @@ import { getNativeCurrencySymbol } from '@webb-dapp/apps/configs/evm/SupportedMi
 import { WebbWeb3Provider } from './webb-web3-provider';
 import { transactionNotificationConfig } from '@webb-dapp/wallet/providers/polkadot/transaction-notification-config';
 
+import React from 'react';
+import { DepositNotification } from '@webb-dapp/ui-components/notification/DepositNotification';
+import { getEVMChainName } from '@webb-dapp/apps/configs/evm/SupportedMixers';
+
 type DepositPayload = IDepositPayload<EvmNote, [Deposit, number]>;
 
 export class Web3MixerDeposit extends MixerDeposit<WebbWeb3Provider, DepositPayload> {
   async deposit(depositPayload: DepositPayload): Promise<void> {
     transactionNotificationConfig.loading?.({
       address: '',
-      data: undefined,
+      data: React.createElement(DepositNotification,
+        {
+          chain: getEVMChainName(depositPayload.note.chainId),
+          amount: depositPayload.note.amount,
+          currency: depositPayload.note.currency,
+        }
+      ),
       key: 'mixer-deposit-evm',
       path: {
         method: 'deposit',
@@ -24,7 +34,7 @@ export class Web3MixerDeposit extends MixerDeposit<WebbWeb3Provider, DepositPayl
     transactionNotificationConfig.finalize?.({
       address: '',
       data: undefined,
-      key: `deposit success`,
+      key: `mixer-deposit-evm`,
       path: {
         method: 'deposit',
         section: 'evm-mixer',

--- a/packages/react-environment/src/api-providers/web3/web3-mixer-withdraw.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-mixer-withdraw.ts
@@ -2,6 +2,7 @@ import { MixerWithdraw, WithdrawState } from '@webb-dapp/react-environment/webb-
 import { WebbWeb3Provider } from '@webb-dapp/react-environment/api-providers/web3/webb-web3-provider';
 import { transactionNotificationConfig } from '@webb-dapp/wallet/providers/polkadot/transaction-notification-config';
 import { EvmNote } from '@webb-dapp/contracts/utils/evm-note';
+import React from 'react';
 
 export class Web3MixerWithdraw extends MixerWithdraw<WebbWeb3Provider> {
   cancelWithdraw(): Promise<void> {
@@ -15,7 +16,7 @@ export class Web3MixerWithdraw extends MixerWithdraw<WebbWeb3Provider> {
     const txReset = await contract.withdraw(note, recipient);
     transactionNotificationConfig.loading?.({
       address: '',
-      data: undefined,
+      data: React.createElement('p', {}, 'Withdraw In Progress'),
       key: 'mixer-withdraw-evm',
       path: {
         method: 'withdraw',

--- a/packages/ui-components/src/notification/DepositNotification.tsx
+++ b/packages/ui-components/src/notification/DepositNotification.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+
+type DepositNotificationProps = {
+  chain: string,
+  amount: number,
+  currency: string,
+}
+
+export class DepositNotification extends React.Component<DepositNotificationProps> {
+  render() {
+    return (
+      <div>
+        <Typography variant={'h6'}>Depositing on: {this.props.chain} </Typography>
+        <Typography variant={'h6'}>Size: {this.props.amount}</Typography>
+        <Typography variant={'h6'}>Token: {this.props.currency}</Typography>
+      </div>
+    )
+  }
+}

--- a/packages/ui-components/src/notification/Notification.tsx
+++ b/packages/ui-components/src/notification/Notification.tsx
@@ -128,9 +128,9 @@ export const Alert: React.FC<{
     <AlertWrapper color={color} as={Paper} elevation={4}>
       <AlertIconWrapper color={opts.transparent ? 'rgba(0,0,0,0)' : color}>{AlertIcon}</AlertIconWrapper>
       <AlertCopyWrapper>
-        <Typography variant={'h6'} component={'p'}>
+        {typeof(opts.message) === "string" ? <Typography variant={'h6'} component={'p'}>
           {opts.message}
-        </Typography>
+        </Typography> : opts.message }
         <Typography>{opts.secondaryMessage}</Typography>
       </AlertCopyWrapper>
       <AlertActionsWrapper>

--- a/packages/wallet/src/providers/polkadot/transaction-notification-config.tsx
+++ b/packages/wallet/src/providers/polkadot/transaction-notification-config.tsx
@@ -21,7 +21,7 @@ export const transactionNotificationConfig: NotificationConfig = {
         persist: true,
       },
       key: data.key,
-      message: data.address ? <FormatAddress address={data.address} /> : '',
+      message: data.data,
       secondaryMessage: `${data.path.section}: ${data.path.method}`,
       variant: 'info',
       // eslint-disable-next-line sort-keys


### PR DESCRIPTION
* Implement style fixes for some fonts on Deposit modal.
* Change to a more descriptive Deposit Notification.

Before:

![DepositModalBefore](https://user-images.githubusercontent.com/16654909/126365754-4e61cef7-71e6-45be-a402-142a313015f4.png)

After:

![DepositModalAfter](https://user-images.githubusercontent.com/16654909/126365852-3e8d4668-4568-4cfb-9b02-9a542e0e409d.png)

Notification:

![DepositNotification](https://user-images.githubusercontent.com/16654909/126365871-cb93d9e4-94f8-4004-b738-7f03556b8b41.png)
