### PR TITLE
Throw an unsupported network error if the chain is not recognized

### DIFF
--- a/packages/apps/src/configs/evm/SupportedMixers.ts
+++ b/packages/apps/src/configs/evm/SupportedMixers.ts
@@ -41,9 +41,7 @@ export const rinkebyMixers: MixerInfo[] = [
   },
 ];
 
-export const ethMainNetMixers: MixerInfo[] = [
-
-];
+export const ethMainNetMixers: MixerInfo[] = [];
 
 export const beresheetMixers: MixerInfo[] = [
   {
@@ -105,5 +103,5 @@ export const harmonyTest1Mixers: MixerInfo[] = [
     address: '0x7cd173094eF78FFAeDee4e14576A73a79aA716ac',
     symbol: 'ONE',
     createdAtBlock: 12892840,
-  }
+  },
 ];

--- a/packages/react-environment/src/WebbProvider.tsx
+++ b/packages/react-environment/src/WebbProvider.tsx
@@ -337,12 +337,13 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
                 },
               });
             };
-            if (chainId !== chain.evmId && activeChain) {
+            if (chainId !== chain.evmId) {
+              const activeChainName = activeChain ? activeChain.name : 'unknown';
               const feedback = evmChainConflict(
                 {
                   activeOnExtension: {
                     id: chainId,
-                    name: activeChain.name,
+                    name: activeChainName,
                   },
                   selected: {
                     id: chain?.evmId ?? 0,

--- a/packages/react-environment/src/error/interactive-errors/evm-network-conflict.ts
+++ b/packages/react-environment/src/error/interactive-errors/evm-network-conflict.ts
@@ -54,8 +54,8 @@ export function evmChainConflict(params: EvmNetworkConflictParams, appEvent: TAp
     },
 
     {
-      content: `The selected chain is ${params.selected.name} with id (${params.selected.id})
-      ;However the active on metamask is ${params.activeOnExtension.name} with id ${params.activeOnExtension.id}`,
+      content: `The selected chain is ${params.selected.name} with id (${params.selected.id});
+       however the active on metamask is ${params.activeOnExtension.name} with id ${params.activeOnExtension.id}`,
     },
     {
       content: `To continue using ${params.selected.name}`,


### PR DESCRIPTION
These changes remove dependency on activeChain variable when initializing interactive feedback in the app.  This allows for an unsupported network error on page load.

It is a bit awkward though because the error will show the Ethereum Mainnet as something 'unknown'. Maybe it would be better to move forward with an update to WebbErrors to differentiate between 'UnknownChain' and 'UnsupportedChain'?