### PR TITLE
Retrieve leaves from relayer and store if appropriate

### DIFF
--- a/packages/contracts/src/contracts/tornado-anchor.ts
+++ b/packages/contracts/src/contracts/tornado-anchor.ts
@@ -16,6 +16,7 @@ import {
 } from '@webb-dapp/react-environment/api-providers/web3/EvmChainMixersInfo';
 import { MerkleTree, MimcSpongeHasher } from '@webb-dapp/utils/merkle';
 import { retryPromise } from '@webb-dapp/utils/retry-promise';
+import { WebbError, WebbErrorCodes } from '@webb-dapp/utils/webb-error';
 import { LoggerService } from '@webb-tools/app-util';
 import { BigNumber, Contract, providers, Signer } from 'ethers';
 import utils from 'web3-utils';
@@ -203,13 +204,50 @@ export class TornadoAnchorContract {
     return { proof, input: zkpInput };
   }
 
-  // If leaves are provided, don't do anything with storage
-  async generateZKPWithLeaves(deposit: Deposit, zkpPublicInputs: ZKPTornPublicInputs, leaves: string[]) {
+  // function to call when generating ZKP with a relayer
+  async generateZKPWithLeaves(
+    deposit: Deposit,
+    zkpPublicInputs: ZKPTornPublicInputs,
+    leaves: string[],
+    lastQueriedBlock: number
+  ) {
+    // Build a local merkle tree from the leaves
     const treeHeight = await this._contract.levels();
     const tree = new MerkleTree('eth', treeHeight, leaves, new MimcSpongeHasher());
     let leafIndex = leaves.findIndex((commitment) => commitment == bufferToFixed(deposit.commitment));
     logger.info(`Leaf index ${leafIndex}`);
     const merkleProof = tree.path(leafIndex);
+
+    // Verify the local merkle tree against what is on chain
+    const newRoot = tree.get_root();
+    const formattedRoot = bufferToFixed(newRoot);
+    const knownRoot = await this._contract.isKnownRoot(formattedRoot);
+
+    if (!knownRoot) {
+      throw WebbError.from(WebbErrorCodes.RelayerMisbehaving);
+    }
+
+    // verify the last commitment in the leaves occurred at the reported block
+    const filter = this._contract.filters.Deposit(null, null, null);
+    const logs = await this.web3Provider.getLogs({
+      fromBlock: lastQueriedBlock,
+      toBlock: lastQueriedBlock,
+      ...filter,
+    });
+    const events = logs.map((log) => this._contract.interface.parseLog(log));
+    let validLatestDeposit = false;
+    events.forEach((event) => {
+      if (event.args.find((elem) => elem === leaves[leaves.length - 1])) {
+        validLatestDeposit = true;
+      }
+    });
+
+    // If the last commitment occurred at the reported block and
+    // the block is later than what we have stored, save into storage
+    const storedContractInfo = await this.mixersInfo.getMixerStorage(this._contract.address);
+    if (validLatestDeposit && lastQueriedBlock > storedContractInfo.lastQueriedBlock) {
+      this.mixersInfo.setMixerStorage(this._contract.address, lastQueriedBlock, [...leaves]);
+    }
 
     const { pathElements, pathIndex: pathIndices, root } = merkleProof;
     let circuitData = require('../circuits/withdraw.json');

--- a/packages/mixer/src/hooks/withdraw/useWithdraw.tsx
+++ b/packages/mixer/src/hooks/withdraw/useWithdraw.tsx
@@ -3,6 +3,8 @@ import { ActiveWebbRelayer, WebbRelayer } from '@webb-dapp/react-environment/web
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Note } from '@webb-tools/sdk-mixer';
 import { LoggerService } from '@webb-tools/app-util';
+import { InteractiveFeedback, WebbErrorCodes } from '@webb-dapp/utils/webb-error';
+import { misbehavingRelayer } from '@webb-dapp/react-environment/error/interactive-errors/misbehaving-relayer';
 
 const logger = LoggerService.get('useWithdrawHook');
 
@@ -38,6 +40,7 @@ export const useWithdraw = (params: UseWithdrawProps) => {
       recipient: '',
     },
   });
+  const { registerInteractiveFeedback } = useWebContext();
   const withdrawApi = useMemo(() => {
     const withdraw = activeApi?.methods.mixer.withdraw;
     if (!withdraw?.enabled) return null;
@@ -98,9 +101,18 @@ export const useWithdraw = (params: UseWithdrawProps) => {
     if (!withdrawApi) return;
     if (stage === WithdrawState.Ideal) {
       const { note, recipient } = params;
-      await withdrawApi.withdraw(note, recipient);
+      try {
+        await withdrawApi.withdraw(note, recipient);
+      } catch (e) {
+        console.log('error from withdraw api');
+
+        if (e.code === WebbErrorCodes.RelayerMisbehaving) {
+          let interactiveFeedback: InteractiveFeedback = misbehavingRelayer();
+          registerInteractiveFeedback(interactiveFeedback);
+        }
+      }
     }
-  }, [withdrawApi, params, stage]);
+  }, [withdrawApi, stage, params]);
 
   const canCancel = useMemo(() => {
     return stage < WithdrawState.SendingTransaction && stage > WithdrawState.Ideal;

--- a/packages/react-environment/src/WebbProvider.tsx
+++ b/packages/react-environment/src/WebbProvider.tsx
@@ -195,6 +195,8 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
           registerInteractiveFeedback(setInteractiveFeedbacks, interactiveFeedback);
         }
         break;
+      case WebbErrorCodes.RelayerMisbehaving:
+        break;
       default:
         alert(code);
     }

--- a/packages/react-environment/src/api-providers/web3/web3-mixer-withdraw.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-mixer-withdraw.ts
@@ -112,120 +112,145 @@ export class Web3MixerWithdraw extends MixerWithdraw<WebbWeb3Provider> {
     const chainId = Number(evmNote.note.chain) as ChainId;
     console.log(deposit);
     if (activeRelayer && activeRelayer.account) {
-      this.emit('stateChange', WithdrawState.GeneratingZk);
+      try {
+        this.emit('stateChange', WithdrawState.GeneratingZk);
 
-      transactionNotificationConfig.loading?.({
-        address: recipient,
-        data: React.createElement(
-          'p',
-          { style: { fontSize: '.9rem' } }, // Matches Typography variant=h6
-          `Relaying withdraw through ${activeRelayer.endpoint}`
-        ),
-        key: 'mixer-withdraw-evm',
-        path: {
-          method: 'withdraw',
-          section: 'evm-mixer',
-        },
-      });
-      logger.info(`Withdrawing through relayer with address ${activeRelayer.endpoint}`);
-      logger.trace('Note deserialized', evmNote);
-      const mixerInfo = this.inner.getMixerInfoBySize(Number(evmNote.note.amount), evmNote.note.tokenSymbol);
-      logger.info(`Withdrawing to mixer info`, mixerInfo);
-      const anchorContract = await this.inner.getContractByAddress(mixerInfo.address);
-      logger.trace('Generating the zkp');
-      const fees = await activeRelayer.fees(note);
-      const zkpInputWithoutMerkleProof = fromDepositIntoZKPTornPublicInputs(deposit, {
-        recipient,
-        relayer: activeRelayer.account,
-        fee: Number(fees?.totalFees),
-      });
-
-      const leavesResponse = await fetch(`${activeRelayer.endpoint}/api/v1/leaves/${mixerInfo.address}`);
-      const leaves: string[] = (await leavesResponse.json()).leaves;
-
-      // This is the part of withdraw that takes a long time
-      this.emit('stateChange', WithdrawState.GeneratingZk);
-      const zkp = await anchorContract.generateZKPWithLeaves(deposit, zkpInputWithoutMerkleProof, leaves);
-
-      logger.trace('Generated the zkp', zkp);
-
-      // Check for cancelled here, abort if it was set.
-      // Mark the withdraw mixer as able to withdraw again.
-      if (this.cancelToken.cancelled) {
-        transactionNotificationConfig.failed?.({
+        transactionNotificationConfig.loading?.({
           address: recipient,
-          data: 'Withdraw cancelled',
+          data: React.createElement(
+            'p',
+            { style: { fontSize: '.9rem' } }, // Matches Typography variant=h6
+            `Relaying withdraw through ${activeRelayer.endpoint}`
+          ),
           key: 'mixer-withdraw-evm',
           path: {
             method: 'withdraw',
             section: 'evm-mixer',
           },
         });
+        logger.info(`Withdrawing through relayer with address ${activeRelayer.endpoint}`);
+        logger.trace('Note deserialized', evmNote);
+        const mixerInfo = this.inner.getMixerInfoBySize(Number(evmNote.note.amount), evmNote.note.tokenSymbol);
+        logger.info(`Withdrawing to mixer info`, mixerInfo);
+        const anchorContract = await this.inner.getContractByAddress(mixerInfo.address);
+        logger.trace('Generating the zkp');
+        const fees = await activeRelayer.fees(note);
+        const zkpInputWithoutMerkleProof = fromDepositIntoZKPTornPublicInputs(deposit, {
+          recipient,
+          relayer: activeRelayer.account,
+          fee: Number(fees?.totalFees),
+        });
+
+        const leavesResponse = await fetch(`${activeRelayer.endpoint}/api/v1/leaves/${mixerInfo.address}`);
+        const formattedLeavesResponse = await leavesResponse.json();
+        const leaves: string[] = formattedLeavesResponse.leaves;
+        const lastQueriedBlock: number = parseInt(formattedLeavesResponse.lastQueriedBlock, 16);
+        console.log(lastQueriedBlock);
+
+        // This is the part of withdraw that takes a long time
+        this.emit('stateChange', WithdrawState.GeneratingZk);
+        const zkp = await anchorContract.generateZKPWithLeaves(
+          deposit,
+          zkpInputWithoutMerkleProof,
+          leaves,
+          lastQueriedBlock
+        );
+
+        logger.trace('Generated the zkp', zkp);
+
+        // Check for cancelled here, abort if it was set.
+        // Mark the withdraw mixer as able to withdraw again.
+        if (this.cancelToken.cancelled) {
+          transactionNotificationConfig.failed?.({
+            address: recipient,
+            data: 'Withdraw cancelled',
+            key: 'mixer-withdraw-evm',
+            path: {
+              method: 'withdraw',
+              section: 'evm-mixer',
+            },
+          });
+          this.emit('stateChange', WithdrawState.Ideal);
+          return;
+        }
+
+        this.emit('stateChange', WithdrawState.SendingTransaction);
+
+        const relayedWithdraw = await activeRelayer.initWithdraw();
+        logger.trace('initialized the withdraw WebSocket');
+
+        const tx = relayedWithdraw.generateWithdrawRequest(
+          {
+            baseOn: 'evm',
+            name: chainIdToRelayerName(chainId),
+            contractAddress: mixerInfo.address,
+            endpoint: '',
+          },
+          zkp.proof,
+          {
+            fee: bufferToFixed(zkp.input.fee),
+            nullifierHash: bufferToFixed(zkp.input.nullifierHash),
+            recipient: zkp.input.recipient,
+            refund: bufferToFixed(zkp.input.refund),
+            relayer: zkp.input.relayer,
+            root: bufferToFixed(zkp.input.root),
+          }
+        );
+        relayedWithdraw.watcher.subscribe(([nextValue, message]) => {
+          switch (nextValue) {
+            case RelayedWithdrawResult.PreFlight:
+            case RelayedWithdrawResult.OnFlight:
+              this.emit('stateChange', WithdrawState.SendingTransaction);
+              break;
+            case RelayedWithdrawResult.Continue:
+              break;
+            case RelayedWithdrawResult.CleanExit:
+              this.emit('stateChange', WithdrawState.Done);
+              this.emit('stateChange', WithdrawState.Ideal);
+              transactionNotificationConfig.finalize?.({
+                address: recipient,
+                data: undefined,
+                key: 'mixer-withdraw-evm',
+                path: {
+                  method: 'withdraw',
+                  section: 'evm-mixer',
+                },
+              });
+              break;
+            case RelayedWithdrawResult.Errored:
+              this.emit('stateChange', WithdrawState.Failed);
+              this.emit('stateChange', WithdrawState.Ideal);
+              transactionNotificationConfig.failed?.({
+                address: recipient,
+                data: message || 'Withdraw failed',
+                key: 'mixer-withdraw-evm',
+                path: {
+                  method: 'withdraw',
+                  section: 'evm-mixer',
+                },
+              });
+              break;
+          }
+        });
+        logger.trace('Sending transaction');
+        relayedWithdraw.send(tx);
+        await relayedWithdraw.await();
+      } catch (e) {
+        this.emit('stateChange', WithdrawState.Failed);
         this.emit('stateChange', WithdrawState.Ideal);
-        return;
+        transactionNotificationConfig.failed?.({
+          address: recipient,
+          data: 'Withdraw failed',
+          key: 'mixer-withdraw-evm',
+          path: {
+            method: 'withdraw',
+            section: 'evm-mixer',
+          },
+        });
+        if (e.code === WebbErrorCodes.RelayerMisbehaving) {
+          throw e;
+        }
       }
-
-      this.emit('stateChange', WithdrawState.SendingTransaction);
-
-      const relayedWithdraw = await activeRelayer.initWithdraw();
-      logger.trace('initialized the withdraw WebSocket');
-
-      const tx = relayedWithdraw.generateWithdrawRequest(
-        {
-          baseOn: 'evm',
-          name: chainIdToRelayerName(chainId),
-          contractAddress: mixerInfo.address,
-          endpoint: '',
-        },
-        zkp.proof,
-        {
-          fee: bufferToFixed(zkp.input.fee),
-          nullifierHash: bufferToFixed(zkp.input.nullifierHash),
-          recipient: zkp.input.recipient,
-          refund: bufferToFixed(zkp.input.refund),
-          relayer: zkp.input.relayer,
-          root: bufferToFixed(zkp.input.root),
-        }
-      );
-      relayedWithdraw.watcher.subscribe(([nextValue, message]) => {
-        switch (nextValue) {
-          case RelayedWithdrawResult.PreFlight:
-          case RelayedWithdrawResult.OnFlight:
-            this.emit('stateChange', WithdrawState.SendingTransaction);
-            break;
-          case RelayedWithdrawResult.Continue:
-            break;
-          case RelayedWithdrawResult.CleanExit:
-            this.emit('stateChange', WithdrawState.Done);
-            this.emit('stateChange', WithdrawState.Ideal);
-            transactionNotificationConfig.finalize?.({
-              address: recipient,
-              data: undefined,
-              key: 'mixer-withdraw-evm',
-              path: {
-                method: 'withdraw',
-                section: 'evm-mixer',
-              },
-            });
-            break;
-          case RelayedWithdrawResult.Errored:
-            this.emit('stateChange', WithdrawState.Failed);
-            this.emit('stateChange', WithdrawState.Ideal);
-            transactionNotificationConfig.failed?.({
-              address: recipient,
-              data: message || 'Withdraw failed',
-              key: 'mixer-withdraw-evm',
-              path: {
-                method: 'withdraw',
-                section: 'evm-mixer',
-              },
-            });
-            break;
-        }
-      });
-      logger.trace('Sending transaction');
-      relayedWithdraw.send(tx);
-      await relayedWithdraw.await();
     } else {
       logger.trace('Withdrawing without relayer');
       transactionNotificationConfig.loading?.({

--- a/packages/react-environment/src/error/interactive-errors/misbehaving-relayer.tsx
+++ b/packages/react-environment/src/error/interactive-errors/misbehaving-relayer.tsx
@@ -1,0 +1,32 @@
+import { InteractiveFeedback, WebbErrorCodes } from '@webb-dapp/utils/webb-error';
+
+export function misbehavingRelayer(): InteractiveFeedback {
+  let interactiveFeedback: InteractiveFeedback;
+  const feedbackBody = InteractiveFeedback.feedbackEntries([
+    {
+      header: `Bad Relayer`,
+    },
+    {
+      content: 'The selected relayer is not operating properly. Please select a different relayer.',
+    },
+  ]);
+  const actions = InteractiveFeedback.actionsBuilder()
+    .action(
+      'Ok',
+      () => {
+        interactiveFeedback?.cancelWithoutHandler();
+      },
+      'success'
+    )
+    .actions();
+  interactiveFeedback = new InteractiveFeedback(
+    'error',
+    actions,
+    () => {
+      interactiveFeedback?.cancel();
+    },
+    feedbackBody,
+    WebbErrorCodes.RelayerMisbehaving
+  );
+  return interactiveFeedback;
+}

--- a/packages/utils/src/webb-error/webb-error.class.ts
+++ b/packages/utils/src/webb-error/webb-error.class.ts
@@ -20,6 +20,8 @@ export enum WebbErrorCodes {
   EVMSessionAlreadyEnded,
   /// Relayer does not support the mixer
   RelayerUnsupportedMixer,
+  /// Relayer is not operating properly (sending bad leaves, etc.)
+  RelayerMisbehaving,
 }
 
 /// An Error message with error metadata
@@ -101,6 +103,11 @@ export class WebbError extends Error {
         return {
           code,
           message: `Attempt to use a relayer which does not support the mixer`,
+        };
+      case WebbErrorCodes.RelayerMisbehaving:
+        return {
+          code,
+          message: `The selected relayer is not operating properly`,
         };
 
       default:


### PR DESCRIPTION
This PR allows for communication with the relayer to store the fetched leaves if the following conditions are met:
1. The merkle root computed from the leaves query matches a known root on chain.
2. The reported block from the relayer contains the transaction of the last entry in the leaves.

These validations are necessary to prevent malicious relayers from injecting incorrect state into the local storage of the client. These validations could allow a client to withdraw without a relayer but quickly build proofs - if we wish to implement this functionality.

Additionally, this PR detects relayers which are not operating properly and shows an interactiveFeedback modal.