### PR TITLE
Prompt to add chain if switching does not work

### DIFF
--- a/packages/mixer/src/hooks/withdraw/useWithdraw.tsx
+++ b/packages/mixer/src/hooks/withdraw/useWithdraw.tsx
@@ -106,7 +106,7 @@ export const useWithdraw = (params: UseWithdrawProps) => {
         const txReceipt = await withdrawApi.withdraw(note, recipient);
         setReceipt(txReceipt);
       } catch (e) {
-        console.log('error from withdraw api');
+        console.log('error from withdraw api', e);
 
         if (e.code === WebbErrorCodes.RelayerMisbehaving) {
           let interactiveFeedback: InteractiveFeedback = misbehavingRelayer();

--- a/packages/react-environment/src/api-providers/web3/web3-mixer-withdraw.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-mixer-withdraw.ts
@@ -11,7 +11,6 @@ import {
   WithdrawState,
 } from '@webb-dapp/react-environment/webb-context';
 import { RelayedWithdrawResult, WebbRelayer } from '@webb-dapp/react-environment/webb-context/relayer';
-import { useFetch } from '@webb-dapp/react-hooks/useFetch';
 import { WebbError, WebbErrorCodes } from '@webb-dapp/utils/webb-error';
 import { transactionNotificationConfig } from '@webb-dapp/wallet/providers/polkadot/transaction-notification-config';
 import { LoggerService } from '@webb-tools/app-util';
@@ -114,23 +113,26 @@ export class Web3MixerWithdraw extends MixerWithdraw<WebbWeb3Provider> {
     const deposit = depositFromPreimage(evmNote.note.secret.replace('0x', ''));
     const chainId = Number(evmNote.note.chain) as ChainId;
     const chainEvmId = chainIdIntoEVMId(chainId);
-    console.log(deposit);
 
     const activeChain = await this.inner.getChainId();
+    console.log('activeChain', activeChain);
+    console.log('chainEvmId', chainEvmId);
+    this.emit('stateChange', WithdrawState.GeneratingZk);
+
     if (activeChain !== chainEvmId) {
       try {
-        await this.inner.innerProvider.switchChain({
-          chainId: `0x${chainEvmId.toString(16)}`,
-        });
+        console.log('trying to switch or add');
+        await this.inner.switchOrAddChain(chainEvmId);
       } catch (e) {
+        console.log('error: ', e);
         this.emit('stateChange', WithdrawState.Ideal);
         transactionNotificationConfig.failed?.({
           address: recipient,
-          data: e?.code === 4001 ? 'Withdraw rejected' : 'Withdraw failed',
-          key: 'mixer-withdraw-evm',
+          data: 'Withdraw rejected',
+          key: 'bridge-withdraw-evm',
           path: {
             method: 'withdraw',
-            section: `evm-mixer`,
+            section: 'evm-mixer',
           },
         });
         return '';
@@ -139,8 +141,6 @@ export class Web3MixerWithdraw extends MixerWithdraw<WebbWeb3Provider> {
 
     if (activeRelayer && activeRelayer.account) {
       try {
-        this.emit('stateChange', WithdrawState.GeneratingZk);
-
         transactionNotificationConfig.loading?.({
           address: recipient,
           data: React.createElement(
@@ -285,7 +285,6 @@ export class Web3MixerWithdraw extends MixerWithdraw<WebbWeb3Provider> {
           section: 'evm-mixer',
         },
       });
-      this.emit('stateChange', WithdrawState.GeneratingZk);
       const contract = await this.inner.getContractBySize(Number(evmNote.note.amount), evmNote.note.tokenSymbol);
       try {
         const zkpInputWithoutMerkleProof = fromDepositIntoZKPTornPublicInputs(deposit, {

--- a/packages/react-environment/src/api-providers/web3/webb-web3-provider.ts
+++ b/packages/react-environment/src/api-providers/web3/webb-web3-provider.ts
@@ -1,3 +1,5 @@
+import { chainsConfig, currenciesConfig, evmIdIntoChainId } from '@webb-dapp/apps/configs';
+import { WebbAnchorContract } from '@webb-dapp/contracts/contracts';
 import { TornadoAnchorContract } from '@webb-dapp/contracts/contracts/tornado-anchor';
 import { WebbApiProvider, WebbMethods, WebbProviderEvents } from '@webb-dapp/react-environment';
 import { EvmChainMixersInfo } from '@webb-dapp/react-environment/api-providers/web3/EvmChainMixersInfo';
@@ -12,7 +14,6 @@ import { Web3Accounts } from '@webb-dapp/wallet/providers/web3/web3-accounts';
 import { Web3Provider } from '@webb-dapp/wallet/providers/web3/web3-provider';
 import { EventBus } from '@webb-tools/app-util';
 import { ethers, providers } from 'ethers';
-import { WebbAnchorContract } from '@webb-dapp/contracts/contracts';
 
 export class WebbWeb3Provider
   extends EventBus<WebbProviderEvents<[number]>>
@@ -166,6 +167,43 @@ export class WebbWeb3Provider
       let reason = ethers.utils.toUtf8String('0x' + code.substr(138));
       return reason;
     }
+  }
+
+  switchOrAddChain(evmChainId: number) {
+    return this.web3Provider
+      .switchChain({
+        chainId: `0x${evmChainId.toString(16)}`,
+      })
+      ?.catch(async (switchError) => {
+        console.log('inside catch for switchChain', switchError);
+
+        // cannot switch because network not recognized, so fetch configuration
+        const chainId = evmIdIntoChainId(evmChainId);
+        const chain = chainsConfig[chainId];
+
+        // prompt to add the chain
+        if (switchError.code === 4902) {
+          const currency = currenciesConfig[chain.nativeCurrencyId];
+          await this.web3Provider.addChain({
+            chainId: `0x${evmChainId.toString(16)}`,
+            chainName: chain.name,
+            rpcUrls: chain.evmRpcUrls!,
+            nativeCurrency: {
+              decimals: 18,
+              name: currency.name,
+              symbol: currency.symbol,
+            },
+          });
+          // add network will prompt the switch, check evmId again and throw if user rejected
+          const newChainId = await this.web3Provider.network;
+
+          if (newChainId != chain.evmId) {
+            throw switchError;
+          }
+        } else {
+          throw switchError;
+        }
+      });
   }
 
   public get innerProvider() {


### PR DESCRIPTION
Changes were recently made to allow withdraws for the DApp starting from any network; however, the logic did not take into account the scenario where a user does not have the network added in Metamask. This PR fixes this case.