### PR TITLE
Relay withdraw requests for Tornados and proper relayer display for Anchors

### DIFF
--- a/packages/apps/src/configs/evm/SupportedMixers.ts
+++ b/packages/apps/src/configs/evm/SupportedMixers.ts
@@ -1,8 +1,8 @@
 import { chainsConfig, currenciesConfig } from '@webb-dapp/apps/configs';
 import { WebbError, WebbErrorCodes } from '@webb-dapp/utils/webb-error';
 
-export const getNativeCurrencySymbol = (chainID: number): string => {
-  const chain = Object.values(chainsConfig).find((chainsConfig) => chainsConfig.evmId === chainID);
+export const getNativeCurrencySymbol = (evmId: number): string => {
+  const chain = Object.values(chainsConfig).find((chainsConfig) => chainsConfig.evmId === evmId);
   if (chain) {
     const nativeCurrency = chain.nativeCurrencyId;
     return currenciesConfig[nativeCurrency].symbol;
@@ -10,8 +10,8 @@ export const getNativeCurrencySymbol = (chainID: number): string => {
   return 'Unknown';
 };
 
-export const getEVMChainName = (chainID: number): string => {
-  const chain = Object.values(chainsConfig).find((chainsConfig) => chainsConfig.evmId === chainID);
+export const getEVMChainName = (evmId: number): string => {
+  const chain = Object.values(chainsConfig).find((chainsConfig) => chainsConfig.evmId === evmId);
   if (chain) {
     return chain.name;
   } else {

--- a/packages/apps/src/configs/wallets/wallets-config.ts
+++ b/packages/apps/src/configs/wallets/wallets-config.ts
@@ -29,7 +29,7 @@ export const walletsConfig: AppConfig['wallet'] = {
     async detect() {
       return true;
     },
-    supportedChainIds: [ChainId.EdgewareTestNet, ChainId.EdgewareLocalNet],
+    supportedChainIds: [ChainId.EdgewareLocalNet],
   },
   [WalletId.MetaMask]: {
     id: WalletId.MetaMask,
@@ -47,18 +47,18 @@ export const walletsConfig: AppConfig['wallet'] = {
     },
     supportedChainIds: [...ANY_EVM],
   },
-  3: {
-    id: 3,
-    logo: WalletConnectLogo,
-    name: 'wallet connect',
-    title: `Wallet Connect`,
-    platform: 'EVM',
-    enabled: true,
-    detect() {
-      return true;
-    },
-    supportedChainIds: [...ANY_EVM],
-  },
+  // 3: {
+  //   id: 3,
+  //   logo: WalletConnectLogo,
+  //   name: 'wallet connect',
+  //   title: `Wallet Connect`,
+  //   platform: 'EVM',
+  //   enabled: true,
+  //   detect() {
+  //     return true;
+  //   },
+  //   supportedChainIds: [...ANY_EVM],
+  // },
   // [WalletId.OneWallet]: {
   //   id: WalletId.OneWallet,
   //   logo: HarmonyLogo,

--- a/packages/bridge/src/components/Withdraw/Withdraw.tsx
+++ b/packages/bridge/src/components/Withdraw/Withdraw.tsx
@@ -1,19 +1,21 @@
-import React, { useCallback, useMemo, useState } from 'react';
 import { FormHelperText, InputBase } from '@material-ui/core';
+import { chainIdIntoEVMId, chainsPopulated, currenciesConfig } from '@webb-dapp/apps/configs';
 import WithdrawingModal from '@webb-dapp/bridge/components/Withdraw/WithdrawingModal';
+import { useWithdraw } from '@webb-dapp/bridge/hooks';
+import { useDepositNote } from '@webb-dapp/mixer';
+import WithdrawSuccessModal from '@webb-dapp/react-components/Withdraw/WithdrawSuccessModal';
+import { useWebContext, WithdrawState } from '@webb-dapp/react-environment';
+import { ActiveWebbRelayer } from '@webb-dapp/react-environment/webb-context/relayer';
 import { SpaceBox } from '@webb-dapp/ui-components';
+import { MixerButton } from '@webb-dapp/ui-components/Buttons/MixerButton';
 import { InputLabel } from '@webb-dapp/ui-components/Inputs/InputLabel/InputLabel';
+import { InputSection } from '@webb-dapp/ui-components/Inputs/InputSection/InputSection';
 import { BridgeNoteInput } from '@webb-dapp/ui-components/Inputs/NoteInput/BridgeNoteInput';
 import { Modal } from '@webb-dapp/ui-components/Modal/Modal';
-import styled from 'styled-components';
-import { WithdrawState } from '@webb-dapp/react-environment';
-import { InputSection } from '@webb-dapp/ui-components/Inputs/InputSection/InputSection';
-import { useDepositNote } from '@webb-dapp/mixer';
-import { useWithdraw } from '@webb-dapp/bridge/hooks';
-import WithdrawSuccessModal from '@webb-dapp/react-components/Withdraw/WithdrawSuccessModal';
-import { MixerButton } from '@webb-dapp/ui-components/Buttons/MixerButton';
 import RelayerInput, { FeesInfo, RelayerApiAdapter } from '@webb-dapp/ui-components/RelayerInput/RelayerInput';
-import { ActiveWebbRelayer, WebbRelayer } from '@webb-dapp/react-environment/webb-context/relayer';
+import { Note } from '@webb-tools/sdk-mixer';
+import React, { useCallback, useMemo, useState } from 'react';
+import styled from 'styled-components';
 
 const WithdrawWrapper = styled.div``;
 type WithdrawProps = {};
@@ -21,12 +23,24 @@ type WithdrawProps = {};
 export const Withdraw: React.FC<WithdrawProps> = () => {
   const [note, setNote] = useState('');
   const [recipient, setRecipient] = useState('');
+  const { activeApi, activeChain } = useWebContext();
 
-  const { canCancel, cancelWithdraw, receipt, relayerMethods, relayersState, setReceipt, setRelayer, stage, validationErrors, withdraw } = useWithdraw({
+  const {
+    canCancel,
+    cancelWithdraw,
+    receipt,
+    relayerMethods,
+    relayersState,
+    setReceipt,
+    setRelayer,
+    stage,
+    validationErrors,
+    withdraw,
+  } = useWithdraw({
     recipient,
     note,
   });
-  console.log("relayerState", relayersState);
+  console.log('relayerState', relayersState);
   const feesGetter = useCallback(
     async (activeRelayer: ActiveWebbRelayer): Promise<FeesInfo> => {
       const defaultFees: FeesInfo = {
@@ -54,6 +68,59 @@ export const Withdraw: React.FC<WithdrawProps> = () => {
       },
     };
   }, [relayerMethods]);
+  const determineDisabled = () => {
+    if (depositNote && determineSwitchButton()) {
+      return false;
+    } else if (depositNote && recipient) {
+      return false;
+    }
+    return true;
+  };
+  const determineSwitchButton = () => {
+    if (depositNote && activeChain && activeChain.evmId != chainIdIntoEVMId(depositNote.note.chain)) {
+      return true;
+    }
+    return false;
+  };
+  const switchChain = async (note: Note | null) => {
+    if (!note) return;
+    if (!activeApi) return;
+    const newChainId = Number(note.note.chain);
+    const chain = chainsPopulated[newChainId];
+
+    const web3Provider = activeApi.getProvider();
+
+    await web3Provider
+      .switchChain({
+        chainId: `0x${chain.evmId?.toString(16)}`,
+      })
+      ?.catch(async (switchError: any) => {
+        console.log('inside catch for switchChain', switchError);
+
+        // cannot switch because network not recognized, so prompt to add it
+        if (switchError.code === 4902) {
+          const currency = currenciesConfig[chain.nativeCurrencyId];
+          await web3Provider.addChain({
+            chainId: `0x${chain.evmId?.toString(16)}`,
+            chainName: chain.name,
+            rpcUrls: chain.evmRpcUrls,
+            nativeCurrency: {
+              decimals: 18,
+              name: currency.name,
+              symbol: currency.symbol,
+            },
+          });
+          // add network will prompt the switch, check evmId again and throw if user rejected
+          const newChainId = await web3Provider.network;
+
+          if (newChainId != chain.evmId) {
+            throw switchError;
+          }
+        } else {
+          throw switchError;
+        }
+      });
+  };
 
   const depositNote = useDepositNote(note);
   return (
@@ -96,7 +163,11 @@ export const Withdraw: React.FC<WithdrawProps> = () => {
         </>
       )}
 
-      <MixerButton disabled={!recipient} onClick={withdraw} label={'Withdraw'} />
+      <MixerButton
+        disabled={determineDisabled()}
+        onClick={determineSwitchButton() ? () => switchChain(depositNote) : withdraw}
+        label={determineSwitchButton() ? 'Switch chains to withdraw' : 'Withdraw'}
+      />
       <Modal open={stage !== WithdrawState.Ideal}>
         {depositNote && (
           <WithdrawingModal

--- a/packages/mixer/src/components/Withdraw/Withdraw.tsx
+++ b/packages/mixer/src/components/Withdraw/Withdraw.tsx
@@ -1,9 +1,10 @@
 import { FormHelperText, InputBase } from '@material-ui/core';
+import { chainIdIntoEVMId, chainsPopulated, currenciesConfig } from '@webb-dapp/apps/configs';
 import WithdrawingModal from '@webb-dapp/mixer/components/Withdraw/WithdrawingModal';
 import { useWithdraw } from '@webb-dapp/mixer/hooks';
 import { useDepositNote } from '@webb-dapp/mixer/hooks/note';
 import WithdrawSuccessModal from '@webb-dapp/react-components/Withdraw/WithdrawSuccessModal';
-import { ActiveWebbRelayer, WithdrawState } from '@webb-dapp/react-environment';
+import { ActiveWebbRelayer, useWebContext, WithdrawState } from '@webb-dapp/react-environment';
 import { SpaceBox } from '@webb-dapp/ui-components';
 import { MixerButton } from '@webb-dapp/ui-components/Buttons/MixerButton';
 import { InputLabel } from '@webb-dapp/ui-components/Inputs/InputLabel/InputLabel';
@@ -11,6 +12,7 @@ import { InputSection } from '@webb-dapp/ui-components/Inputs/InputSection/Input
 import { MixerNoteInput } from '@webb-dapp/ui-components/Inputs/NoteInput/MixerNoteInput';
 import { Modal } from '@webb-dapp/ui-components/Modal/Modal';
 import RelayerInput, { FeesInfo, RelayerApiAdapter } from '@webb-dapp/ui-components/RelayerInput/RelayerInput';
+import { Note } from '@webb-tools/sdk-mixer';
 import React, { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
@@ -23,6 +25,7 @@ export const Withdraw: React.FC<WithdrawProps> = () => {
   const [recipient, setRecipient] = useState('');
   const [withdrawPercentage, setWithdrawPercentage] = useState(0);
   const [fees, setFees] = useState('');
+  const { activeApi, activeChain } = useWebContext();
 
   const {
     canCancel,
@@ -69,6 +72,60 @@ export const Withdraw: React.FC<WithdrawProps> = () => {
   }, [relayerMethods]);
 
   const depositNote = useDepositNote(note);
+  const determineDisabled = () => {
+    if (depositNote && determineSwitchButton()) {
+      return false;
+    } else if (depositNote && recipient) {
+      return false;
+    }
+    return true;
+  };
+  const determineSwitchButton = () => {
+    if (depositNote && activeChain && activeChain.evmId != chainIdIntoEVMId(depositNote.note.chain)) {
+      return true;
+    }
+    return false;
+  };
+  const switchChain = async (note: Note | null) => {
+    if (!note) return;
+    if (!activeApi) return;
+    const newChainId = Number(note.note.chain);
+    const chain = chainsPopulated[newChainId];
+
+    const web3Provider = activeApi.getProvider();
+
+    await web3Provider
+      .switchChain({
+        chainId: `0x${chain.evmId?.toString(16)}`,
+      })
+      ?.catch(async (switchError: any) => {
+        console.log('inside catch for switchChain', switchError);
+
+        // cannot switch because network not recognized, so prompt to add it
+        if (switchError.code === 4902) {
+          const currency = currenciesConfig[chain.nativeCurrencyId];
+          await web3Provider.addChain({
+            chainId: `0x${chain.evmId?.toString(16)}`,
+            chainName: chain.name,
+            rpcUrls: chain.evmRpcUrls,
+            nativeCurrency: {
+              decimals: 18,
+              name: currency.name,
+              symbol: currency.symbol,
+            },
+          });
+          // add network will prompt the switch, check evmId again and throw if user rejected
+          const newChainId = await web3Provider.network;
+
+          if (newChainId != chain.evmId) {
+            throw switchError;
+          }
+        } else {
+          throw switchError;
+        }
+      });
+  };
+
   return (
     <WithdrawWrapper>
       <InputSection>
@@ -109,8 +166,11 @@ export const Withdraw: React.FC<WithdrawProps> = () => {
         </>
       )}
 
-      <MixerButton disabled={!recipient} onClick={withdraw} label={'Withdraw'} />
-
+      <MixerButton
+        disabled={determineDisabled()}
+        onClick={determineSwitchButton() ? () => switchChain(depositNote) : withdraw}
+        label={determineSwitchButton() ? 'Switch chains to withdraw' : 'Withdraw'}
+      />
       {/* Modal to show while in progress */}
       <Modal open={stage !== WithdrawState.Ideal}>
         {depositNote && (

--- a/packages/react-environment/src/api-providers/web3/web3-bridge-withdraw.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-bridge-withdraw.ts
@@ -44,10 +44,9 @@ export class Web3BridgeWithdraw extends BridgeWithdraw<WebbWeb3Provider> {
   }
 
   async getRelayersByNote(evmNote: Note) {
-    const evmId = await this.inner.getChainId();
     return this.inner.relayingManager.getRelayer({
       baseOn: 'evm',
-      chainId: evmIdIntoChainId(evmId),
+      chainId: Number(evmNote.note.chain),
       mixerSupport: {
         amount: Number(evmNote.note.amount),
         tokenSymbol: evmNote.note.tokenSymbol,
@@ -190,6 +189,7 @@ export class Web3BridgeWithdraw extends BridgeWithdraw<WebbWeb3Provider> {
 
     // Setup a provider for the source chain
     const sourceChainId = Number(note.sourceChain) as ChainId;
+    const sourceEvmId = chainIdIntoEVMId(sourceChainId);
     const sourceChainConfig = chainsConfig[sourceChainId];
     const rpc = sourceChainConfig.url;
     const sourceHttpProvider = Web3Provider.fromUri(rpc);
@@ -248,7 +248,7 @@ export class Web3BridgeWithdraw extends BridgeWithdraw<WebbWeb3Provider> {
 
     // loop through the sourceRelayers to fetch leaves
     for (let i = 0; i < sourceRelayers.length; i++) {
-      const relayerLeaves = await sourceRelayers[i].getLeaves(sourceContractAddress);
+      const relayerLeaves = await sourceRelayers[i].getLeaves(sourceEvmId.toString(16), sourceContractAddress);
 
       const validLatestLeaf = await sourceContract.leafCreatedAtBlock(
         relayerLeaves.leaves[relayerLeaves.leaves.length - 1],

--- a/packages/react-environment/src/api-providers/web3/web3-bridge-withdraw.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-bridge-withdraw.ts
@@ -61,23 +61,6 @@ export class Web3BridgeWithdraw extends BridgeWithdraw<WebbWeb3Provider> {
 
     const activeChain = await this.inner.getChainId();
     const internalId = evmIdIntoChainId(activeChain);
-    if (Number(note.chain) !== internalId) {
-      try {
-        await this.inner.switchOrAddChain(activeChain);
-      } catch (e) {
-        this.emit('stateChange', WithdrawState.Ideal);
-        transactionNotificationConfig.failed?.({
-          address: recipient,
-          data: 'Withdraw rejected',
-          key: 'bridge-withdraw-evm',
-          path: {
-            method: 'withdraw',
-            section: `Bridge ${bridge.currency.chainIds.map(getEVMChainNameFromInternal).join('-')}`,
-          },
-        });
-        return '';
-      }
-    }
 
     const contractAddresses = bridge.anchors.find((anchor) => anchor.amount === note.amount)!;
     const contractAddress = contractAddresses.anchorAddresses[internalId]!;
@@ -211,23 +194,6 @@ export class Web3BridgeWithdraw extends BridgeWithdraw<WebbWeb3Provider> {
     const sourceContractAddress = linkedAnchors.anchorAddresses[sourceChainId]!;
 
     const activeChain = await this.inner.getChainId();
-    if (activeChain !== destChainEvmId) {
-      try {
-        await this.inner.switchOrAddChain(destChainEvmId);
-      } catch (e) {
-        this.emit('stateChange', WithdrawState.Ideal);
-        transactionNotificationConfig.failed?.({
-          address: recipient,
-          data: 'Withdraw rejected',
-          key: 'bridge-withdraw-evm',
-          path: {
-            method: 'withdraw',
-            section: `Bridge ${bridge.currency.chainIds.map(getEVMChainNameFromInternal).join('-')}`,
-          },
-        });
-        return '';
-      }
-    }
 
     // get root and neighbour root from the dest provider
     const destAnchor = this.inner.getWebbAnchorByAddress(destContractAddress);

--- a/packages/react-environment/src/api-providers/web3/web3-mixer-withdraw.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-mixer-withdraw.ts
@@ -1,3 +1,4 @@
+import { parseUnits } from '@ethersproject/units';
 import { ChainId, chainIdIntoEVMId, evmIdIntoChainId } from '@webb-dapp/apps/configs';
 import { chainIdToRelayerName } from '@webb-dapp/apps/configs/relayer-config';
 import { bufferToFixed } from '@webb-dapp/contracts/utils/buffer-to-fixed';
@@ -37,14 +38,15 @@ export class Web3MixerWithdraw extends MixerWithdraw<WebbWeb3Provider> {
       async (note: string) => {
         const depositNote = await Note.deserialize(note);
         const evmNote = depositNote.note;
-        const contract = await this.inner.getContractBySize(Number(evmNote.amount), evmNote.tokenSymbol);
+        const contractAddress = await this.inner.getTornadoContractAddressByNote(depositNote);
 
-        // Given the note, iterate over the potential relayers and find the corresponding relayer configuration
+        // Given the note, iterate over the relayer's supported contracts and find the corresponding configuration
         // for the contract.
         const supportedContract = relayer.capabilities.supportedChains['evm']
           .get(Number(evmNote.chain))
-          ?.contracts.find(({ address }) => {
-            return address.toLowerCase() === contract.inner.address.toLowerCase();
+          ?.contracts.find(({ address, size }) => {
+            // Match on the relayer configuration as well as note
+            return address.toLowerCase() === contractAddress.toLowerCase() && size == Number(evmNote.amount);
           });
 
         // The user somehow selected a relayer which does not support the mixer.
@@ -53,7 +55,9 @@ export class Web3MixerWithdraw extends MixerWithdraw<WebbWeb3Provider> {
           throw WebbError.from(WebbErrorCodes.RelayerUnsupportedMixer);
         }
 
-        const principleBig = await contract.denomination;
+        // const bigDenomination = BigNumber.from(10).pow(Number(evmNote.denomination));
+        const principleBig = parseUnits(supportedContract.size.toString(), evmNote.denomination);
+        // const principleBig = BigNumber.from(contractSizeBig).mul(bigDenomination);
 
         const withdrawFeeMill = supportedContract.withdrawFeePercentage * 1000000;
 
@@ -115,26 +119,6 @@ export class Web3MixerWithdraw extends MixerWithdraw<WebbWeb3Provider> {
     console.log('chainEvmId', chainEvmId);
     this.emit('stateChange', WithdrawState.GeneratingZk);
 
-    if (activeChain !== chainEvmId) {
-      try {
-        console.log('trying to switch or add');
-        await this.inner.switchOrAddChain(chainEvmId);
-      } catch (e) {
-        console.log('error: ', e);
-        this.emit('stateChange', WithdrawState.Ideal);
-        transactionNotificationConfig.failed?.({
-          address: recipient,
-          data: 'Withdraw rejected',
-          key: 'mixer-withdraw-evm',
-          path: {
-            method: 'withdraw',
-            section: 'evm-mixer',
-          },
-        });
-        return '';
-      }
-    }
-
     if (activeRelayer && activeRelayer.account) {
       try {
         transactionNotificationConfig.loading?.({
@@ -163,6 +147,7 @@ export class Web3MixerWithdraw extends MixerWithdraw<WebbWeb3Provider> {
           fee: Number(fees?.totalFees),
         });
 
+        console.log('evmId: ', chainEvmId.toString(16));
         const relayerLeaves = await activeRelayer.getLeaves(chainEvmId.toString(16), mixerInfo.address);
 
         // This is the part of withdraw that takes a long time

--- a/packages/react-environment/src/api-providers/web3/web3-mixer-withdraw.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-mixer-withdraw.ts
@@ -55,10 +55,7 @@ export class Web3MixerWithdraw extends MixerWithdraw<WebbWeb3Provider> {
           throw WebbError.from(WebbErrorCodes.RelayerUnsupportedMixer);
         }
 
-        // const bigDenomination = BigNumber.from(10).pow(Number(evmNote.denomination));
         const principleBig = parseUnits(supportedContract.size.toString(), evmNote.denomination);
-        // const principleBig = BigNumber.from(contractSizeBig).mul(bigDenomination);
-
         const withdrawFeeMill = supportedContract.withdrawFeePercentage * 1000000;
 
         const withdrawFeeMillBig = BigNumber.from(withdrawFeeMill);
@@ -147,7 +144,6 @@ export class Web3MixerWithdraw extends MixerWithdraw<WebbWeb3Provider> {
           fee: Number(fees?.totalFees),
         });
 
-        console.log('evmId: ', chainEvmId.toString(16));
         const relayerLeaves = await activeRelayer.getLeaves(chainEvmId.toString(16), mixerInfo.address);
 
         // This is the part of withdraw that takes a long time
@@ -242,7 +238,7 @@ export class Web3MixerWithdraw extends MixerWithdraw<WebbWeb3Provider> {
       } catch (e) {
         this.emit('stateChange', WithdrawState.Failed);
         this.emit('stateChange', WithdrawState.Ideal);
-        console.log(e);
+        logger.trace(e);
         transactionNotificationConfig.failed?.({
           address: recipient,
           data: 'Withdraw failed',

--- a/packages/react-environment/src/api-providers/web3/webb-web3-provider.ts
+++ b/packages/react-environment/src/api-providers/web3/webb-web3-provider.ts
@@ -1,4 +1,4 @@
-import { chainsConfig, currenciesConfig, evmIdIntoChainId } from '@webb-dapp/apps/configs';
+import { chainIdIntoEVMId, chainsConfig, currenciesConfig, evmIdIntoChainId } from '@webb-dapp/apps/configs';
 import { AnchorContract } from '@webb-dapp/contracts/contracts';
 import { TornadoContract } from '@webb-dapp/contracts/contracts/tornado-anchor';
 import { WebbApiProvider, WebbMethods, WebbProviderEvents } from '@webb-dapp/react-environment';
@@ -13,6 +13,7 @@ import { WebbError, WebbErrorCodes } from '@webb-dapp/utils/webb-error';
 import { Web3Accounts } from '@webb-dapp/wallet/providers/web3/web3-accounts';
 import { Web3Provider } from '@webb-dapp/wallet/providers/web3/web3-provider';
 import { EventBus } from '@webb-tools/app-util';
+import { Note } from '@webb-tools/sdk-mixer';
 import { ethers, providers } from 'ethers';
 
 export class WebbWeb3Provider
@@ -98,6 +99,16 @@ export class WebbWeb3Provider
 
   getMixers() {
     return this.connectedMixers;
+  }
+
+  getTornadoContractAddressByNote(note: Note) {
+    const evmId = chainIdIntoEVMId(Number(note.note.chain));
+    const availableMixers = new EvmChainMixersInfo(evmId);
+    const mixer = availableMixers.getTornMixerInfoBySize(Number(note.note.amount), note.note.tokenSymbol);
+    if (!mixer) {
+      throw new Error('Mixer not found');
+    }
+    return mixer.address;
   }
 
   async getContractByAddress(mixerAddress: string): Promise<TornadoContract> {

--- a/packages/react-environment/src/webb-context/bridge/bridge-config.ts
+++ b/packages/react-environment/src/webb-context/bridge/bridge-config.ts
@@ -63,9 +63,6 @@ export const bridgeConfig: BridgeConfig = {
 };
 
 export const getAnchorAddressForBridge = (assetName: string, chainId: number, amount: number): string | undefined => {
-  console.log('assetName', assetName);
-  console.log('bridgeConfig', bridgeConfig);
-
   const linkedAnchorConfig = bridgeConfig[assetName].anchors.find((anchor) => anchor.amount == amount.toString());
   if (!linkedAnchorConfig) {
     throw new Error('Unsupported configuration for bridge');

--- a/packages/react-environment/src/webb-context/bridge/bridge-config.ts
+++ b/packages/react-environment/src/webb-context/bridge/bridge-config.ts
@@ -38,7 +38,7 @@ export const bridgeConfig: BridgeConfig = {
           [ChainId.HarmonyTestnet0]: '0x30a9E294b1Fc166194d2D1AF936CDdfF0e86A47B',
           [ChainId.Rinkeby]: '0x6244Cf3D15aE8D9F973f080Af561b99c501e5e9D',
         },
-        amount: '.1',
+        amount: '0.1',
       },
     ],
   },
@@ -56,8 +56,21 @@ export const bridgeConfig: BridgeConfig = {
           [ChainId.Rinkeby]: '0x15A66977f0A9D21e09eB6C1B42b001aF992f0C8f',
           [ChainId.Goerli]: '0x025348e15e9d5529E5A4A55E8eA7eC923b7fB8b6',
         },
-        amount: '.01',
+        amount: '0.01',
       },
     ],
   },
+};
+
+export const getAnchorAddressForBridge = (assetName: string, chainId: number, amount: number): string | undefined => {
+  console.log('assetName', assetName);
+  console.log('bridgeConfig', bridgeConfig);
+
+  const linkedAnchorConfig = bridgeConfig[assetName].anchors.find((anchor) => anchor.amount == amount.toString());
+  if (!linkedAnchorConfig) {
+    throw new Error('Unsupported configuration for bridge');
+  }
+
+  const anchorAddress = linkedAnchorConfig.anchorAddresses[chainId as ChainId];
+  return anchorAddress;
 };

--- a/packages/react-environment/src/webb-context/relayer/webb-relayer.class.ts
+++ b/packages/react-environment/src/webb-context/relayer/webb-relayer.class.ts
@@ -1,4 +1,4 @@
-import { ChainId } from '@webb-dapp/apps/configs';
+import { ChainId, getEVMChainNameFromInternal } from '@webb-dapp/apps/configs';
 import { chainsConfig } from '@webb-dapp/apps/configs/chains';
 import { EvmChainMixersInfo } from '@webb-dapp/react-environment/api-providers/web3/EvmChainMixersInfo';
 import {
@@ -10,6 +10,7 @@ import {
 import { LoggerService } from '@webb-tools/app-util';
 import { Observable, Subject } from 'rxjs';
 import { filter } from 'rxjs/operators';
+import { bridgeConfig, getAnchorAddressForBridge } from '../bridge';
 
 const logger = LoggerService.get('webb-relayer class');
 
@@ -201,6 +202,7 @@ export class WebbRelayerBuilder {
             const evmId = chainsConfig[chainId].evmId!;
             const mixersInfoForChain = new EvmChainMixersInfo(evmId);
             const mixerInfo = mixersInfoForChain.getTornMixerInfoBySize(mixerSupport.amount, mixerSupport.tokenSymbol);
+            const bridgeAddress = getAnchorAddressForBridge(mixerSupport.tokenSymbol, chainId, mixerSupport.amount);
             if (mixerInfo) {
               return Boolean(
                 capabilities.supportedChains[baseOn]
@@ -208,6 +210,15 @@ export class WebbRelayerBuilder {
                   ?.contracts?.find(
                     (contract) =>
                       contract.address == mixerInfo.address.toLowerCase() && contract.eventsWatcher.enabled == true
+                  )
+              );
+            } else if (bridgeAddress) {
+              return Boolean(
+                capabilities.supportedChains[baseOn]
+                  .get(chainId)
+                  ?.contracts?.find(
+                    (contract) =>
+                      contract.address == bridgeAddress.toLowerCase() && contract.eventsWatcher.enabled == true
                   )
               );
             } else {

--- a/packages/react-environment/src/webb-context/relayer/webb-relayer.class.ts
+++ b/packages/react-environment/src/webb-context/relayer/webb-relayer.class.ts
@@ -189,7 +189,10 @@ export class WebbRelayerBuilder {
             return Boolean(
               capabilities.supportedChains[baseOn]
                 .get(chainId)
-                ?.contracts?.find((contract) => contract.address == contractAddress.toLowerCase())
+                ?.contracts?.find(
+                  (contract) =>
+                    contract.address == contractAddress.toLowerCase() && contract.eventsWatcher.enabled == true
+                )
             );
           }
         }
@@ -202,7 +205,10 @@ export class WebbRelayerBuilder {
               return Boolean(
                 capabilities.supportedChains[baseOn]
                   .get(chainId)
-                  ?.contracts?.find((contract) => contract.address == mixerInfo.address.toLowerCase())
+                  ?.contracts?.find(
+                    (contract) =>
+                      contract.address == mixerInfo.address.toLowerCase() && contract.eventsWatcher.enabled == true
+                  )
               );
             } else {
               return false;

--- a/packages/react-environment/src/webb-context/relayer/webb-relayer.class.ts
+++ b/packages/react-environment/src/webb-context/relayer/webb-relayer.class.ts
@@ -355,8 +355,9 @@ export class WebbRelayer {
     }
   }
 
-  async getLeaves(contractAddress: string): Promise<RelayerLeaves> {
-    const req = await fetch(`${this.endpoint}/api/v1/leaves/${contractAddress}`);
+  // chainId should be formatted as a hex string
+  async getLeaves(chainId: string, contractAddress: string): Promise<RelayerLeaves> {
+    const req = await fetch(`${this.endpoint}/api/v1/leaves/${chainId}/${contractAddress}`);
     if (req.ok) {
       const jsonResponse = await req.json();
       const fetchedLeaves: string[] = jsonResponse.leaves;

--- a/packages/ui-components/src/NetworkManger/NetworkManager.tsx
+++ b/packages/ui-components/src/NetworkManger/NetworkManager.tsx
@@ -110,7 +110,7 @@ export const NetworkManager: React.FC<NetworkManagerProps> = () => {
           <RadioGroup value={radioButtonFilter} onChange={handleRadioFilter} row>
             <FormControlLabel value='live' control={<Radio />} label='live' />
             <FormControlLabel value='test' control={<Radio />} label='test' />
-            {/* <FormControlLabel value='dev' control={<Radio />} label='dev' /> */}
+            {(process.env.NODE_ENV === 'development') && <FormControlLabel value='dev' control={<Radio />} label='dev' />}
           </RadioGroup>
         </FormControl>
       </FilterSection>


### PR DESCRIPTION
This PR changes the 'switch chain' functionality. It enforces the user to switch chains before withdrawing. This is because there were issues with the correct WebbProvider state with the previous switch chain strategy in withdraw flows.

Relayers available for selection are dependent on the note rather than the selected chain. Relayers displayed must support event-watching.

Tornados are properly interacting with relayers; while Anchors have the appropriate relayers displayed, but cannot currently be selected.