### PR TITLE
Only make one call to ipapi for geolocation and use across the app

### DIFF
--- a/packages/apps/src/App.tsx
+++ b/packages/apps/src/App.tsx
@@ -1,7 +1,7 @@
 import './initI18n';
 
 import { DAppError } from '@webb-dapp/react-components/utils/Error/DAppError';
-import { RouterProvider, WebbProvider } from '@webb-dapp/react-environment';
+import { RouterProvider, WebbProvider, IpProvider } from '@webb-dapp/react-environment';
 import { UIProvider } from '@webb-dapp/ui-components';
 import { NotificationStacked } from '@webb-dapp/ui-components/notification';
 import Theme from '@webb-dapp/ui-components/styles/Theme';
@@ -18,10 +18,12 @@ const App: FC = () => {
     <DAppError logger={appLogger}>
       <WebbProvider applicationName={'Webb DApp'}>
         <UIProvider>
-          <Theme />
+          <IpProvider>
+            <Theme />
 
-          <RouterProvider config={routerConfig} />
-          <NotificationStacked />
+            <RouterProvider config={routerConfig} />
+            <NotificationStacked />
+          </IpProvider>
         </UIProvider>
       </WebbProvider>
     </DAppError>

--- a/packages/bridge/src/Bridge.tsx
+++ b/packages/bridge/src/Bridge.tsx
@@ -2,7 +2,6 @@ import { Deposit, Withdraw } from '@webb-dapp/bridge/components';
 import IPDisplay from '@webb-dapp/react-components/IPDisplay/IPDisplay';
 import { PermissionedAccess } from '@webb-dapp/react-components/PermissionedAccess/PermissionedAccess';
 import { useWebContext } from '@webb-dapp/react-environment/webb-context';
-import { useIp } from '@webb-dapp/react-hooks/useIP';
 import { SpaceBox } from '@webb-dapp/ui-components/Box';
 import { MixerTabs } from '@webb-dapp/ui-components/Tabs/MixerTabs';
 import React, { useEffect, useState } from 'react';
@@ -13,15 +12,14 @@ type MixerProps = {};
 
 export const Bridge: React.FC<MixerProps> = () => {
   const { activeApi } = useWebContext();
-  const { ip } = useIp(activeApi);
 
   return (
     <MixerWrapper>
-      <PermissionedAccess ip={ip}>
+      <PermissionedAccess>
         <MixerTabs Withdraw={<Withdraw />} Deposit={<Deposit />} />
       </PermissionedAccess>
       <SpaceBox height={8} />
-      <IPDisplay ip={ip} />
+      <IPDisplay />
     </MixerWrapper>
   );
 };

--- a/packages/bridge/src/components/Withdraw/Withdraw.tsx
+++ b/packages/bridge/src/components/Withdraw/Withdraw.tsx
@@ -189,6 +189,7 @@ export const Withdraw: React.FC<WithdrawProps> = () => {
             receipt={receipt}
             recipient={recipient}
             note={depositNote.note}
+            relayer={relayersState.activeRelayer}
             exit={() => {
               setNote('');
               setRecipient('');

--- a/packages/mixer/src/Mixer.tsx
+++ b/packages/mixer/src/Mixer.tsx
@@ -2,7 +2,6 @@ import { Deposit, Withdraw } from '@webb-dapp/mixer/components';
 import IPDisplay from '@webb-dapp/react-components/IPDisplay/IPDisplay';
 import { PermissionedAccess } from '@webb-dapp/react-components/PermissionedAccess/PermissionedAccess';
 import { useWebContext } from '@webb-dapp/react-environment/webb-context';
-import { useIp } from '@webb-dapp/react-hooks/useIP';
 import { SpaceBox } from '@webb-dapp/ui-components';
 import { MixerTabs } from '@webb-dapp/ui-components/Tabs/MixerTabs';
 import React from 'react';
@@ -13,15 +12,14 @@ type MixerProps = {};
 
 export const Mixer: React.FC<MixerProps> = () => {
   const { activeApi } = useWebContext();
-  const { ip } = useIp(activeApi);
 
   return (
     <MixerWrapper>
-      <PermissionedAccess ip={ip}>
+      <PermissionedAccess>
         <MixerTabs Withdraw={<Withdraw />} Deposit={<Deposit />} />
       </PermissionedAccess>
       <SpaceBox height={8} />
-      <IPDisplay ip={ip} />
+      <IPDisplay />
     </MixerWrapper>
   );
 };

--- a/packages/mixer/src/components/Withdraw/Withdraw.tsx
+++ b/packages/mixer/src/components/Withdraw/Withdraw.tsx
@@ -185,7 +185,6 @@ export const Withdraw: React.FC<WithdrawProps> = () => {
           />
         )}
       </Modal>
-
       {/* Modal to show on success  */}
       <Modal open={receipt != ''}>
         {depositNote && (
@@ -193,6 +192,7 @@ export const Withdraw: React.FC<WithdrawProps> = () => {
             receipt={receipt}
             recipient={recipient}
             note={depositNote.note}
+            relayer={relayersState.activeRelayer}
             exit={() => {
               setNote('');
               setRecipient('');

--- a/packages/page-transfer/src/index.tsx
+++ b/packages/page-transfer/src/index.tsx
@@ -4,7 +4,6 @@ import { useBridge } from '@webb-dapp/bridge/hooks/bridge/use-bridge';
 import IPDisplay from '@webb-dapp/react-components/IPDisplay/IPDisplay';
 import { useWebContext } from '@webb-dapp/react-environment';
 import { Currency, CurrencyContent } from '@webb-dapp/react-environment/types/currency';
-import { useIp } from '@webb-dapp/react-hooks/useIP';
 import { SpaceBox } from '@webb-dapp/ui-components';
 import { MixerButton } from '@webb-dapp/ui-components/Buttons/MixerButton';
 import { ContentWrapper } from '@webb-dapp/ui-components/ContentWrappers';
@@ -38,7 +37,6 @@ const PageTransfers: FC = () => {
   const [isSwap, setIsSwap] = useState(false);
   const { activeApi, activeChain, activeWallet, chains: chainsStore, switchChain } = useWebContext();
 
-  const ip = useIp(activeApi);
   const chains = useMemo(() => {
     return Object.keys(chainsStore);
   }, [chainsStore]);
@@ -143,7 +141,7 @@ const PageTransfers: FC = () => {
 
       <SpaceBox height={8} />
 
-      <IPDisplay ip={ip.ip} />
+      <IPDisplay />
     </div>
   );
 };

--- a/packages/page-wrap-unwrap/src/index.tsx
+++ b/packages/page-wrap-unwrap/src/index.tsx
@@ -7,7 +7,6 @@ import { useWrapUnwrap } from '@webb-dapp/page-wrap-unwrap/hooks/useWrapUnwrap';
 import IPDisplay from '@webb-dapp/react-components/IPDisplay/IPDisplay';
 import { BridgeCurrency, MixerSize, useWebContext } from '@webb-dapp/react-environment';
 import { Currency } from '@webb-dapp/react-environment/types/currency';
-import { useIp } from '@webb-dapp/react-hooks/useIP';
 import { SpaceBox } from '@webb-dapp/ui-components';
 import { MixerButton } from '@webb-dapp/ui-components/Buttons/MixerButton';
 import { Flex } from '@webb-dapp/ui-components/Flex/Flex';
@@ -123,7 +122,6 @@ const PageWrappUnwrap: FC = () => {
   const [isSwap, setIsSwap] = useState(false);
   const [loading, setLoading] = useState(false);
   const { activeApi } = useWebContext();
-  const ip = useIp(activeApi);
 
   const [useFixedDeposits, setUseFixedDepoists] = useState(false);
 
@@ -320,7 +318,7 @@ const PageWrappUnwrap: FC = () => {
 
       <SpaceBox height={8} />
 
-      <IPDisplay ip={ip.ip} />
+      <IPDisplay />
     </div>
   );
 };

--- a/packages/react-components/src/IPDisplay/IPDisplay.tsx
+++ b/packages/react-components/src/IPDisplay/IPDisplay.tsx
@@ -1,5 +1,5 @@
 import { Icon, Typography } from '@material-ui/core';
-import { useFetch } from '@webb-dapp/react-hooks/';
+import { useIp } from '@webb-dapp/react-environment';
 import { Pallet } from '@webb-dapp/ui-components/styling/colors';
 import { FontFamilies } from '@webb-dapp/ui-components/styling/fonts/font-families.enum';
 import { above } from '@webb-dapp/ui-components/utils/responsive-utils';
@@ -42,16 +42,14 @@ const IPDisplayWrapper = styled.div`
   }
 `;
 
-type IPDisplayProps = {
-  ip: String;
-};
+type IPDisplayProps = {};
 
-const IPDisplay: React.FC<IPDisplayProps> = ({ ip }) => {
-  const { city, country_code_iso3 } = useFetch(`https://ipapi.co/${ip}/json`, {});
+const IPDisplay: React.FC<IPDisplayProps> = () => {
+  const { city, countryCode, ip } = useIp();
 
   function createLocationText() {
-    if (city && country_code_iso3) {
-      return `${city}, ${country_code_iso3}`;
+    if (city && countryCode) {
+      return `${city}, ${countryCode}`;
     }
     return '';
   }

--- a/packages/react-components/src/PermissionedAccess/DisableAdblock.tsx
+++ b/packages/react-components/src/PermissionedAccess/DisableAdblock.tsx
@@ -9,7 +9,7 @@ export const DisableAdblock: React.FC<DisableAdblockProps> = () => {
     <ContentWrapper>
       <Typography variant={'h1'}>Please disable adblock</Typography>
       <Typography variant={'h3'} style={{ paddingTop: '30px' }}>
-        In order to comply with regulations, we must make calls to third-party APIs to prevent unauthorized users. Your
+        In order to comply with regulations, calls must be made to third-party APIs to prevent unauthorized users. Your
         adblock software is preventing these calls from happening.
       </Typography>
     </ContentWrapper>

--- a/packages/react-components/src/PermissionedAccess/PermissionedAccess.tsx
+++ b/packages/react-components/src/PermissionedAccess/PermissionedAccess.tsx
@@ -1,3 +1,4 @@
+import { useIp } from '@webb-dapp/react-environment/';
 import { useFetch } from '@webb-dapp/react-hooks/useFetch';
 import { ContentWrapper } from '@webb-dapp/ui-components/ContentWrappers';
 import { Spinner } from '@webb-dapp/ui-components/Spinner/Spinner';
@@ -42,15 +43,13 @@ export const acceptedTermsStorageFactory = () => {
   });
 };
 
-type PermissionedAccessProps = {
-  ip: string;
-};
+type PermissionedAccessProps = {};
 
-export const PermissionedAccess: React.FC<PermissionedAccessProps> = ({ children, ip }) => {
+export const PermissionedAccess: React.FC<PermissionedAccessProps> = ({ children }) => {
   const [permissionedState, setPermissionedState] = useState<PermissionedState>(PermissionedState.Checking);
   const [acceptedTerms, setAcceptedTerms] = useState(false);
   const [acceptedTermsStorage, setAcceptedTermsStorage] = useState<AcceptedTermsStorage | null>(null);
-  const data = useFetch(`https://ipapi.co/${ip}/json`, {});
+  const { countryCode } = useIp();
 
   const storeAcceptedTerms = () => {
     acceptedTermsStorage?.set('acceptedTerms', true);
@@ -58,17 +57,16 @@ export const PermissionedAccess: React.FC<PermissionedAccessProps> = ({ children
   };
 
   useEffect(() => {
-    console.log('data: ', data);
     const checkPermissions = async () => {
-      if (data.error) {
-        setPermissionedState(PermissionedState.Adblocked);
-        return;
-      }
-      if (!data.country_code_iso3) {
+      if (!countryCode) {
         setPermissionedState(PermissionedState.Checking);
         return;
       }
-      if (data.country_code_iso3 === 'USA') {
+      if (countryCode === 'unknown') {
+        setPermissionedState(PermissionedState.Adblocked);
+        return;
+      }
+      if (countryCode === 'USA') {
         setPermissionedState(PermissionedState.Geofenced);
         return;
       }
@@ -82,7 +80,7 @@ export const PermissionedAccess: React.FC<PermissionedAccessProps> = ({ children
       setPermissionedState(PermissionedState.Allowed);
     };
     checkPermissions();
-  }, [data, acceptedTerms]);
+  }, [countryCode]);
 
   return (
     <>

--- a/packages/react-environment/src/IpProvider.tsx
+++ b/packages/react-environment/src/IpProvider.tsx
@@ -1,0 +1,53 @@
+import { useFetch } from '@webb-dapp/react-hooks/useFetch';
+import React, { createContext, FC, PropsWithChildren, useEffect, useState } from 'react';
+
+export interface IpInformation {
+  ip: string;
+  countryCode: string;
+  city: string;
+}
+
+export const IpContext = createContext<IpInformation>({
+  ip: '',
+  countryCode: '',
+  city: '',
+});
+
+export const IpProvider: FC<PropsWithChildren<any>> = ({ children }) => {
+  const [ip, setIp] = useState('');
+  const [countryCode, setCountryCode] = useState('');
+  const [city, setCity] = useState('');
+
+  const data = useFetch(`https://ipapi.co//json`, {});
+
+  useEffect(() => {
+    if (data.ip) {
+      setIp(data.ip);
+    }
+    if (data.country_code_iso3) {
+      setCountryCode(data.country_code_iso3);
+    }
+    if (data.city) {
+      setCity(data.city);
+    }
+    if (data.error) {
+      setCountryCode('unknown');
+    }
+  }, [data]);
+
+  return (
+    <IpContext.Provider
+      value={{
+        ip,
+        countryCode,
+        city,
+      }}
+    >
+      {children}
+    </IpContext.Provider>
+  );
+};
+
+export const useIp = () => {
+  return React.useContext(IpContext) as IpInformation;
+};

--- a/packages/react-environment/src/index.ts
+++ b/packages/react-environment/src/index.ts
@@ -1,10 +1,9 @@
 export * from './WebbProvider';
 export * from './RouterProvider';
+export * from './IpProvider';
 export * from './store';
 export * from './webb-context';
 
 export * from './webb-context/bridge';
 export * from './webb-context/mixer';
 export * from './webb-context/relayer';
-
-export * from './WebbProvider';

--- a/packages/react-hooks/src/useRelayerIp.ts
+++ b/packages/react-hooks/src/useRelayerIp.ts
@@ -5,7 +5,7 @@ export type RelayerIpInfo = {
   ip: string;
 };
 
-export function useIp(activeApi?: WebbApiProvider<any>) {
+export function useRelayerIp(activeApi?: WebbApiProvider<any>) {
   const [ip, setIp] = useState<RelayerIpInfo>({ ip: '' });
 
   useEffect(() => {


### PR DESCRIPTION
Update the implementation for retrieving for IP and related information. Previously it was a hook which would be called separately in each included component.  Now this information is retrieved in a react context which makes the call once and provides to the rest of the components.