### PR TITLE
Set bridge state to null in depositApi useEffect cleanup

### DIFF
--- a/packages/bridge/src/hooks/deposit/useBridgeDeposit.tsx
+++ b/packages/bridge/src/hooks/deposit/useBridgeDeposit.tsx
@@ -57,6 +57,7 @@ export const useBridgeDeposit = (): BridgeDepositApi => {
       });
     });
     return () => {
+      setActiveBridge(null);
       unSub && unSub();
       subscribe.unsubscribe();
     };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

If a user is selected on the Bridge deposit screen and switches chains in metamask to another chain (which is supported on tornados but not in the bridge), then the values populated in the bridge deposit will stay as if it were still selected on the old chain.

## What is the new behavior?

In the useEffect cleanup on depositApi change, set the active bridge state to null. This will remove the destination chain selection values and reset the selected token.

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
