### PR TITLE
Fix infinite render state on wrap/unwrap without selected network

### DIFF
--- a/packages/page-wrap-unwrap/src/hooks/useWrapUnwrap.ts
+++ b/packages/page-wrap-unwrap/src/hooks/useWrapUnwrap.ts
@@ -67,7 +67,6 @@ export function useWrapUnwrap() {
 
   useEffect(() => {
     init();
-    console.log('useEffect init loop');
     const sub = wrapUnwrapApi?.$currentTokenValue.subscribe((val) => {
       console.log(`current token value`, val);
     });
@@ -90,7 +89,6 @@ export function useWrapUnwrap() {
           break;
       }
     });
-    console.log('useEffect subscription loop');
 
     return () => r?.unsubscribe();
   }, [init, wrapUnwrapApi]);
@@ -126,7 +124,6 @@ export function useWrapUnwrap() {
       wrapUnwrapApi?.setCurrentToken(leftHandToken ? currencyContentToWrappingToken(leftHandToken) : null);
       wrapUnwrapApi?.setOtherEdgToken(rightHandToken ? currencyContentToWrappingToken(rightHandToken) : null);
     }
-    console.log('useEffect context? loop');
   }, [leftHandToken, rightHandToken, context, wrapUnwrapApi]);
 
   const execute = useCallback(() => {

--- a/packages/page-wrap-unwrap/src/hooks/useWrapUnwrap.ts
+++ b/packages/page-wrap-unwrap/src/hooks/useWrapUnwrap.ts
@@ -67,6 +67,7 @@ export function useWrapUnwrap() {
 
   useEffect(() => {
     init();
+    console.log('useEffect init loop');
     const sub = wrapUnwrapApi?.$currentTokenValue.subscribe((val) => {
       console.log(`current token value`, val);
     });
@@ -89,6 +90,7 @@ export function useWrapUnwrap() {
           break;
       }
     });
+    console.log('useEffect subscription loop');
 
     return () => r?.unsubscribe();
   }, [init, wrapUnwrapApi]);
@@ -124,6 +126,7 @@ export function useWrapUnwrap() {
       wrapUnwrapApi?.setCurrentToken(leftHandToken ? currencyContentToWrappingToken(leftHandToken) : null);
       wrapUnwrapApi?.setOtherEdgToken(rightHandToken ? currencyContentToWrappingToken(rightHandToken) : null);
     }
+    console.log('useEffect context? loop');
   }, [leftHandToken, rightHandToken, context, wrapUnwrapApi]);
 
   const execute = useCallback(() => {

--- a/packages/page-wrap-unwrap/src/index.tsx
+++ b/packages/page-wrap-unwrap/src/index.tsx
@@ -104,7 +104,7 @@ const TabButton = styled.button<{ active?: boolean }>`
   border-radius: 32px;
 `;
 
-const PageWrappUnwrap: FC = () => {
+const PageWrapUnwrap: FC = () => {
   const {
     amount,
     context: status,
@@ -121,9 +121,8 @@ const PageWrappUnwrap: FC = () => {
 
   const [isSwap, setIsSwap] = useState(false);
   const [loading, setLoading] = useState(false);
-  const { activeApi } = useWebContext();
 
-  const [useFixedDeposits, setUseFixedDepoists] = useState(false);
+  const [useFixedDeposits, setUseFixedDeposits] = useState(false);
 
   const nativeOrWrapToProps: TokenInputProps = useMemo(() => {
     return {
@@ -133,7 +132,7 @@ const PageWrappUnwrap: FC = () => {
         setLeftHandToken(currencyContent);
       },
     };
-  }, [status, tokens, wrappedTokens, leftHandToken, setLeftHandToken]);
+  }, [status, tokens, wrappedTokens, leftHandToken]);
 
   const wrappedOrWrappedFrom: TokenInputProps = useMemo(() => {
     return {
@@ -143,7 +142,7 @@ const PageWrappUnwrap: FC = () => {
         setRightHandToken(currencyContent);
       },
     };
-  }, [status, tokens, wrappedTokens, rightHandToken, setRightHandToken]);
+  }, [status, tokens, wrappedTokens, rightHandToken]);
   const leftInputProps = nativeOrWrapToProps;
   const rightInputProps = wrappedOrWrappedFrom;
   const buttonText = status;
@@ -295,7 +294,7 @@ const PageWrappUnwrap: FC = () => {
           value={useFixedDeposits}
           checked={useFixedDeposits}
           onChange={() => {
-            setUseFixedDepoists((t) => !t);
+            setUseFixedDeposits((t) => !t);
           }}
           control={<Checkbox color={'primary'} />}
           label={<Typography color={'textPrimary'}>Use Fixed deposits</Typography>}
@@ -323,4 +322,4 @@ const PageWrappUnwrap: FC = () => {
   );
 };
 
-export default PageWrappUnwrap;
+export default PageWrapUnwrap;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

If the user has not selected a wallet or approved in metamask and visits the wrap/unwrap page, the website will crash. This is because setState call in functions setRightHandToken and setLeftHandToken in useWrapUnwrap hook is re-evaluated on render in the page-wrap-unwrap - which imports the hook.

## What is the new behavior?

The website doesn't crash. Do not update UI when functions change.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
