### PR TITLE
Add beneficiary relayer properties for tornado relayer transaction

### DIFF
--- a/packages/react-environment/src/api-providers/web3/web3-mixer-withdraw.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-mixer-withdraw.ts
@@ -116,7 +116,7 @@ export class Web3MixerWithdraw extends MixerWithdraw<WebbWeb3Provider> {
     console.log('chainEvmId', chainEvmId);
     this.emit('stateChange', WithdrawState.GeneratingZk);
 
-    if (activeRelayer && activeRelayer.account) {
+    if (activeRelayer && (activeRelayer.beneficiary || activeRelayer.account)) {
       try {
         transactionNotificationConfig.loading?.({
           address: recipient,
@@ -140,7 +140,7 @@ export class Web3MixerWithdraw extends MixerWithdraw<WebbWeb3Provider> {
         const fees = await activeRelayer.fees(note);
         const zkpInputWithoutMerkleProof = fromDepositIntoZKPTornPublicInputs(deposit, {
           recipient,
-          relayer: activeRelayer.account,
+          relayer: activeRelayer.account ?? activeRelayer.beneficiary,
           fee: Number(fees?.totalFees),
         });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The latest relayer stores the reward address in a property called beneficiary while old relayers store this address in a property called account. Relay transactions sent from the dapp -> a relayer will fail because they are generated without the proper reward address.

## What is the new behavior?
properly take into account the 'beneficiary' field if the account field is absent.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
