### PR TITLE
Fix development.webb.tools to use IPFS fixtures instead of cached ones

### DIFF
--- a/packages/react-environment/src/api-providers/polkadot/polkadot-mixer-withdraw.ts
+++ b/packages/react-environment/src/api-providers/polkadot/polkadot-mixer-withdraw.ts
@@ -2,7 +2,7 @@ import { ChainId } from '@webb-dapp/apps/configs';
 // @ts-ignore
 import Worker from '@webb-dapp/mixer/utils/proving-manager.worker';
 import { RelayedWithdrawResult, WebbRelayer } from '@webb-dapp/react-environment';
-import { getCachedFixtureURI, isProduction } from '@webb-dapp/utils/misc';
+import { getCachedFixtureURI, isLocalServer } from '@webb-dapp/utils/misc';
 import { WebbError, WebbErrorCodes } from '@webb-dapp/utils/webb-error';
 import { transactionNotificationConfig } from '@webb-dapp/wallet/providers/polkadot/transaction-notification-config';
 import { LoggerService } from '@webb-tools/app-util';
@@ -25,7 +25,7 @@ const transactionString = (hexString: string) => {
 async function fetchSubstrateProvingKey() {
   const IPFSUrl = `https://ipfs.io/ipfs/QmYDtGX7Wf5qUPEpGsgrX6oss2m2mm8vi7uzNdK4C9yJdZ`;
   const cachedURI = getCachedFixtureURI('QmYDtGX7Wf5qUPEpGsgrX6oss2m2mm8vi7uzNdK4C9yJdZ');
-  const ipfsKeyRequest = await fetch(isProduction() ? IPFSUrl : cachedURI);
+  const ipfsKeyRequest = await fetch(isLocalServer() ? IPFSUrl : cachedURI);
   const circuitKeyArrayBuffer = await ipfsKeyRequest.arrayBuffer();
   logger.info(`Done Fetching key`);
   const circuitKey = new Uint8Array(circuitKeyArrayBuffer);

--- a/packages/utils/src/misc/app-mode.ts
+++ b/packages/utils/src/misc/app-mode.ts
@@ -12,3 +12,7 @@ export function isProduction() {
 export function isDevelopment() {
   return appMode() === 'development';
 }
+
+export function isLocalServer() {
+  return process.env.NODE_ENV === 'development';
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`development.webb.tools` attempts to use cached fixtures instead of fetching from IPFS.

## What is the new behavior?
any deployed build will fetch from IPFS instead of cached fixtures.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
