### PR TITLE
Change `AppConfig` to be a statful object

### DIFF
--- a/packages/apps/src/configs/bridges/bridge-config.ts
+++ b/packages/apps/src/configs/bridges/bridge-config.ts
@@ -13,20 +13,3 @@ export const bridgeConfigByAsset: AppConfig['bridgeByAsset'] = {
     anchors: anchorsConfig[WebbCurrencyId.webbWETH],
   },
 };
-
-export const getAnchorAddressForBridge = (
-  assetId: WebbCurrencyId,
-  chainId: number,
-  amount: number
-): string | undefined => {
-  const linkedAnchorConfig = bridgeConfigByAsset[assetId]?.anchors.find(
-    (anchor) => anchor.amount === amount.toString()
-  );
-  if (!linkedAnchorConfig) {
-    throw new Error('Unsupported configuration for bridge');
-  }
-
-  const anchorAddress = linkedAnchorConfig.anchorAddresses[chainId as ChainId];
-  logger.log('got anchor address: ', anchorAddress);
-  return anchorAddress;
-};

--- a/packages/apps/src/configs/index.ts
+++ b/packages/apps/src/configs/index.ts
@@ -1,4 +1,8 @@
-import { Chain, Wallet } from '@webb-dapp/react-environment';
+import { anchorsConfig } from '@webb-dapp/apps/configs/anchors';
+import { bridgeConfigByAsset } from '@webb-dapp/apps/configs/bridges';
+import { currenciesConfig } from '@webb-dapp/apps/configs/currencies';
+import { mixersConfig } from '@webb-dapp/apps/configs/mixers';
+import { AppConfig, Chain, Wallet } from '@webb-dapp/react-environment';
 
 import { chainsConfig } from './chains/chain-config';
 import { walletsConfig } from './wallets/wallets-config';
@@ -30,3 +34,12 @@ export * from './anchors';
 export * from './bridges';
 export * from './mixers';
 export * from './wallets';
+
+export const staticAppConfig: AppConfig = {
+  anchors: anchorsConfig,
+  bridgeByAsset: bridgeConfigByAsset,
+  chains: chainsConfig,
+  currencies: currenciesConfig,
+  mixers: mixersConfig,
+  wallet: walletsConfig,
+};

--- a/packages/apps/src/configs/mixers/mixer-config.ts
+++ b/packages/apps/src/configs/mixers/mixer-config.ts
@@ -1,15 +1,5 @@
-import { ChainId, chainsConfig, currenciesConfig } from '@webb-dapp/apps/configs';
+import { ChainId } from '@webb-dapp/apps/configs';
 import { AppConfig } from '@webb-dapp/react-environment/webb-context';
-import { WebbError, WebbErrorCodes } from '@webb-dapp/utils/webb-error';
-
-export const getEVMChainName = (evmId: number): string => {
-  const chain = Object.values(chainsConfig).find((chainsConfig) => chainsConfig.evmId === evmId);
-  if (chain) {
-    return chain.name;
-  } else {
-    throw WebbError.from(WebbErrorCodes.UnsupportedChain);
-  }
-};
 
 export const mixersConfig: AppConfig['mixers'] = {
   [ChainId.Edgeware]: {

--- a/packages/apps/src/configs/mixers/mixer-config.ts
+++ b/packages/apps/src/configs/mixers/mixer-config.ts
@@ -2,26 +2,8 @@ import { ChainId, chainsConfig, currenciesConfig } from '@webb-dapp/apps/configs
 import { AppConfig } from '@webb-dapp/react-environment/webb-context';
 import { WebbError, WebbErrorCodes } from '@webb-dapp/utils/webb-error';
 
-export const getNativeCurrencySymbol = (evmId: number): string => {
-  const chain = Object.values(chainsConfig).find((chainsConfig) => chainsConfig.evmId === evmId);
-  if (chain) {
-    const nativeCurrency = chain.nativeCurrencyId;
-    return currenciesConfig[nativeCurrency].symbol;
-  }
-  return 'Unknown';
-};
-
 export const getEVMChainName = (evmId: number): string => {
   const chain = Object.values(chainsConfig).find((chainsConfig) => chainsConfig.evmId === evmId);
-  if (chain) {
-    return chain.name;
-  } else {
-    throw WebbError.from(WebbErrorCodes.UnsupportedChain);
-  }
-};
-
-export const getEVMChainNameFromInternal = (chainID: number): string => {
-  const chain = Object.values(chainsConfig).find((chainsConfig) => chainsConfig.id === chainID);
   if (chain) {
     return chain.name;
   } else {

--- a/packages/apps/src/configs/relayer-config.ts
+++ b/packages/apps/src/configs/relayer-config.ts
@@ -1,4 +1,5 @@
 import { ChainId } from '@webb-dapp/apps/configs/chains';
+import { AppConfigApi } from '@webb-dapp/react-environment';
 import { RelayerConfig, WebbRelayerBuilder } from '@webb-dapp/react-environment/webb-context/relayer';
 
 let builder: WebbRelayerBuilder | null = null;
@@ -120,15 +121,19 @@ export function chainIdToRelayerName(id: ChainId): string {
   throw new Error(`unhandled Chain id ${id}`);
 }
 
-export async function getWebbRelayer() {
+export async function getWebbRelayer(appConfigApi: AppConfigApi) {
   if (!builder) {
-    builder = await WebbRelayerBuilder.initBuilder(relayerConfig, (name, basedOn) => {
-      try {
-        return basedOn === 'evm' ? relayerNameToChainId(name) : relayerSubstrateNameToChainId(name);
-      } catch (e) {
-        return null;
-      }
-    });
+    builder = await WebbRelayerBuilder.initBuilder(
+      relayerConfig,
+      (name, basedOn) => {
+        try {
+          return basedOn === 'evm' ? relayerNameToChainId(name) : relayerSubstrateNameToChainId(name);
+        } catch (e) {
+          return null;
+        }
+      },
+      appConfigApi
+    );
   }
   return builder;
 }

--- a/packages/apps/src/configs/storages/EvmChainStorage.ts
+++ b/packages/apps/src/configs/storages/EvmChainStorage.ts
@@ -1,11 +1,11 @@
-import { getEVMChainName } from '@webb-dapp/apps/configs/';
+import { AppConfigApi } from '@webb-dapp/react-environment';
 import { Storage } from '@webb-dapp/utils';
 
 export type MixerStorage = Record<string, { lastQueriedBlock: number; leaves: string[] }>;
 
-export const evmChainStorageFactory = (chainId: number) => {
+export const evmChainStorageFactory = (chainId: number, configApi: AppConfigApi) => {
   // localStorage will have key: <name of chain>, value: { Record<contractAddress: string, info: DynamicMixerInfoStore> }
-  return Storage.newFromCache<MixerStorage>(getEVMChainName(chainId), {
+  return Storage.newFromCache<MixerStorage>(configApi.getEVMChainName(chainId), {
     async commit(key: string, data: MixerStorage): Promise<void> {
       localStorage.setItem(key, JSON.stringify(data));
     },

--- a/packages/apps/src/initI18n.ts
+++ b/packages/apps/src/initI18n.ts
@@ -1,9 +1,9 @@
-
 // @ts-nocheck
 // auto generate by buildI18n.js
 
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+
 import resources from '../src/i18n/index.json';
 
 // for debug
@@ -15,5 +15,5 @@ i18n.use(initReactI18next).init({
   defaultNS: 'translations',
   fallbackLng: 'en',
   ns: ['apps', 'page-mixer', 'react-components'],
-  resources
+  resources,
 });

--- a/packages/apps/src/initI18n.ts
+++ b/packages/apps/src/initI18n.ts
@@ -1,9 +1,9 @@
+
 // @ts-nocheck
 // auto generate by buildI18n.js
 
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-
 import resources from '../src/i18n/index.json';
 
 // for debug
@@ -15,5 +15,5 @@ i18n.use(initReactI18next).init({
   defaultNS: 'translations',
   fallbackLng: 'en',
   ns: ['apps', 'page-mixer', 'react-components'],
-  resources,
+  resources
 });

--- a/packages/bridge/src/components/Withdraw/WithdrawingModal.tsx
+++ b/packages/bridge/src/components/Withdraw/WithdrawingModal.tsx
@@ -1,6 +1,5 @@
 import { Button, Divider, Icon, LinearProgress, Tooltip, Typography } from '@material-ui/core';
-import { getEVMChainNameFromInternal } from '@webb-dapp/apps/configs';
-import { WithdrawState } from '@webb-dapp/react-environment';
+import { useWebContext, WithdrawState } from '@webb-dapp/react-environment';
 import { FontFamilies } from '@webb-dapp/ui-components/styling/fonts/font-families.enum';
 import { JsNote as DepositNote } from '@webb-tools/wasm-utils';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -75,16 +74,16 @@ const WithdrawInfoRow = styled.div`
 `;
 
 const InfoItemLabel = styled.div`
-  flex: 1 0 20%;
-  justify-content: center;
+	flex: 1 0 20%;
+	justify-content: center;
 
-  .label-icon {
-    vertical-align: middle;
-  padding: 1rem 0;
+	.label-icon {
+		vertical-align: middle;
+		padding: 1rem 0;
 
-  td:nth-child(2) {
-    padding: 0 2rem;
-  }
+		td:nth-child(2) {
+			padding: 0 2rem;
+		}
 `;
 
 const InfoItem = styled.div`
@@ -99,6 +98,7 @@ const alternatingMessages = [
   'Anyone with your note can withdraw, You should keep it secret',
 ];
 const WithdrawingModal: React.FC<WithdrawingModalProps> = ({ canCancel, cancel, note, stage, withdrawTxInfo }) => {
+  const { appConfig } = useWebContext();
   const [rm, setAlternatingMessage] = useState(0);
   useEffect(() => {
     const handle = setInterval(() => {
@@ -131,6 +131,11 @@ const WithdrawingModal: React.FC<WithdrawingModalProps> = ({ canCancel, cancel, 
     const address = withdrawTxInfo.account;
     return `${address.slice(0, 6)}...${address.slice(address.length - 6, address.length)}`;
   }, [withdrawTxInfo]);
+
+  const chainName = useMemo(() => {
+    const chainId = note.targetChainId;
+    return appConfig.getEVMChainNameFromInternal(Number(chainId));
+  }, [note, appConfig]);
 
   return (
     <WithdrawInfoWrapper>
@@ -174,8 +179,7 @@ const WithdrawingModal: React.FC<WithdrawingModalProps> = ({ canCancel, cancel, 
               <InfoItem>
                 <Typography variant={'caption'}>
                   <b>
-                    Receiving {note.amount + ' ' + note.tokenSymbol} on{' '}
-                    {getEVMChainNameFromInternal(Number(note.targetChainId))}
+                    Receiving {note.amount + ' ' + note.tokenSymbol} on {chainName}
                   </b>
                 </Typography>
               </InfoItem>

--- a/packages/react-environment/src/WebbProvider.tsx
+++ b/packages/react-environment/src/WebbProvider.tsx
@@ -1,13 +1,6 @@
 import Icon from '@material-ui/core/Icon';
 import WalletConnectProvider from '@walletconnect/web3-provider';
-import {
-  ChainId,
-  chainsPopulated,
-  currenciesConfig,
-  getEVMChainName,
-  staticAppConfig,
-  WebbEVMChain,
-} from '@webb-dapp/apps/configs';
+import { ChainId, chainsPopulated, currenciesConfig, staticAppConfig, WebbEVMChain } from '@webb-dapp/apps/configs';
 import { getWebbRelayer } from '@webb-dapp/apps/configs/relayer-config';
 import { WalletId } from '@webb-dapp/apps/configs/wallets/wallet-id.enum';
 import { walletsConfig } from '@webb-dapp/apps/configs/wallets/wallets-config';
@@ -188,7 +181,7 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
       case WebbErrorCodes.UnsupportedChain:
         {
           setActiveChain(undefined);
-          const interactiveFeedback = unsupportedChain();
+          const interactiveFeedback = unsupportedChain(appConfig);
           if (interactiveFeedback) {
             registerInteractiveFeedback(setInteractiveFeedbacks, interactiveFeedback);
           }
@@ -322,7 +315,7 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
               const nextChain = Object.values(chains).find((chain) => chain.evmId === chainId);
               try {
                 /// this will throw if the user switched to unsupported chain
-                const name = getEVMChainName(chainId);
+                const name = appConfig.getEVMChainName(chainId);
                 /// Alerting that the provider has changed via the extension
                 notificationApi({
                   message: 'Web3: changed the connected network',

--- a/packages/react-environment/src/WebbProvider.tsx
+++ b/packages/react-environment/src/WebbProvider.tsx
@@ -25,6 +25,7 @@ import { SettingProvider } from './SettingProvider';
 import {
   AppConfigApi,
   Chain,
+  EnhancedAppConfig,
   netStorageFactory,
   NetworkStorage,
   Wallet,
@@ -57,8 +58,12 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
   const [activeWallet, setActiveWallet] = useState<Wallet | undefined>(undefined);
   const [activeChain, setActiveChain] = useState<Chain | undefined>(undefined);
 
-  const appConfig = useMemo(() => appConfigApi, []);
+  const [appConfig, setAppConfig] = useState(new EnhancedAppConfig(appConfigApi.config));
 
+  useEffect(() => {
+    let subscription = appConfigApi.$config.subscribe((nextConfig) => setAppConfig(nextConfig));
+    return () => subscription.unsubscribe();
+  }, []);
   const [activeApi, setActiveApi] = useState<WebbApiProvider<any> | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const [networkStorage, setNetworkStorage] = useState<NetworkStorage | null>(null);
@@ -181,7 +186,7 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
       case WebbErrorCodes.UnsupportedChain:
         {
           setActiveChain(undefined);
-          const interactiveFeedback = unsupportedChain(appConfig);
+          const interactiveFeedback = unsupportedChain(appConfigApi);
           if (interactiveFeedback) {
             registerInteractiveFeedback(setInteractiveFeedbacks, interactiveFeedback);
           }
@@ -216,7 +221,7 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
   };
   /// Network switcher
   const switchChain = async (chain: Chain, _wallet: Wallet) => {
-    const relayer = await getWebbRelayer(appConfig);
+    const relayer = await getWebbRelayer(appConfigApi);
 
     const wallet = _wallet || activeWallet;
     // wallet cleanup

--- a/packages/react-environment/src/WebbProvider.tsx
+++ b/packages/react-environment/src/WebbProvider.tsx
@@ -64,13 +64,7 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
   const [activeWallet, setActiveWallet] = useState<Wallet | undefined>(undefined);
   const [activeChain, setActiveChain] = useState<Chain | undefined>(undefined);
 
-  const [appConfig, setAppConfig] = useState(appConfigApi.config);
-
-  useEffect(() => {
-    appConfigApi.$config.subscribe((next) => {
-      setAppConfig(next);
-    });
-  }, []);
+  const appConfig = useMemo(() => appConfigApi, []);
 
   const [activeApi, setActiveApi] = useState<WebbApiProvider<any> | undefined>(undefined);
   const [loading, setLoading] = useState(true);
@@ -229,7 +223,7 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
   };
   /// Network switcher
   const switchChain = async (chain: Chain, _wallet: Wallet) => {
-    const relayer = await getWebbRelayer();
+    const relayer = await getWebbRelayer(appConfig);
 
     const wallet = _wallet || activeWallet;
     // wallet cleanup

--- a/packages/react-environment/src/api-providers/polkadot/polkadot-mixer-deposit.ts
+++ b/packages/react-environment/src/api-providers/polkadot/polkadot-mixer-deposit.ts
@@ -37,7 +37,7 @@ export class PolkadotMixerDeposit extends MixerDeposit<WebbPolkadot, DepositPayl
     // @ts-ignore
     const tokenProperty: Array<NativeTokenProperties> = await api.rpc.system.properties();
     const groupItem = data
-      .map(([storageKey, info]: [StorageKey, PalletMixerMixerMetadata]) => {
+      .map(([storageKey, info]) => {
         const mixerInfo = (info as PalletMixerMixerMetadata).toHuman();
         console.log(mixerInfo);
         const cId: number = Number(mixerInfo.asset);

--- a/packages/react-environment/src/api-providers/polkadot/webb-polkadot-provider.ts
+++ b/packages/react-environment/src/api-providers/polkadot/webb-polkadot-provider.ts
@@ -7,6 +7,7 @@ import {
 } from '@webb-dapp/react-environment/api-providers/polkadot';
 import {
   ApiInitHandler,
+  AppConfigApi,
   ProvideCapabilities,
   WebbApiProvider,
   WebbMethods,
@@ -31,7 +32,8 @@ export class WebbPolkadot extends EventBus<WebbProviderEvents> implements WebbAp
   private constructor(
     apiPromise: ApiPromise,
     injectedExtension: InjectedExtension,
-    readonly relayingManager: WebbRelayerBuilder
+    readonly relayingManager: WebbRelayerBuilder,
+    public readonly appConfig: AppConfigApi
   ) {
     super();
     this.provider = new PolkadotProvider(apiPromise, injectedExtension);
@@ -115,10 +117,11 @@ export class WebbPolkadot extends EventBus<WebbProviderEvents> implements WebbAp
     appName: string,
     endpoints: string[],
     errorHandler: ApiInitHandler,
-    relayerBuilder: WebbRelayerBuilder
+    relayerBuilder: WebbRelayerBuilder,
+    config: AppConfigApi
   ): Promise<WebbPolkadot> {
     const [apiPromise, injectedExtension] = await PolkadotProvider.getParams(appName, endpoints, errorHandler.onError);
-    const instance = new WebbPolkadot(apiPromise, injectedExtension, relayerBuilder);
+    const instance = new WebbPolkadot(apiPromise, injectedExtension, relayerBuilder, config);
     await instance.insureApiInterface();
     /// check metadata update
     await instance.awaitMetaDataCheck();

--- a/packages/react-environment/src/api-providers/web3/web3-bridge-deposit.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-bridge-deposit.ts
@@ -1,11 +1,4 @@
-import {
-  ChainId,
-  chainIdIntoEVMId,
-  chainsConfig,
-  currenciesConfig,
-  evmIdIntoChainId,
-  getEVMChainNameFromInternal,
-} from '@webb-dapp/apps/configs';
+import { ChainId, chainIdIntoEVMId, chainsConfig, currenciesConfig, evmIdIntoChainId } from '@webb-dapp/apps/configs';
 import { WebbGovernedToken } from '@webb-dapp/contracts/contracts';
 import { ERC20__factory } from '@webb-dapp/contracts/types';
 import { createAnchor2Deposit, Deposit } from '@webb-dapp/contracts/utils/make-deposit';
@@ -22,6 +15,7 @@ import React from 'react';
 import { u8aToHex } from '@polkadot/util';
 
 import { BridgeDeposit } from '../../webb-context/bridge/bridge-deposit';
+
 const logger = LoggerService.get('web3-bridge-deposit');
 
 type DepositPayload = IDepositPayload<Note, [Deposit, number | string, string?]>;
@@ -38,10 +32,11 @@ export class Web3BridgeDeposit extends BridgeDeposit<WebbWeb3Provider, DepositPa
       const note = depositPayload.note.note;
       const sourceEvmId = await this.inner.getChainId();
       const sourceChainId = evmIdIntoChainId(sourceEvmId);
+      const chainName = this.inner.appConfig.getEVMChainNameFromInternal(Number(note.sourceChainId));
       transactionNotificationConfig.loading?.({
         address: '',
         data: React.createElement(DepositNotification, {
-          chain: getEVMChainNameFromInternal(Number(note.sourceChainId)),
+          chain: chainName,
           amount: Number(note.amount),
           currency: bridge.currency.view.name,
         }),

--- a/packages/react-environment/src/api-providers/web3/web3-mixer-deposit.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-mixer-deposit.ts
@@ -1,4 +1,4 @@
-import { ChainId, chainIdIntoEVMId, evmIdIntoChainId, getEVMChainName } from '@webb-dapp/apps/configs';
+import { ChainId, chainIdIntoEVMId, evmIdIntoChainId } from '@webb-dapp/apps/configs';
 import { createTornDeposit, Deposit } from '@webb-dapp/contracts/utils/make-deposit';
 import { DepositPayload as IDepositPayload, MixerDeposit, MixerSize } from '@webb-dapp/react-environment/webb-context';
 import { DepositNotification } from '@webb-dapp/ui-components/notification/DepositNotification';
@@ -20,7 +20,7 @@ export class Web3MixerDeposit extends MixerDeposit<WebbWeb3Provider, DepositPayl
     transactionNotificationConfig.loading?.({
       address: '',
       data: React.createElement(DepositNotification, {
-        chain: getEVMChainName(evmChainId),
+        chain: this.inner.appConfig.getEVMChainName(evmChainId),
         amount: Number(depositPayload.note.amount),
         currency: depositPayload.note.tokenSymbol,
       }),

--- a/packages/react-environment/src/api-providers/web3/web3-mixer-deposit.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-mixer-deposit.ts
@@ -1,10 +1,4 @@
-import {
-  ChainId,
-  chainIdIntoEVMId,
-  evmIdIntoChainId,
-  getEVMChainName,
-  getNativeCurrencySymbol,
-} from '@webb-dapp/apps/configs';
+import { ChainId, chainIdIntoEVMId, evmIdIntoChainId, getEVMChainName } from '@webb-dapp/apps/configs';
 import { createTornDeposit, Deposit } from '@webb-dapp/contracts/utils/make-deposit';
 import { DepositPayload as IDepositPayload, MixerDeposit, MixerSize } from '@webb-dapp/react-environment/webb-context';
 import { DepositNotification } from '@webb-dapp/ui-components/notification/DepositNotification';
@@ -37,7 +31,8 @@ export class Web3MixerDeposit extends MixerDeposit<WebbWeb3Provider, DepositPayl
       },
     });
     const [deposit, amount] = params;
-    const contract = await this.inner.getContractBySize(amount, getNativeCurrencySymbol(await this.inner.getChainId()));
+    const symbol = this.inner.appConfig.getNativeCurrencySymbol(await this.inner.getChainId());
+    const contract = await this.inner.getContractBySize(amount, symbol);
     try {
       await contract.deposit(deposit.commitment);
 
@@ -113,6 +108,7 @@ export class Web3MixerDeposit extends MixerDeposit<WebbWeb3Provider, DepositPayl
   }
 
   async getSizes(): Promise<MixerSize[]> {
-    return this.inner.getMixerSizes(getNativeCurrencySymbol(await this.inner.getChainId()));
+    const symbol = this.inner.appConfig.getNativeCurrencySymbol(await this.inner.getChainId());
+    return this.inner.getMixerSizes(symbol);
   }
 }

--- a/packages/react-environment/src/api-providers/web3/webb-web3-provider.ts
+++ b/packages/react-environment/src/api-providers/web3/webb-web3-provider.ts
@@ -1,7 +1,7 @@
 import { chainIdIntoEVMId, chainsConfig, currenciesConfig, evmIdIntoChainId } from '@webb-dapp/apps/configs';
 import { TornadoContract } from '@webb-dapp/contracts/contracts/tornado-anchor';
 import { AnchorContract } from '@webb-dapp/contracts/contracts/webb-anchor';
-import { WebbApiProvider, WebbMethods, WebbProviderEvents } from '@webb-dapp/react-environment';
+import { AppConfigApi, WebbApiProvider, WebbMethods, WebbProviderEvents } from '@webb-dapp/react-environment';
 import { Web3WrapUnwrap } from '@webb-dapp/react-environment/api-providers';
 import { EvmChainMixersInfo } from '@webb-dapp/react-environment/api-providers/web3/EvmChainMixersInfo';
 import { Web3BridgeDeposit } from '@webb-dapp/react-environment/api-providers/web3/web3-bridge-deposit';
@@ -30,7 +30,8 @@ export class WebbWeb3Provider
   private constructor(
     private web3Provider: Web3Provider,
     private chainId: number,
-    readonly relayingManager: WebbRelayerBuilder
+    readonly relayingManager: WebbRelayerBuilder,
+    public readonly appConfig: AppConfigApi
   ) {
     super();
     this.accounts = new Web3Accounts(web3Provider.eth);
@@ -161,8 +162,13 @@ export class WebbWeb3Provider
     return Promise.resolve(this.connectedMixers.getTornMixerSizes(tokenSymbol));
   }
 
-  static async init(web3Provider: Web3Provider, chainId: number, relayerBuilder: WebbRelayerBuilder) {
-    return new WebbWeb3Provider(web3Provider, chainId, relayerBuilder);
+  static async init(
+    web3Provider: Web3Provider,
+    chainId: number,
+    relayerBuilder: WebbRelayerBuilder,
+    config: AppConfigApi
+  ) {
+    return new WebbWeb3Provider(web3Provider, chainId, relayerBuilder, config);
   }
 
   get capabilities() {

--- a/packages/react-environment/src/api-providers/web3/webb-web3-provider.ts
+++ b/packages/react-environment/src/api-providers/web3/webb-web3-provider.ts
@@ -45,7 +45,7 @@ export class WebbWeb3Provider
     this.ethersProvider.provider?.on?.('accountsChanged', () => {
       this.emit('newAccounts', this.accounts);
     });
-    this.connectedMixers = new EvmChainMixersInfo(chainId);
+    this.connectedMixers = new EvmChainMixersInfo(chainId, appConfig);
     this.methods = {
       wrapUnwrap: {
         core: {
@@ -93,7 +93,7 @@ export class WebbWeb3Provider
   }
 
   setStorage(chainId: number) {
-    this.connectedMixers = new EvmChainMixersInfo(chainId);
+    this.connectedMixers = new EvmChainMixersInfo(chainId, this.appConfig);
   }
 
   async destroy(): Promise<void> {
@@ -114,7 +114,7 @@ export class WebbWeb3Provider
 
   getTornadoContractAddressByNote(note: Note) {
     const evmId = chainIdIntoEVMId(Number(note.note.targetChainId));
-    const availableMixers = new EvmChainMixersInfo(evmId);
+    const availableMixers = new EvmChainMixersInfo(evmId, this.appConfig);
     const mixer = availableMixers.getTornMixerInfoBySize(Number(note.note.amount), note.note.tokenSymbol);
     if (!mixer) {
       throw new Error('Mixer not found');

--- a/packages/react-environment/src/error/interactive-errors/unsupported-chain.ts
+++ b/packages/react-environment/src/error/interactive-errors/unsupported-chain.ts
@@ -1,7 +1,8 @@
-import { getEVMChainName, WebbEVMChain } from '@webb-dapp/apps/configs';
+import { WebbEVMChain } from '@webb-dapp/apps/configs';
+import { AppConfigApi } from '@webb-dapp/react-environment';
 import { InteractiveFeedback, WebbErrorCodes } from '@webb-dapp/utils/webb-error';
 
-export function unsupportedChain(): InteractiveFeedback {
+export function unsupportedChain(appConfigApi: AppConfigApi): InteractiveFeedback {
   let interactiveFeedback: InteractiveFeedback;
   const feedbackBody = InteractiveFeedback.feedbackEntries([
     {
@@ -12,9 +13,9 @@ export function unsupportedChain(): InteractiveFeedback {
     },
     {
       list: [
-        getEVMChainName(WebbEVMChain.Rinkeby),
-        getEVMChainName(WebbEVMChain.Beresheet),
-        getEVMChainName(WebbEVMChain.HarmonyTestnet1),
+        appConfigApi.getEVMChainName(WebbEVMChain.Rinkeby),
+        appConfigApi.getEVMChainName(WebbEVMChain.Beresheet),
+        appConfigApi.getEVMChainName(WebbEVMChain.HarmonyTestnet1),
       ],
     },
     {

--- a/packages/react-environment/src/webb-context/common.ts
+++ b/packages/react-environment/src/webb-context/common.ts
@@ -5,6 +5,11 @@ import { CurrencyConfig } from '@webb-dapp/react-environment/types/currency-conf
 import { MixerConfig } from '@webb-dapp/react-environment/types/mixer-config.interface';
 import { WalletConfig } from '@webb-dapp/react-environment/types/wallet-config.interface';
 import { BehaviorSubject, Observable } from 'rxjs';
+import { ChainId, chainsConfig, currenciesConfig, WebbCurrencyId } from '@webb-dapp/apps/configs';
+import { LoggerService } from '@webb-tools/app-util';
+import { WebbError, WebbErrorCodes } from '@webb-dapp/utils/webb-error';
+
+const logger = LoggerService.get('config api');
 
 export type Chain = ChainConfig & {
   wallets: Record<number, Wallet>;
@@ -43,5 +48,45 @@ export class AppConfigApi {
       ...partialConfig,
     };
     this._appConfig.next(nextConfig);
+  }
+
+  public getAnchorAddressForBridge(assetId: WebbCurrencyId, chainId: number, amount: number): string | undefined {
+    const linkedAnchorConfig = this.config.bridgeByAsset[assetId]?.anchors.find(
+      (anchor) => anchor.amount === amount.toString()
+    );
+    if (!linkedAnchorConfig) {
+      throw new Error('Unsupported configuration for bridge');
+    }
+
+    const anchorAddress = linkedAnchorConfig.anchorAddresses[chainId as ChainId];
+    logger.log('got anchor address: ', anchorAddress);
+    return anchorAddress;
+  }
+
+  public getNativeCurrencySymbol(evmId: number): string {
+    const chain = Object.values(this.config.chains).find((chainsConfig) => chainsConfig.evmId === evmId);
+    if (chain) {
+      const nativeCurrency = chain.nativeCurrencyId;
+      return currenciesConfig[nativeCurrency].symbol;
+    }
+    return 'Unknown';
+  }
+
+  public getEVMChainName(evmId: number): string {
+    const chain = Object.values(this.config.chains).find((chainsConfig) => chainsConfig.evmId === evmId);
+    if (chain) {
+      return chain.name;
+    } else {
+      throw WebbError.from(WebbErrorCodes.UnsupportedChain);
+    }
+  }
+
+  public getEVMChainNameFromInternal(chainID: number): string {
+    const chain = Object.values(this.config.chains).find((chainsConfig) => chainsConfig.id === chainID);
+    if (chain) {
+      return chain.name;
+    } else {
+      throw WebbError.from(WebbErrorCodes.UnsupportedChain);
+    }
   }
 }

--- a/packages/react-environment/src/webb-context/common.ts
+++ b/packages/react-environment/src/webb-context/common.ts
@@ -4,6 +4,7 @@ import { ChainConfig } from '@webb-dapp/react-environment/types/chain-config.int
 import { CurrencyConfig } from '@webb-dapp/react-environment/types/currency-config.interface';
 import { MixerConfig } from '@webb-dapp/react-environment/types/mixer-config.interface';
 import { WalletConfig } from '@webb-dapp/react-environment/types/wallet-config.interface';
+import { BehaviorSubject, Observable } from 'rxjs';
 
 export type Chain = ChainConfig & {
   wallets: Record<number, Wallet>;
@@ -18,3 +19,29 @@ export type AppConfig = {
   anchors: Record<number, AnchorConfigEntry[]>;
   mixers: Record<number, MixerConfig>;
 };
+
+export class AppConfigApi {
+  private readonly _appConfig: BehaviorSubject<AppConfig>;
+
+  constructor(staticConfig: AppConfig) {
+    this._appConfig = new BehaviorSubject({ ...staticConfig });
+  }
+
+  get $config(): Observable<AppConfig> {
+    return this._appConfig.asObservable();
+  }
+
+  get config(): AppConfig {
+    return {
+      ...this._appConfig.value,
+    };
+  }
+
+  set config(partialConfig: Partial<AppConfig>) {
+    const nextConfig = {
+      ...this.config,
+      ...partialConfig,
+    };
+    this._appConfig.next(nextConfig);
+  }
+}

--- a/packages/react-environment/src/webb-context/currency/orml-currency.ts
+++ b/packages/react-environment/src/webb-context/currency/orml-currency.ts
@@ -16,7 +16,7 @@ export class ORMLCurrency {
 
   async list() {
     const assets = await this.api.api.query.assetRegistry.assets.entries();
-    return assets.map(([storageKey, i]: [StorageKey, PalletAssetRegistryAssetDetails]) => ({
+    return assets.map(([storageKey, i]) => ({
       // @ts-ignore
       ...i.toHuman(),
       // @ts-ignore
@@ -31,7 +31,7 @@ export class ORMLCurrency {
     if (activeAccount) {
       const ormlBalances = await this.api.api.query.tokens.accounts.entries(activeAccount.address);
       logger.info(`ORML Balances ${ormlBalances.length}`, ormlBalances);
-      return ormlBalances.map(([storageKey, balance]: [StorageKey, Balance]) => {
+      return ormlBalances.map(([storageKey, balance]) => {
         const currencyId = storageKey[0];
         return {
           id: currencyId,

--- a/packages/react-environment/src/webb-context/currency/orml-currency.ts
+++ b/packages/react-environment/src/webb-context/currency/orml-currency.ts
@@ -1,6 +1,8 @@
 import { WebbPolkadot } from '@webb-dapp/react-environment/api-providers';
 import { LoggerService } from '@webb-tools/app-util';
+import { Balance, PalletAssetRegistryAssetDetails } from '@webb-tools/types/interfaces';
 
+import { StorageKey } from '@polkadot/types';
 export type ORMLAsset = {
   existentialDeposit: string;
   locked: false;
@@ -14,7 +16,7 @@ export class ORMLCurrency {
 
   async list() {
     const assets = await this.api.api.query.assetRegistry.assets.entries();
-    return assets.map(([storageKey, i]) => ({
+    return assets.map(([storageKey, i]: [StorageKey, PalletAssetRegistryAssetDetails]) => ({
       // @ts-ignore
       ...i.toHuman(),
       // @ts-ignore
@@ -29,7 +31,7 @@ export class ORMLCurrency {
     if (activeAccount) {
       const ormlBalances = await this.api.api.query.tokens.accounts.entries(activeAccount.address);
       logger.info(`ORML Balances ${ormlBalances.length}`, ormlBalances);
-      return ormlBalances.map(([storageKey, balance]) => {
+      return ormlBalances.map(([storageKey, balance]: [StorageKey, Balance]) => {
         const currencyId = storageKey[0];
         return {
           id: currencyId,

--- a/packages/react-environment/src/webb-context/index.ts
+++ b/packages/react-environment/src/webb-context/index.ts
@@ -1,7 +1,6 @@
 export * from './mixer';
 export * from './bridge';
 export * from './webb-provider.interface';
-export * from './webb-content-state.interface';
 export * from './common';
 export * from './webb-context';
 export * from './networks-storage';

--- a/packages/react-environment/src/webb-context/webb-context.ts
+++ b/packages/react-environment/src/webb-context/webb-context.ts
@@ -1,4 +1,4 @@
-import { AppConfig, Chain, Wallet } from '@webb-dapp/react-environment/webb-context/common';
+import { AppConfigApi, Chain, Wallet } from '@webb-dapp/react-environment/webb-context/common';
 import { WebbApiProvider } from '@webb-dapp/react-environment/webb-context/webb-provider.interface';
 import { InteractiveFeedback } from '@webb-dapp/utils/webb-error';
 import { Account } from '@webb-dapp/wallet/account/Accounts.adapter';
@@ -19,7 +19,7 @@ export interface WebbContextState<T = unknown> {
   activeApi?: WebbApiProvider<T>;
   activeWallet?: Wallet;
   activeChain?: Chain;
-  appConfig: AppConfig;
+  appConfig: AppConfigApi;
   accounts: Account[];
   activeAccount: Account | null;
   isConnecting: boolean;
@@ -42,14 +42,14 @@ export const WebbContext = React.createContext<WebbContextState>({
 
   activeAccount: null,
   isConnecting: false,
-  appConfig: {
+  appConfig: new AppConfigApi({
     anchors: {},
     bridgeByAsset: {},
     chains: {},
     currencies: {},
     mixers: {},
     wallet: {},
-  },
+  }),
   setActiveAccount<T extends Account>(account: T): Promise<void> {
     return Promise.resolve();
   },

--- a/packages/react-environment/src/webb-context/webb-context.ts
+++ b/packages/react-environment/src/webb-context/webb-context.ts
@@ -1,4 +1,4 @@
-import { AppConfigApi, Chain, Wallet } from '@webb-dapp/react-environment/webb-context/common';
+import { AppConfigApi, Chain, EnhancedAppConfig, Wallet } from '@webb-dapp/react-environment/webb-context/common';
 import { WebbApiProvider } from '@webb-dapp/react-environment/webb-context/webb-provider.interface';
 import { InteractiveFeedback } from '@webb-dapp/utils/webb-error';
 import { Account } from '@webb-dapp/wallet/account/Accounts.adapter';
@@ -19,7 +19,7 @@ export interface WebbContextState<T = unknown> {
   activeApi?: WebbApiProvider<T>;
   activeWallet?: Wallet;
   activeChain?: Chain;
-  appConfig: AppConfigApi;
+  appConfig: EnhancedAppConfig;
   accounts: Account[];
   activeAccount: Account | null;
   isConnecting: boolean;
@@ -42,7 +42,7 @@ export const WebbContext = React.createContext<WebbContextState>({
 
   activeAccount: null,
   isConnecting: false,
-  appConfig: new AppConfigApi({
+  appConfig: new EnhancedAppConfig({
     anchors: {},
     bridgeByAsset: {},
     chains: {},

--- a/packages/react-environment/src/webb-context/webb-context.ts
+++ b/packages/react-environment/src/webb-context/webb-context.ts
@@ -1,4 +1,4 @@
-import { Chain, Wallet } from '@webb-dapp/react-environment/webb-context/common';
+import { AppConfig, Chain, Wallet } from '@webb-dapp/react-environment/webb-context/common';
 import { WebbApiProvider } from '@webb-dapp/react-environment/webb-context/webb-provider.interface';
 import { InteractiveFeedback } from '@webb-dapp/utils/webb-error';
 import { Account } from '@webb-dapp/wallet/account/Accounts.adapter';
@@ -12,14 +12,14 @@ interface Note {
 
 type DespotStates = 'ideal' | 'generating-note' | 'depositing';
 
-export interface WebbContentState<T = unknown> {
+export interface WebbContextState<T = unknown> {
   loading: boolean;
   wallets: Record<number, Wallet>;
   chains: Record<number, Chain>;
   activeApi?: WebbApiProvider<T>;
   activeWallet?: Wallet;
   activeChain?: Chain;
-
+  appConfig: AppConfig;
   accounts: Account[];
   activeAccount: Account | null;
   isConnecting: boolean;
@@ -34,12 +34,22 @@ export interface WebbContentState<T = unknown> {
   registerInteractiveFeedback: (interactiveFeedback: InteractiveFeedback) => void;
 }
 
-export const WebbContext = React.createContext<WebbContentState>({
+export const WebbContext = React.createContext<WebbContextState>({
   chains: {},
   accounts: [],
   loading: true,
+  wallets: {},
+
   activeAccount: null,
   isConnecting: false,
+  appConfig: {
+    anchors: {},
+    bridgeByAsset: {},
+    chains: {},
+    currencies: {},
+    mixers: {},
+    wallet: {},
+  },
   setActiveAccount<T extends Account>(account: T): Promise<void> {
     return Promise.resolve();
   },
@@ -49,7 +59,6 @@ export const WebbContext = React.createContext<WebbContentState>({
   inactivateApi(): Promise<void> {
     return Promise.resolve();
   },
-  wallets: {},
   activeFeedback: null,
   registerInteractiveFeedback: (interactiveFeedback: InteractiveFeedback) => {
     return;
@@ -57,5 +66,5 @@ export const WebbContext = React.createContext<WebbContentState>({
 });
 
 export const useWebContext = <T = unknown>() => {
-  return React.useContext(WebbContext) as WebbContentState<T>;
+  return React.useContext(WebbContext) as WebbContextState<T>;
 };

--- a/packages/react-environment/src/webb-context/webb-provider.interface.ts
+++ b/packages/react-environment/src/webb-context/webb-provider.interface.ts
@@ -1,5 +1,6 @@
 import { Bridge, BridgeDeposit, BridgeWithdraw } from '@webb-dapp/react-environment/webb-context/bridge';
 import { ChainQuery } from '@webb-dapp/react-environment/webb-context/chain-query';
+import { AppConfigApi } from '@webb-dapp/react-environment/webb-context/common';
 import { WebbRelayerBuilder } from '@webb-dapp/react-environment/webb-context/relayer';
 import { WrapUnWrap } from '@webb-dapp/react-environment/webb-context/wrap-unwrap';
 import { InteractiveFeedback } from '@webb-dapp/utils/webb-error';
@@ -90,4 +91,6 @@ export interface WebbApiProvider<T> extends EventBus<WebbProviderEvents> {
   relayingManager: WebbRelayerBuilder;
 
   getProvider(): any;
+
+  appConfig: AppConfigApi;
 }

--- a/packages/ui-components/src/Inputs/NoteInput/BridgeNoteInput.tsx
+++ b/packages/ui-components/src/Inputs/NoteInput/BridgeNoteInput.tsx
@@ -1,12 +1,13 @@
 import { FormHelperText, Icon, InputBase } from '@material-ui/core';
-import { getEVMChainNameFromInternal, webbCurrencyIdFromString } from '@webb-dapp/apps/configs';
+import { webbCurrencyIdFromString } from '@webb-dapp/apps/configs';
 import { useBridge } from '@webb-dapp/bridge/hooks/bridge/use-bridge';
 import { useDepositNote } from '@webb-dapp/mixer/hooks/note';
+import { useWebContext } from '@webb-dapp/react-environment';
 import { Currency } from '@webb-dapp/react-environment/webb-context/currency/currency';
 import { InputLabel } from '@webb-dapp/ui-components/Inputs/InputLabel/InputLabel';
 import { notificationApi } from '@webb-dapp/ui-components/notification';
 import { Pallet } from '@webb-dapp/ui-components/styling/colors';
-import React, { useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
@@ -27,7 +28,13 @@ export const BridgeNoteInput: React.FC<NoteInputProps> = ({ error, onChange, val
   const depositNote = useDepositNote(value);
   const { getBridge } = useBridge();
   const navigate = useNavigate();
-
+  const { appConfig } = useWebContext();
+  const getEVMChainNameFromInternal = useCallback(
+    (id) => {
+      return appConfig.getEVMChainNameFromInternal(id);
+    },
+    [appConfig]
+  );
   // Switch to mixer tab if note is for mixer
   useEffect(() => {
     if (depositNote && depositNote.note.prefix === 'webb.mixer') {

--- a/packages/ui-components/src/Inputs/NoteInput/MixerNoteInput.tsx
+++ b/packages/ui-components/src/Inputs/NoteInput/MixerNoteInput.tsx
@@ -1,11 +1,10 @@
 import { FormHelperText, Icon, InputBase } from '@material-ui/core';
-import { getEVMChainNameFromInternal } from '@webb-dapp/apps/configs';
 import { useDepositNote } from '@webb-dapp/mixer/hooks/note';
 import { useWebContext } from '@webb-dapp/react-environment/webb-context';
 import { InputLabel } from '@webb-dapp/ui-components/Inputs/InputLabel/InputLabel';
 import { notificationApi } from '@webb-dapp/ui-components/notification';
 import { Pallet } from '@webb-dapp/ui-components/styling/colors';
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
@@ -25,7 +24,6 @@ const NoteDetails = styled.div`
 export const MixerNoteInput: React.FC<NoteInputProps> = ({ error, onChange, value }) => {
   const depositNote = useDepositNote(value);
   const navigate = useNavigate();
-  const { registerInteractiveFeedback } = useWebContext();
 
   // Switch to bridge tab if note is for bridge
   useEffect(() => {
@@ -39,6 +37,14 @@ export const MixerNoteInput: React.FC<NoteInputProps> = ({ error, onChange, valu
       navigate('/bridge', { replace: true });
     }
   }, [depositNote, navigate]);
+
+  const { appConfig } = useWebContext();
+  const getEVMChainNameFromInternal = useCallback(
+    (id) => {
+      return appConfig.getEVMChainNameFromInternal(id);
+    },
+    [appConfig]
+  );
 
   return (
     <InputLabel label={'Note'}>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The app is configurated  with just static config and no way to update config on runtime, which makes it hard to deal with changes that should happen after dApp bootstrap ex ( Wrappbable assets,  substrate storage/anchors ..etc)
Issue Number: #301 


## What is the new behavior?
- `AppConfig` is now a state object.
- `AppConfig` and its utils (utils that depend on the config)  are merged into a type `AppConfigApi` which is accessible by Webb provides

## Does this PR introduce a breaking change?
- [X] Yes
- [ ] No
The migration and usage of the config is included in the PR, already removed older utils of static config, updated the deps

## Other information
