### PR TITLE
[RE] Linking the notification API/TX notification config to the provider

### DIFF
--- a/packages/apps/src/initI18n.ts
+++ b/packages/apps/src/initI18n.ts
@@ -1,9 +1,9 @@
-
 // @ts-nocheck
 // auto generate by buildI18n.js
 
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+
 import resources from '../src/i18n/index.json';
 
 // for debug
@@ -15,5 +15,5 @@ i18n.use(initReactI18next).init({
   defaultNS: 'translations',
   fallbackLng: 'en',
   ns: ['apps', 'page-mixer', 'react-components'],
-  resources
+  resources,
 });

--- a/packages/apps/src/initI18n.ts
+++ b/packages/apps/src/initI18n.ts
@@ -1,9 +1,9 @@
+
 // @ts-nocheck
 // auto generate by buildI18n.js
 
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-
 import resources from '../src/i18n/index.json';
 
 // for debug
@@ -15,5 +15,5 @@ i18n.use(initReactI18next).init({
   defaultNS: 'translations',
   fallbackLng: 'en',
   ns: ['apps', 'page-mixer', 'react-components'],
-  resources,
+  resources
 });

--- a/packages/react-environment/src/WebbProvider.tsx
+++ b/packages/react-environment/src/WebbProvider.tsx
@@ -74,60 +74,63 @@ const appConfig: AppConfig = {
 
 function notificationHandler(notification: NotificationPayload) {
   switch (notification.name) {
-    case 'Transaction':
-      {
-        const isFailed = notification.level === 'error';
-        const isFinalized = notification.level === 'success';
-        const description = notification.data ? (
-          <div>
-            {Object.keys(notification.data).map((i) => (
-              <Typography variant={'h6'}>{notification.data?.[i]}</Typography>
-            ))}
-          </div>
-        ) : (
-          notification.description
-        );
-        if (isFinalized) {
-          notificationApi({
-            extras: {
-              persist: false,
-            },
-            message: notification.message ?? 'Submit Transaction Success',
-            secondaryMessage: description,
-            key: notification.key,
-            variant: 'success',
-          });
-          setTimeout(() => notificationApi.remove(notification.key), 6000);
-        } else if (isFailed) {
-          notificationApi({
-            extras: {
-              persist: false,
-            },
-            key: notification.key,
-            message: notification.message,
-            secondaryMessage: description,
-            variant: 'error',
-          });
-        } else {
-          notificationApi({
-            extras: {
-              persist: true,
-            },
-            key: notification.key,
-            message: notification.message,
-            secondaryMessage: description,
-            variant: 'info',
-            // eslint-disable-next-line sort-keys
-            Icon: <Spinner />,
-            transparent: true,
-          });
-        }
+    case 'Transaction': {
+      const isFailed = notification.level === 'error';
+      const isFinalized = notification.level === 'success';
+      const description = notification.data ? (
+        <div>
+          {Object.keys(notification.data).map((i) => (
+            <Typography variant={'h6'}>{notification.data?.[i]}</Typography>
+          ))}
+        </div>
+      ) : (
+        notification.description
+      );
+      if (isFinalized) {
+        const key = notificationApi({
+          extras: {
+            persist: false,
+          },
+          message: notification.message ?? 'Submit Transaction Success',
+          secondaryMessage: description,
+          key: notification.key,
+          variant: 'success',
+        });
+        setTimeout(() => notificationApi.remove(notification.key), 6000);
+        return key;
+      } else if (isFailed) {
+        return notificationApi({
+          extras: {
+            persist: false,
+          },
+          key: notification.key,
+          message: notification.message,
+          secondaryMessage: description,
+          variant: 'error',
+        });
+      } else {
+        return notificationApi({
+          extras: {
+            persist: true,
+          },
+          key: notification.key,
+          message: notification.message,
+          secondaryMessage: description,
+          variant: 'info',
+          // eslint-disable-next-line sort-keys
+          Icon: <Spinner />,
+          transparent: true,
+        });
       }
-
-      break;
+    }
+    default:
+      return '';
   }
 }
 
+notificationHandler.remove = (key: string | number) => {
+  notificationApi.remove(key);
+};
 export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Dapp', children }) => {
   const [activeWallet, setActiveWallet] = useState<Wallet | undefined>(undefined);
   const [activeChain, setActiveChain] = useState<Chain | undefined>(undefined);

--- a/packages/react-environment/src/WebbProvider.tsx
+++ b/packages/react-environment/src/WebbProvider.tsx
@@ -83,6 +83,7 @@ function notificationHandler(notification: NotificationPayload) {
               persist: false,
             },
             message: notification.message ?? 'Submit Transaction Success',
+            secondaryMessage: notification.description,
             key: notification.key,
             variant: 'success',
           });
@@ -94,6 +95,7 @@ function notificationHandler(notification: NotificationPayload) {
             },
             key: notification.key,
             message: notification.message,
+            secondaryMessage: notification.description,
             variant: 'error',
           });
         } else {

--- a/packages/react-environment/src/WebbProvider.tsx
+++ b/packages/react-environment/src/WebbProvider.tsx
@@ -1,3 +1,4 @@
+import { Typography } from '@material-ui/core';
 import Icon from '@material-ui/core/Icon';
 import WalletConnectProvider from '@walletconnect/web3-provider';
 import {
@@ -77,13 +78,22 @@ function notificationHandler(notification: NotificationPayload) {
       {
         const isFailed = notification.level === 'error';
         const isFinalized = notification.level === 'success';
+        const description = notification.data ? (
+          <div>
+            {Object.keys(notification.data).map((i) => (
+              <Typography variant={'h6'}>{notification.data?.[i]}</Typography>
+            ))}
+          </div>
+        ) : (
+          notification.description
+        );
         if (isFinalized) {
           notificationApi({
             extras: {
               persist: false,
             },
             message: notification.message ?? 'Submit Transaction Success',
-            secondaryMessage: notification.description,
+            secondaryMessage: description,
             key: notification.key,
             variant: 'success',
           });
@@ -95,7 +105,7 @@ function notificationHandler(notification: NotificationPayload) {
             },
             key: notification.key,
             message: notification.message,
-            secondaryMessage: notification.description,
+            secondaryMessage: description,
             variant: 'error',
           });
         } else {
@@ -105,7 +115,7 @@ function notificationHandler(notification: NotificationPayload) {
             },
             key: notification.key,
             message: notification.message,
-            secondaryMessage: notification.description,
+            secondaryMessage: description,
             variant: 'info',
             // eslint-disable-next-line sort-keys
             Icon: <Spinner />,

--- a/packages/react-environment/src/api-providers/polkadot/polkadot-transaction.ts
+++ b/packages/react-environment/src/api-providers/polkadot/polkadot-transaction.ts
@@ -50,9 +50,9 @@ type PolkadotTXEvents = {
 };
 
 export type NotificationConfig = {
-  loading?: (data: PolkadotTXEventsPayload<JSX.Element>) => void;
-  finalize?: (data: PolkadotTXEventsPayload<string | void | undefined>) => void;
-  failed?: (data: PolkadotTXEventsPayload<string>) => void;
+  loading: (data: PolkadotTXEventsPayload<JSX.Element>) => string | number;
+  finalize: (data: PolkadotTXEventsPayload<string | void | undefined>) => string | number;
+  failed: (data: PolkadotTXEventsPayload<string>) => string | number;
 };
 const txLogger = LoggerService.get('PolkadotTx');
 

--- a/packages/react-environment/src/api-providers/polkadot/polkadot-transaction.ts
+++ b/packages/react-environment/src/api-providers/polkadot/polkadot-transaction.ts
@@ -1,3 +1,4 @@
+import { NotificationHandler } from '@webb-dapp/react-environment';
 import { EventBus, LoggerService } from '@webb-tools/app-util';
 import { uniqueId } from 'lodash';
 import React from 'react';
@@ -179,26 +180,48 @@ export class PolkadotTx<P extends Array<any>> extends EventBus<PolkadotTXEvents>
 }
 
 export class PolkaTXBuilder {
-  constructor(private apiPromise: ApiPromise, private notificationConfig: NotificationConfig) {}
+  constructor(private apiPromise: ApiPromise, private notificationHandler: NotificationHandler) {}
 
   buildWithoutNotification<P extends Array<any>>({ method, section }: MethodPath, params: P): PolkadotTx<P> {
     return new PolkadotTx<P>(this.apiPromise.clone(), { method, section }, params);
   }
 
-  build<P extends Array<any>>(path: MethodPath, params: P, notificationConfig?: NotificationConfig): PolkadotTx<P> {
+  build<P extends Array<any>>(path: MethodPath, params: P, notificationHandler?: NotificationHandler): PolkadotTx<P> {
     const tx = this.buildWithoutNotification(path, params);
-    const nc = notificationConfig || this.notificationConfig;
+    const handler = notificationHandler || this.notificationHandler;
 
     tx.on('loading', (data) => {
-      nc.loading?.(data);
+      handler({
+        message: `${data.path.section}:${data.path.method}`,
+        key: data.key,
+        description: data.address,
+        level: 'loading',
+        name: 'Transaction',
+        persist: true,
+      });
     });
 
     tx.on('finalize', (data) => {
-      nc.finalize?.(data);
+      handler({
+        message: `${data.path.section}:${data.path.method}`,
+        key: data.key,
+        description: data.address,
+        level: 'success',
+        name: 'Transaction',
+        persist: true,
+      });
     });
 
     tx.on('failed', (data) => {
-      nc.failed?.(data);
+      console.log(data);
+      handler({
+        message: `${data.path.section}:${data.path.method}`,
+        key: data.key,
+        description: data.data,
+        level: 'error',
+        name: 'Transaction',
+        persist: true,
+      });
     });
 
     return tx;

--- a/packages/react-environment/src/api-providers/polkadot/webb-polkadot-provider.ts
+++ b/packages/react-environment/src/api-providers/polkadot/webb-polkadot-provider.ts
@@ -38,7 +38,7 @@ export class WebbPolkadot extends EventBus<WebbProviderEvents> implements WebbAp
     injectedExtension: InjectedExtension,
     readonly relayingManager: WebbRelayerBuilder,
     readonly config: AppConfig,
-    readonly notification: ProviderNotification
+    readonly notificationHandler: ProviderNotification
   ) {
     super();
     this.provider = new PolkadotProvider(apiPromise, injectedExtension);

--- a/packages/react-environment/src/api-providers/polkadot/webb-polkadot-provider.ts
+++ b/packages/react-environment/src/api-providers/polkadot/webb-polkadot-provider.ts
@@ -12,6 +12,7 @@ import {
   ApiInitHandler,
   AppConfig,
   ProvideCapabilities,
+  ProviderNotification,
   WebbApiProvider,
   WebbMethods,
   WebbProviderEvents,
@@ -36,7 +37,8 @@ export class WebbPolkadot extends EventBus<WebbProviderEvents> implements WebbAp
     apiPromise: ApiPromise,
     injectedExtension: InjectedExtension,
     readonly relayingManager: WebbRelayerBuilder,
-    readonly config: AppConfig
+    readonly config: AppConfig,
+    readonly notification: ProviderNotification
   ) {
     super();
     this.provider = new PolkadotProvider(apiPromise, injectedExtension);
@@ -122,10 +124,11 @@ export class WebbPolkadot extends EventBus<WebbProviderEvents> implements WebbAp
     endpoints: string[],
     errorHandler: ApiInitHandler,
     relayerBuilder: WebbRelayerBuilder,
-    appConfig: AppConfig
+    appConfig: AppConfig,
+    notification: ProviderNotification
   ): Promise<WebbPolkadot> {
     const [apiPromise, injectedExtension] = await PolkadotProvider.getParams(appName, endpoints, errorHandler.onError);
-    const instance = new WebbPolkadot(apiPromise, injectedExtension, relayerBuilder, appConfig);
+    const instance = new WebbPolkadot(apiPromise, injectedExtension, relayerBuilder, appConfig, notification);
     await instance.insureApiInterface();
     /// check metadata update
     await instance.awaitMetaDataCheck();

--- a/packages/react-environment/src/api-providers/polkadot/webb-polkadot-provider.ts
+++ b/packages/react-environment/src/api-providers/polkadot/webb-polkadot-provider.ts
@@ -2,6 +2,7 @@ import {
   PolkadotChainQuery,
   PolkadotMixerDeposit,
   PolkadotMixerWithdraw,
+  PolkadotTx,
   PolkadotWrapUnwrap,
   PolkaTXBuilder,
 } from '@webb-dapp/react-environment/api-providers/polkadot';
@@ -11,8 +12,8 @@ import { PolkadotBridgeWithdraw } from '@webb-dapp/react-environment/api-provide
 import {
   ApiInitHandler,
   AppConfig,
+  NotificationHandler,
   ProvideCapabilities,
-  ProviderNotification,
   WebbApiProvider,
   WebbMethods,
   WebbProviderEvents,
@@ -38,10 +39,14 @@ export class WebbPolkadot extends EventBus<WebbProviderEvents> implements WebbAp
     injectedExtension: InjectedExtension,
     readonly relayingManager: WebbRelayerBuilder,
     readonly config: AppConfig,
-    readonly notificationHandler: ProviderNotification
+    readonly notificationHandler: NotificationHandler
   ) {
     super();
-    this.provider = new PolkadotProvider(apiPromise, injectedExtension);
+    this.provider = new PolkadotProvider(
+      apiPromise,
+      injectedExtension,
+      new PolkaTXBuilder(apiPromise, notificationHandler)
+    );
     this.accounts = this.provider.accounts;
     this.api = this.provider.api;
     this.txBuilder = this.provider.txBuilder;
@@ -125,7 +130,7 @@ export class WebbPolkadot extends EventBus<WebbProviderEvents> implements WebbAp
     errorHandler: ApiInitHandler,
     relayerBuilder: WebbRelayerBuilder,
     appConfig: AppConfig,
-    notification: ProviderNotification
+    notification: NotificationHandler
   ): Promise<WebbPolkadot> {
     const [apiPromise, injectedExtension] = await PolkadotProvider.getParams(appName, endpoints, errorHandler.onError);
     const instance = new WebbPolkadot(apiPromise, injectedExtension, relayerBuilder, appConfig, notification);

--- a/packages/react-environment/src/api-providers/web3/web3-bridge-deposit.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-bridge-deposit.ts
@@ -14,7 +14,6 @@ import { createAnchor2Deposit, Deposit } from '@webb-dapp/contracts/utils/make-d
 import { DepositPayload as IDepositPayload, MixerSize } from '@webb-dapp/react-environment';
 import { WebbWeb3Provider } from '@webb-dapp/react-environment/api-providers/web3/webb-web3-provider';
 import { Currency } from '@webb-dapp/react-environment/webb-context/currency/currency';
-import { notificationApi } from '@webb-dapp/ui-components/notification';
 import { DepositNotification } from '@webb-dapp/ui-components/notification/DepositNotification';
 import { transactionNotificationConfig } from '@webb-dapp/wallet/providers/polkadot/transaction-notification-config';
 import { LoggerService } from '@webb-tools/app-util';
@@ -31,9 +30,11 @@ export class Web3BridgeDeposit extends BridgeDeposit<WebbWeb3Provider, DepositPa
   private get bridgeApi() {
     return this.inner.methods.bridgeApi;
   }
+
   private get config() {
     return this.inner.config;
   }
+
   async deposit(depositPayload: DepositPayload): Promise<void> {
     const bridge = this.bridgeApi.activeBridge;
     const currency = this.bridgeApi.currency;
@@ -59,6 +60,18 @@ export class Web3BridgeDeposit extends BridgeDeposit<WebbWeb3Provider, DepositPa
           section: currency.view.name,
         },
       });
+      this.inner.notificationHandler({
+        key: 'bridge-deposit',
+        level: 'loading',
+        name: 'Transaction',
+        description: 'Depositing',
+        message: `bridge:${depositPayload.params[2] ? 'wrap and deposit' : 'deposit'}`,
+        data: {
+          chain: getEVMChainNameFromInternal(Number(sourceInternalId)),
+          amount: note.amount,
+          currency: currency.view.name,
+        },
+      });
 
       const anchors = await this.bridgeApi.getAnchors();
       // Find the Anchor for this bridge amount
@@ -77,11 +90,13 @@ export class Web3BridgeDeposit extends BridgeDeposit<WebbWeb3Provider, DepositPa
       if (depositPayload.params[2]) {
         const requiredApproval = await contract.isWrappableTokenApprovalRequired(depositPayload.params[2]);
         if (requiredApproval) {
-          notificationApi.addToQueue({
+          this.inner.notificationHandler({
+            description: 'Waiting for token approval',
+            persist: true,
+            level: 'info',
+            name: 'Transaction',
             message: 'Waiting for token approval',
-            variant: 'info',
             key: 'waiting-approval',
-            extras: { persist: true },
           });
           const tokenInstance = await ERC20__factory.connect(
             depositPayload.params[2],
@@ -90,89 +105,106 @@ export class Web3BridgeDeposit extends BridgeDeposit<WebbWeb3Provider, DepositPa
           const webbToken = await contract.getWebbToken();
           const tx = await tokenInstance.approve(webbToken.address, await contract.denomination);
           await tx.wait();
-          notificationApi.remove('waiting-approval');
+          this.inner.notificationHandler.remove('waiting-approval');
         }
 
         const enoughBalance = await contract.hasEnoughBalance(depositPayload.params[2]);
         if (enoughBalance) {
           await contract.wrapAndDeposit(commitment, depositPayload.params[2]);
-          transactionNotificationConfig.finalize?.({
-            address: '',
-            data: undefined,
+
+          this.inner.notificationHandler({
             key: 'bridge-deposit',
-            path: {
-              method: 'wrap and deposit',
-              section: currency.view.name,
+            level: 'success',
+            name: 'Transaction',
+            description: 'Depositing',
+            message: `${currency.view.name}:wrap and deposit`,
+            data: {
+              chain: getEVMChainNameFromInternal(Number(sourceInternalId)),
+              amount: note.amount,
+              currency: currency.view.name,
             },
           });
         } else {
-          notificationApi.addToQueue({
-            message: 'Not enough token balance',
-            variant: 'error',
-            key: 'waiting-approval',
+          this.inner.notificationHandler({
+            key: 'bridge-deposit',
+            level: 'error',
+            name: 'Transaction',
+            description: 'Not enough token balance',
+            message: `${currency.view.name}:wrap and deposit`,
+            data: {
+              chain: getEVMChainNameFromInternal(Number(sourceInternalId)),
+              amount: note.amount,
+              currency: currency.view.name,
+            },
           });
         }
         return;
       } else {
         const requiredApproval = await contract.isWebbTokenApprovalRequired();
         if (requiredApproval) {
-          notificationApi.addToQueue({
+          this.inner.notificationHandler({
+            description: 'Waiting for token approval',
+            persist: true,
+            level: 'info',
+            name: 'Transaction',
             message: 'Waiting for token approval',
-            variant: 'info',
             key: 'waiting-approval',
-            extras: { persist: true },
           });
           const tokenInstance = await contract.getWebbToken();
           const tx = await tokenInstance.approve(contract.inner.address, await contract.denomination);
           await tx.wait();
-          notificationApi.remove('waiting-approval');
+          this.inner.notificationHandler.remove('waiting-approval');
         }
 
         const enoughBalance = await contract.hasEnoughBalance();
         if (enoughBalance) {
           await contract.deposit(commitment);
-          transactionNotificationConfig.finalize?.({
-            address: '',
-            data: undefined,
+          this.inner.notificationHandler({
             key: 'bridge-deposit',
-            path: {
-              method: 'deposit',
-              section: currency.view.name,
+            level: 'success',
+            name: 'Transaction',
+            description: 'Depositing',
+            message: `${currency.view.name}:deposit`,
+            data: {
+              chain: getEVMChainNameFromInternal(Number(sourceInternalId)),
+              amount: note.amount,
+              currency: currency.view.name,
             },
           });
         } else {
-          notificationApi.addToQueue({
-            message: 'Not enough token balance',
-            variant: 'error',
-            key: 'waiting-approval',
+          this.inner.notificationHandler({
+            key: 'bridge-deposit',
+            level: 'error',
+            name: 'Transaction',
+            description: 'Not enough token balance',
+            message: `${currency.view.name}deposit`,
+            data: {
+              chain: getEVMChainNameFromInternal(Number(sourceInternalId)),
+              amount: note.amount,
+              currency: currency.view.name,
+            },
           });
         }
       }
     } catch (e: any) {
       console.log(e);
       if ((e as any)?.code == 4001) {
-        notificationApi.remove('waiting-approval');
-        transactionNotificationConfig.failed?.({
-          address: '',
-          data: 'User Rejected Deposit',
+        this.inner.notificationHandler.remove('waiting-approval');
+        this.inner.notificationHandler({
           key: 'bridge-deposit',
-
-          path: {
-            method: 'deposit',
-            section: currency.view.name,
-          },
+          level: 'error',
+          name: 'Transaction',
+          description: 'user rejected deposit',
+          message: `${currency.view.name}:deposit`,
         });
       } else {
-        notificationApi.remove('waiting-approval');
-        transactionNotificationConfig.failed?.({
-          address: '',
-          data: 'Deposit Transaction Failed',
+        this.inner.notificationHandler.remove('waiting-approval');
+        this.inner.notificationHandler({
           key: 'bridge-deposit',
-
-          path: {
-            method: 'deposit',
-            section: currency.view.name,
-          },
+          level: 'error',
+          name: 'Transaction',
+          description: 'Deposit Transaction Failed',
+          message: `${currency.view.name}:deposit`,
         });
       }
     }
@@ -232,6 +264,7 @@ export class Web3BridgeDeposit extends BridgeDeposit<WebbWeb3Provider, DepositPa
    * @param wrappableAssetAddress - the address of the token to wrap into the bridge
    * @returns
    */
+
   /*
    *
    *  Mixer id => the fixed deposit amount

--- a/packages/react-environment/src/api-providers/web3/web3-bridge-deposit.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-bridge-deposit.ts
@@ -14,11 +14,8 @@ import { createAnchor2Deposit, Deposit } from '@webb-dapp/contracts/utils/make-d
 import { DepositPayload as IDepositPayload, MixerSize } from '@webb-dapp/react-environment';
 import { WebbWeb3Provider } from '@webb-dapp/react-environment/api-providers/web3/webb-web3-provider';
 import { Currency } from '@webb-dapp/react-environment/webb-context/currency/currency';
-import { DepositNotification } from '@webb-dapp/ui-components/notification/DepositNotification';
-import { transactionNotificationConfig } from '@webb-dapp/wallet/providers/polkadot/transaction-notification-config';
 import { LoggerService } from '@webb-tools/app-util';
 import { Note, NoteGenInput } from '@webb-tools/sdk-core';
-import React from 'react';
 
 import { BridgeDeposit } from '../../webb-context/bridge/bridge-deposit';
 
@@ -47,19 +44,7 @@ export class Web3BridgeDeposit extends BridgeDeposit<WebbWeb3Provider, DepositPa
       const sourceEvmId = await this.inner.getChainId();
       const sourceChainId = computeChainIdType(ChainType.EVM, sourceEvmId);
       const sourceInternalId = evmIdIntoInternalChainId(sourceEvmId);
-      transactionNotificationConfig.loading?.({
-        address: '',
-        data: React.createElement(DepositNotification, {
-          chain: getEVMChainNameFromInternal(Number(sourceInternalId)),
-          amount: Number(note.amount),
-          currency: currency.view.name,
-        }),
-        key: 'bridge-deposit',
-        path: {
-          method: depositPayload.params[2] ? 'wrap and deposit' : 'deposit',
-          section: currency.view.name,
-        },
-      });
+
       this.inner.notificationHandler({
         key: 'bridge-deposit',
         level: 'loading',

--- a/packages/react-environment/src/api-providers/web3/web3-bridge-deposit.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-bridge-deposit.ts
@@ -94,7 +94,7 @@ export class Web3BridgeDeposit extends BridgeDeposit<WebbWeb3Provider, DepositPa
             description: 'Waiting for token approval',
             persist: true,
             level: 'info',
-            name: 'Transaction',
+            name: 'Approval',
             message: 'Waiting for token approval',
             key: 'waiting-approval',
           });
@@ -146,7 +146,7 @@ export class Web3BridgeDeposit extends BridgeDeposit<WebbWeb3Provider, DepositPa
             description: 'Waiting for token approval',
             persist: true,
             level: 'info',
-            name: 'Transaction',
+            name: 'Approval',
             message: 'Waiting for token approval',
             key: 'waiting-approval',
           });

--- a/packages/react-environment/src/api-providers/web3/web3-mixer-deposit.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-mixer-deposit.ts
@@ -23,54 +23,45 @@ export class Web3MixerDeposit extends MixerDeposit<WebbWeb3Provider, DepositPayl
   async deposit({ note: depositPayload, params }: DepositPayload): Promise<void> {
     const chainId = Number(depositPayload.note.targetChainId);
     const evmChainId = parseChainIdType(chainId).chainId;
-    transactionNotificationConfig.loading?.({
-      address: '',
-      data: React.createElement(DepositNotification, {
+    this.inner.notificationHandler({
+      name: 'Transaction',
+      key: 'web3-mixer-deposit',
+      level: 'loading',
+      description: 'Depositing',
+      data: {
         chain: getEVMChainName(evmChainId),
-        amount: Number(depositPayload.note.amount),
+        amount: String(Number(depositPayload.note.amount)),
         currency: depositPayload.note.tokenSymbol,
-      }),
-      key: 'mixer-deposit-evm',
-      path: {
-        method: 'deposit',
-        section: 'evm-mixer',
       },
+      message: 'mixer:deposit',
     });
     const [deposit, amount] = params;
     const contract = await this.inner.getContractBySize(amount, getNativeCurrencySymbol(await this.inner.getChainId()));
     try {
       await contract.deposit(deposit.commitment);
-
-      transactionNotificationConfig.finalize?.({
-        address: '',
-        data: undefined,
-        key: `mixer-deposit-evm`,
-        path: {
-          method: 'deposit',
-          section: 'evm-mixer',
-        },
+      this.inner.notificationHandler({
+        name: 'Transaction',
+        key: 'web3-mixer-deposit',
+        level: 'success',
+        description: 'Deposit succeed',
+        message: 'mixer:deposit',
       });
     } catch (e) {
-      console.log(e);
       if ((e as any)?.code == 4001) {
-        transactionNotificationConfig.failed?.({
-          address: '',
-          data: 'User Rejected Deposit',
-          key: `mixer-deposit-evm`,
-          path: {
-            method: 'deposit',
-            section: 'evm-mixer',
-          },
+        this.inner.notificationHandler({
+          name: 'Transaction',
+          key: 'web3-mixer-deposit',
+          level: 'error',
+          description: 'User Rejected Deposit',
+          message: 'mixer:deposit',
         });
       } else {
-        transactionNotificationConfig.failed?.({
-          address: '',
-          data: 'Deposit Transaction Failed',
-          key: `mixer-deposit-evm`,
-          path: {
-            method: 'deposit',
-            section: 'evm-mixer',
-          },
+        this.inner.notificationHandler({
+          name: 'Transaction',
+          key: 'web3-mixer-deposit',
+          level: 'error',
+          description: 'Deposit Failed',
+          message: 'mixer:deposit',
         });
       }
     }

--- a/packages/react-environment/src/api-providers/web3/web3-mixer-deposit.ts
+++ b/packages/react-environment/src/api-providers/web3/web3-mixer-deposit.ts
@@ -7,10 +7,7 @@ import {
 } from '@webb-dapp/apps/configs';
 import { createTornDeposit, Deposit } from '@webb-dapp/contracts/utils/make-deposit';
 import { DepositPayload as IDepositPayload, MixerDeposit, MixerSize } from '@webb-dapp/react-environment/webb-context';
-import { DepositNotification } from '@webb-dapp/ui-components/notification/DepositNotification';
-import { transactionNotificationConfig } from '@webb-dapp/wallet/providers/polkadot/transaction-notification-config';
 import { Note, NoteGenInput } from '@webb-tools/sdk-core';
-import React from 'react';
 import utils from 'web3-utils';
 
 import { u8aToHex } from '@polkadot/util';

--- a/packages/react-environment/src/api-providers/web3/webb-web3-provider.ts
+++ b/packages/react-environment/src/api-providers/web3/webb-web3-provider.ts
@@ -3,7 +3,7 @@ import { TornadoContract } from '@webb-dapp/contracts/contracts/tornado-anchor';
 import { AnchorContract } from '@webb-dapp/contracts/contracts/webb-anchor';
 import {
   AppConfig,
-  ProviderNotification,
+  NotificationHandler,
   WebbApiProvider,
   WebbMethods,
   WebbProviderEvents,
@@ -39,7 +39,7 @@ export class WebbWeb3Provider
     private chainId: number,
     readonly relayingManager: WebbRelayerBuilder,
     readonly config: AppConfig,
-    readonly notificationHandler: ProviderNotification
+    readonly notificationHandler: NotificationHandler
   ) {
     super();
     this.accounts = new Web3Accounts(web3Provider.eth);
@@ -177,7 +177,7 @@ export class WebbWeb3Provider
     chainId: number,
     relayerBuilder: WebbRelayerBuilder,
     appConfig: AppConfig,
-    notification: ProviderNotification
+    notification: NotificationHandler
   ) {
     return new WebbWeb3Provider(web3Provider, chainId, relayerBuilder, appConfig, notification);
   }

--- a/packages/react-environment/src/api-providers/web3/webb-web3-provider.ts
+++ b/packages/react-environment/src/api-providers/web3/webb-web3-provider.ts
@@ -39,7 +39,7 @@ export class WebbWeb3Provider
     private chainId: number,
     readonly relayingManager: WebbRelayerBuilder,
     readonly config: AppConfig,
-    readonly notification: ProviderNotification
+    readonly notificationHandler: ProviderNotification
   ) {
     super();
     this.accounts = new Web3Accounts(web3Provider.eth);

--- a/packages/react-environment/src/api-providers/web3/webb-web3-provider.ts
+++ b/packages/react-environment/src/api-providers/web3/webb-web3-provider.ts
@@ -1,7 +1,13 @@
 import { EVMChainId, evmIdIntoInternalChainId, parseChainIdType } from '@webb-dapp/apps/configs';
 import { TornadoContract } from '@webb-dapp/contracts/contracts/tornado-anchor';
 import { AnchorContract } from '@webb-dapp/contracts/contracts/webb-anchor';
-import { AppConfig, WebbApiProvider, WebbMethods, WebbProviderEvents } from '@webb-dapp/react-environment';
+import {
+  AppConfig,
+  ProviderNotification,
+  WebbApiProvider,
+  WebbMethods,
+  WebbProviderEvents,
+} from '@webb-dapp/react-environment';
 import { Web3WrapUnwrap } from '@webb-dapp/react-environment/api-providers';
 import { EvmChainMixersInfo } from '@webb-dapp/react-environment/api-providers/web3/EvmChainMixersInfo';
 import { Web3BridgeApi } from '@webb-dapp/react-environment/api-providers/web3/web3-bridge-api';
@@ -32,7 +38,8 @@ export class WebbWeb3Provider
     private web3Provider: Web3Provider,
     private chainId: number,
     readonly relayingManager: WebbRelayerBuilder,
-    readonly config: AppConfig
+    readonly config: AppConfig,
+    readonly notification: ProviderNotification
   ) {
     super();
     this.accounts = new Web3Accounts(web3Provider.eth);
@@ -169,9 +176,10 @@ export class WebbWeb3Provider
     web3Provider: Web3Provider,
     chainId: number,
     relayerBuilder: WebbRelayerBuilder,
-    appConfig: AppConfig
+    appConfig: AppConfig,
+    notification: ProviderNotification
   ) {
-    return new WebbWeb3Provider(web3Provider, chainId, relayerBuilder, appConfig);
+    return new WebbWeb3Provider(web3Provider, chainId, relayerBuilder, appConfig, notification);
   }
 
   get capabilities() {

--- a/packages/react-environment/src/webb-context/webb-provider.interface.ts
+++ b/packages/react-environment/src/webb-context/webb-provider.interface.ts
@@ -122,7 +122,7 @@ export type NotificationPayload = {
   description: string;
   // Event name/ event identifier
   name: 'Transaction' | 'Approval';
-  // key for a given notification
+  // key for a given notification can be used to remove/dismiss a notification
   key: string;
   //level
   level: NotificationLevel;
@@ -131,6 +131,7 @@ export type NotificationPayload = {
   // if true the notification will be dismissed by the user or with another action
   persist?: boolean;
 };
+// Function call to register a notification
 export type NotificationHandler = ((notification: NotificationPayload) => string | number) & {
   // remove the notification programmatically
   remove(key: string | number): void;

--- a/packages/react-environment/src/webb-context/webb-provider.interface.ts
+++ b/packages/react-environment/src/webb-context/webb-provider.interface.ts
@@ -131,7 +131,10 @@ export type NotificationPayload = {
   // if true the notification will be dismissed by the user or with another action
   persist?: boolean;
 };
-export type NotificationHandler = (notification: NotificationPayload) => void;
+export type NotificationHandler = ((notification: NotificationPayload) => string | number) & {
+  // remove the notification programmatically
+  remove(key: string | number): void;
+};
 export interface WebbApiProvider<T> extends EventBus<WebbProviderEvents> {
   /// Accounts Adapter will have all methods related to the provider accounts
   accounts: AccountsAdapter<any>;

--- a/packages/react-environment/src/webb-context/webb-provider.interface.ts
+++ b/packages/react-environment/src/webb-context/webb-provider.interface.ts
@@ -121,7 +121,7 @@ export type NotificationPayload = {
   // details about the notification
   description: string;
   // Event name/ event identifier
-  name: 'Transaction';
+  name: 'Transaction' | 'Approval';
   // key for a given notification
   key: string;
   //level

--- a/packages/react-environment/src/webb-context/webb-provider.interface.ts
+++ b/packages/react-environment/src/webb-context/webb-provider.interface.ts
@@ -113,7 +113,23 @@ export type TXNotification = {
   // Transaction Done with success
   finalize(payload: TXNotificationPayload<any>): NotificationKey;
 };
-export type ProviderNotification = NotificationApi & TXNotification;
+export type NotificationLevel = 'loading' | 'error' | 'success' | 'warning' | 'info';
+
+export type NotificationPayload = {
+  // Title of the notification
+  message: string;
+  // details about the notification
+  description: string;
+  // Event name/ event identifier
+  name: 'Transaction';
+  // key for a given notification
+  key: string;
+  //level
+  level: NotificationLevel;
+  // if true the notification will be dismissed by the user or with another action
+  persist: boolean;
+};
+export type ProviderNotification = (notification: NotificationPayload) => void;
 export interface WebbApiProvider<T> extends EventBus<WebbProviderEvents> {
   /// Accounts Adapter will have all methods related to the provider accounts
   accounts: AccountsAdapter<any>;
@@ -133,6 +149,6 @@ export interface WebbApiProvider<T> extends EventBus<WebbProviderEvents> {
   getProvider(): any;
   // Configs
   config: AppConfig;
-  // Notification
-  notification: ProviderNotification;
+  // Notification handler
+  notificationHandler: ProviderNotification;
 }

--- a/packages/react-environment/src/webb-context/webb-provider.interface.ts
+++ b/packages/react-environment/src/webb-context/webb-provider.interface.ts
@@ -129,7 +129,7 @@ export type NotificationPayload = {
   // if true the notification will be dismissed by the user or with another action
   persist: boolean;
 };
-export type ProviderNotification = (notification: NotificationPayload) => void;
+export type NotificationHandler = (notification: NotificationPayload) => void;
 export interface WebbApiProvider<T> extends EventBus<WebbProviderEvents> {
   /// Accounts Adapter will have all methods related to the provider accounts
   accounts: AccountsAdapter<any>;
@@ -150,5 +150,5 @@ export interface WebbApiProvider<T> extends EventBus<WebbProviderEvents> {
   // Configs
   config: AppConfig;
   // Notification handler
-  notificationHandler: ProviderNotification;
+  notificationHandler: NotificationHandler;
 }

--- a/packages/react-environment/src/webb-context/webb-provider.interface.ts
+++ b/packages/react-environment/src/webb-context/webb-provider.interface.ts
@@ -126,8 +126,10 @@ export type NotificationPayload = {
   key: string;
   //level
   level: NotificationLevel;
+  // Record for more metadata
+  data?: Record<string, string>;
   // if true the notification will be dismissed by the user or with another action
-  persist: boolean;
+  persist?: boolean;
 };
 export type NotificationHandler = (notification: NotificationPayload) => void;
 export interface WebbApiProvider<T> extends EventBus<WebbProviderEvents> {

--- a/packages/react-environment/src/webb-context/webb-provider.interface.ts
+++ b/packages/react-environment/src/webb-context/webb-provider.interface.ts
@@ -75,8 +75,16 @@ export type ProvideCapabilities = {
 type WebApiCalls = {
   addToken(input: any): Promise<void>;
 };
-type NotificationKey = string | number;
-type NotificationData = {};
+export type NotificationKey = string | number;
+export type VariantType = 'default' | 'error' | 'success' | 'warning' | 'info';
+
+export type NotificationData = {
+  persist: boolean;
+  message: string;
+  description: string;
+  variant: VariantType;
+  action: string;
+};
 
 export type NotificationApi = {
   addToQueue(data: NotificationData): NotificationKey;
@@ -87,7 +95,7 @@ type MethodPath = {
   method: string;
 };
 
-type TXNotificationPayload<T = undefined> = {
+export type TXNotificationPayload<T = undefined> = {
   // Generic data for the transaction payload
   data: T;
   // notification key
@@ -96,7 +104,7 @@ type TXNotificationPayload<T = undefined> = {
   // More metadata for the transaction path (EX Anchor::Deposit ,VAnchor::Withdraw)
   path: MethodPath;
 };
-
+// Transaction notification
 export type TXNotification = {
   // Transaction status is in progress
   loading(payload: TXNotificationPayload<any>): NotificationKey;
@@ -105,7 +113,7 @@ export type TXNotification = {
   // Transaction Done with success
   finalize(payload: TXNotificationPayload<any>): NotificationKey;
 };
-
+export type ProviderNotification = NotificationApi & TXNotification;
 export interface WebbApiProvider<T> extends EventBus<WebbProviderEvents> {
   /// Accounts Adapter will have all methods related to the provider accounts
   accounts: AccountsAdapter<any>;
@@ -126,5 +134,5 @@ export interface WebbApiProvider<T> extends EventBus<WebbProviderEvents> {
   // Configs
   config: AppConfig;
   // Notification
-  notification: NotificationApi & TXNotification;
+  notification: ProviderNotification;
 }

--- a/packages/react-environment/src/webb-context/webb-provider.interface.ts
+++ b/packages/react-environment/src/webb-context/webb-provider.interface.ts
@@ -75,6 +75,36 @@ export type ProvideCapabilities = {
 type WebApiCalls = {
   addToken(input: any): Promise<void>;
 };
+type NotificationKey = string | number;
+type NotificationData = {};
+
+export type NotificationApi = {
+  addToQueue(data: NotificationData): NotificationKey;
+  remove(key: NotificationKey): void;
+};
+type MethodPath = {
+  section: string;
+  method: string;
+};
+
+type TXNotificationPayload<T = undefined> = {
+  // Generic data for the transaction payload
+  data: T;
+  // notification key
+  key: NotificationKey;
+  address: string;
+  // More metadata for the transaction path (EX Anchor::Deposit ,VAnchor::Withdraw)
+  path: MethodPath;
+};
+
+export type TXNotification = {
+  // Transaction status is in progress
+  loading(payload: TXNotificationPayload<any>): NotificationKey;
+  // Transaction failed
+  failed(payload: TXNotificationPayload<any>): NotificationKey;
+  // Transaction Done with success
+  finalize(payload: TXNotificationPayload<any>): NotificationKey;
+};
 
 export interface WebbApiProvider<T> extends EventBus<WebbProviderEvents> {
   /// Accounts Adapter will have all methods related to the provider accounts
@@ -95,4 +125,6 @@ export interface WebbApiProvider<T> extends EventBus<WebbProviderEvents> {
   getProvider(): any;
   // Configs
   config: AppConfig;
+  // Notification
+  notification: NotificationApi & TXNotification;
 }

--- a/packages/wallet/src/providers/polkadot/polkadot-provider.ts
+++ b/packages/wallet/src/providers/polkadot/polkadot-provider.ts
@@ -2,7 +2,6 @@ import { ApiInitHandler } from '@webb-dapp/react-environment';
 import { PolkaTXBuilder } from '@webb-dapp/react-environment/api-providers/polkadot';
 import { InteractiveFeedback, WebbError, WebbErrorCodes } from '@webb-dapp/utils/webb-error';
 import { PolkadotAccount, PolkadotAccounts } from '@webb-dapp/wallet/providers/polkadot/polkadot-accounts';
-import { transactionNotificationConfig } from '@webb-dapp/wallet/providers/polkadot/transaction-notification-config';
 import { optionsWithEdgeware as options } from '@webb-tools/api';
 import { EventBus, LoggerService } from '@webb-tools/app-util';
 import { isNumber } from 'lodash';
@@ -25,11 +24,13 @@ const logger = LoggerService.get('Polkadot-Provider');
 
 export class PolkadotProvider extends EventBus<ExtensionProviderEvents> {
   private _accounts: PolkadotAccounts;
-  public txBuilder: PolkaTXBuilder;
 
-  constructor(protected apiPromise: ApiPromise, protected injectedExtension: InjectedExtension) {
+  constructor(
+    protected apiPromise: ApiPromise,
+    protected injectedExtension: InjectedExtension,
+    readonly txBuilder: PolkaTXBuilder
+  ) {
     super();
-    this.txBuilder = new PolkaTXBuilder(this.apiPromise, transactionNotificationConfig);
     this.hookListeners();
     this._accounts = new PolkadotAccounts(this.injectedExtension);
   }
@@ -37,14 +38,15 @@ export class PolkadotProvider extends EventBus<ExtensionProviderEvents> {
   static async fromExtension(
     appName: string,
     [endPoint, ...allEndPoints]: string[],
-    apiInitHandler: ApiInitHandler
+    apiInitHandler: ApiInitHandler,
+    txBuilder: PolkaTXBuilder
   ): Promise<PolkadotProvider> {
     const [apiPromise, currentExtensions] = await PolkadotProvider.getParams(
       appName,
       [endPoint, ...allEndPoints],
       apiInitHandler.onError
     );
-    return new PolkadotProvider(apiPromise, currentExtensions);
+    return new PolkadotProvider(apiPromise, currentExtensions, txBuilder);
   }
 
   static async getParams(

--- a/packages/wallet/src/providers/polkadot/transaction-notification-config.tsx
+++ b/packages/wallet/src/providers/polkadot/transaction-notification-config.tsx
@@ -30,7 +30,7 @@ export const transactionNotificationConfig: NotificationConfig = {
     });
   },
   finalize(data) {
-    return notificationApi({
+    const notificationId = notificationApi({
       extras: {
         persist: false,
       },
@@ -39,5 +39,6 @@ export const transactionNotificationConfig: NotificationConfig = {
       variant: 'success',
     });
     setTimeout(() => notificationApi.remove(data.key), 6000);
+    return notificationId;
   },
 };

--- a/packages/wallet/src/providers/polkadot/transaction-notification-config.tsx
+++ b/packages/wallet/src/providers/polkadot/transaction-notification-config.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 export const transactionNotificationConfig: NotificationConfig = {
   failed(data) {
-    notificationApi({
+    return notificationApi({
       extras: {
         persist: false,
       },
@@ -16,7 +16,7 @@ export const transactionNotificationConfig: NotificationConfig = {
     });
   },
   loading(data) {
-    notificationApi({
+    return notificationApi({
       extras: {
         persist: true,
       },
@@ -30,7 +30,7 @@ export const transactionNotificationConfig: NotificationConfig = {
     });
   },
   finalize(data) {
-    notificationApi({
+    return notificationApi({
       extras: {
         persist: false,
       },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
`NotificaitonApi` and `TransactionConfig` are used across the providers
Issue Number: Closes #331 


## What is the new behavior?

```
// Function call to register a notification
export type NotificationHandler = ((notification: NotificationPayload) => string | number) & {
  // remove the notification programmatically
  remove(key: string | number): void;
}
```

Added this interface to the provider will make it easer to control the behavior of ht notification

## Does this PR introduce a breaking change?
- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
