### PR TITLE
Fix sync the display account with metamask account

### DIFF
--- a/packages/api-providers/src/web3/webb-provider.ts
+++ b/packages/api-providers/src/web3/webb-provider.ts
@@ -110,6 +110,16 @@ export class WebbWeb3Provider
     this.ethersProvider.provider?.on?.('chainChanged', handler);
   }
 
+  async setAccountListener() {
+    const handler = async () => {
+      this.emit('newAccounts', this.accounts);
+    };
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    this.ethersProvider.provider?.on?.('accountsChanged', handler);
+  }
+
   async destroy(): Promise<void> {
     await this.endSession();
     this.subscriptions = {

--- a/packages/mixer/src/components/DepositConfirm/DepositConfirm.tsx
+++ b/packages/mixer/src/components/DepositConfirm/DepositConfirm.tsx
@@ -235,9 +235,9 @@ export const DepositConfirm: React.FC<DepositInfoProps> = ({ mixerSize, onClose,
             }
             setLoading(true);
             downloadNote();
-            onClose();
             await provider.deposit(depositPayload);
             setLoading(false);
+            onClose();
           }}
           disabled={!backupConfirmation || !depositPayload || loading}
           label={'Deposit'}

--- a/packages/react-environment/src/WebbProvider.tsx
+++ b/packages/react-environment/src/WebbProvider.tsx
@@ -461,6 +461,7 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
             webbWeb3Provider.on('providerUpdate', providerUpdateHandler);
 
             webbWeb3Provider.setChainListener();
+            webbWeb3Provider.setAccountListener();
             const cantAddChain = !chain.chainId && !chain.evmRpcUrls;
             const addEvmChain = async () => {
               if (cantAddChain) {

--- a/packages/react-environment/src/WebbProvider.tsx
+++ b/packages/react-environment/src/WebbProvider.tsx
@@ -188,26 +188,37 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
   /// callback for setting active account
   /// it will store on the provider and the storage of the network
   const setActiveAccount = useCallback(
-    async (account: Account<any>) => {
-      if (networkStorage && activeChain) {
-        const networksConfig = await networkStorage.get('networksConfig');
-        networkStorage?.set('networksConfig', {
+    async (
+      account: Account<any>,
+      options: {
+        networkStorage?: NetworkStorage | undefined | null;
+        chain?: Chain | undefined;
+        activeApi?: WebbApiProvider<any> | undefined;
+      } = {}
+    ) => {
+      const innerNetworkStorage = options.networkStorage ?? networkStorage;
+      const innerChain = options.chain ?? activeChain;
+      const innerActiveApi = options.activeApi ?? activeApi;
+
+      if (innerNetworkStorage && innerChain) {
+        const networksConfig = await innerNetworkStorage.get('networksConfig');
+        innerNetworkStorage?.set('networksConfig', {
           ...networksConfig,
-          [activeChain.id]: {
-            ...networksConfig[activeChain.id],
+          [innerChain.id]: {
+            ...networksConfig[innerChain.id],
             defaultAccount: account.address,
           },
         });
       }
 
-      if (!activeApi) {
+      if (!innerActiveApi) {
         return;
       }
       _setActiveAccount(account);
       // TODO resolve the account inner type issue
-      await activeApi.accounts.setActiveAccount(account as any);
+      await innerActiveApi.accounts.setActiveAccount(account as any);
     },
-    [activeApi, networkStorage, activeChain]
+    [activeApi, activeChain, networkStorage]
   );
 
   /// Forcefully tell react to rerender the application with api change
@@ -223,26 +234,32 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
   /// this will set the active api and the accounts
   const setActiveApiWithAccounts = async (
     nextActiveApi: WebbApiProvider<any> | undefined,
-    chainId: number
+    chain: Chain,
+    _networkStorage?: NetworkStorage | null
   ): Promise<void> => {
     if (nextActiveApi) {
+      let hasSetFromStorage = false;
       const accounts = await nextActiveApi.accounts.accounts();
       // TODO resolve the account inner type issue
       setAccounts(accounts as any);
 
-      if (networkStorage) {
-        const networkDefaultConfig = await networkStorage.get('networksConfig');
-        let defaultAccount = networkDefaultConfig?.[chainId]?.defaultAccount;
+      if (_networkStorage) {
+        const networkDefaultConfig = await _networkStorage.get('networksConfig');
+        let defaultAccount = networkDefaultConfig?.[chain.id]?.defaultAccount;
         defaultAccount = defaultAccount ?? accounts[0]?.address;
         const defaultFromSettings = accounts.find((account) => account.address === defaultAccount);
         if (defaultFromSettings) {
           // TODO resolve the account inner type issue
           _setActiveAccount(defaultFromSettings as any);
           await nextActiveApi.accounts.setActiveAccount(defaultFromSettings);
+          hasSetFromStorage = true;
         }
-      } else {
-        // await setActiveAccount(accounts[0]);
       }
+
+      if (!hasSetFromStorage) {
+        await setActiveAccount(accounts[0], { networkStorage: _networkStorage, chain, activeApi: nextActiveApi });
+      }
+
       setActiveApi(nextActiveApi);
       nextActiveApi?.on('newAccounts', async (accounts) => {
         const acs = await accounts.accounts();
@@ -269,6 +286,7 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
       _setActiveAccount(null);
     }
   };
+
   /// Error handler for the `WebbError`
   const catchWebbError = (e: WebbError) => {
     const errorMessage = e.errorMessage;
@@ -310,8 +328,9 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
         alert(code);
     }
   };
+
   /// Network switcher
-  const switchChain = async (chain: Chain, _wallet: Wallet) => {
+  const switchChain = async (chain: Chain, _wallet: Wallet, _networkStorage?: NetworkStorage | undefined) => {
     const relayerManagerFactory = await getRelayerManagerFactory(appConfig);
 
     const wallet = _wallet || activeWallet;
@@ -342,7 +361,7 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
               notificationHandler,
               () => new Worker(new URL('./proving-manager.worker', import.meta.url))
             );
-            await setActiveApiWithAccounts(webbPolkadot, chain.id);
+            await setActiveApiWithAccounts(webbPolkadot, chain, _networkStorage ?? networkStorage);
             localActiveApi = webbPolkadot;
             setLoading(false);
           }
@@ -494,7 +513,7 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
               await addEvmChain();
             }
 
-            await setActiveApiWithAccounts(webbWeb3Provider, chain.id);
+            await setActiveApiWithAccounts(webbWeb3Provider, chain, _networkStorage ?? networkStorage);
             /// listen to `providerUpdate` by MetaMask
             localActiveApi = webbWeb3Provider;
 
@@ -518,6 +537,7 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
       return null;
     }
   };
+
   /// a util will store the network/wallet config before switching
   const switchChainAndStore = async (chain: Chain, wallet: Wallet) => {
     const provider = await switchChain(chain, wallet);
@@ -534,12 +554,12 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
     /// init the dApp
     const init = async () => {
       setIsConnecting(true);
-      const networkStorage = await netStorageFactory();
-      setNetworkStorage(networkStorage);
+      const _networkStorage = await netStorageFactory();
+      setNetworkStorage(_networkStorage);
       /// get the default wallet and network from storage
       const [net, wallet] = await Promise.all([
-        networkStorage.get('defaultNetwork'),
-        networkStorage.get('defaultWallet'),
+        _networkStorage.get('defaultNetwork'),
+        _networkStorage.get('defaultWallet'),
       ]);
       /// if there's no chain, return
       if (!net || !wallet) {
@@ -549,8 +569,8 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
       const chainConfig = chains[net];
       // wallet config by chain
       const walletConfig = chainConfig.wallets[wallet] || Object.values(chainConfig)[0];
-      const activeApi = await switchChain(chainConfig, walletConfig);
-      const networkDefaultConfig = await networkStorage.get('networksConfig');
+      const activeApi = await switchChain(chainConfig, walletConfig, _networkStorage);
+      const networkDefaultConfig = await _networkStorage.get('networksConfig');
 
       if (activeApi) {
         const accounts = await activeApi.accounts.accounts();
@@ -561,7 +581,7 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
         if (defaultFromSettings) {
           _setActiveAccount(defaultFromSettings);
           await activeApi.accounts.setActiveAccount(defaultFromSettings);
-          networkStorage?.set('networksConfig', {
+          _networkStorage?.set('networksConfig', {
             ...networkDefaultConfig,
             [chainConfig.id]: {
               ...chainConfig,
@@ -590,6 +610,7 @@ export const WebbProvider: FC<WebbProviderProps> = ({ applicationName = 'Webb Da
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
   return (
     <WebbContext.Provider
       value={{

--- a/packages/react-hooks/src/currency/useNativeCurrencyBalance.tsx
+++ b/packages/react-hooks/src/currency/useNativeCurrencyBalance.tsx
@@ -2,7 +2,7 @@ import { useWebContext } from '@webb-dapp/react-environment/webb-context';
 import { useEffect, useState } from 'react';
 
 export const useNativeCurrencyBalance = () => {
-  const { activeApi, activeChain } = useWebContext();
+  const { activeAccount, activeApi, activeChain } = useWebContext();
 
   const [balance, setBalance] = useState('');
 
@@ -22,7 +22,7 @@ export const useNativeCurrencyBalance = () => {
     return () => {
       isSubscribed = false;
     };
-  }, [activeChain, activeApi, activeApi?.accounts.activeOrDefault]);
+  }, [activeChain, activeApi, activeAccount, activeApi?.accounts.activeOrDefault]);
 
   return balance;
 };


### PR DESCRIPTION
- fix: change the order of function call for removing warning
- fix: not display address when changing account then make a hard refresh
- fix: sync display account with Metamask account when changing account using metamask

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Account did not display when you switch to another account and made a hard refresh on the Dapp (on the first render).
- The displayed account on the Dapp won't update properly when switching between different accounts using Metamask wallet.

Issue Number: Closes #409 


## What is the new behavior?

- Display the account correctly when you switch to another account and make a hard refresh.
- Added a missing event listener for `accountsChange` event to sync with Metamask account.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I added a video demo for the new behavior below. Also, say thanks to @nepoche for his suggestions 😇.