### PR TITLE
Fix substrate native token not showing

### DIFF
--- a/packages/api-providers/src/polkadot/anchor-api.ts
+++ b/packages/api-providers/src/polkadot/anchor-api.ts
@@ -21,7 +21,7 @@ export class PolkadotAnchorApi extends AnchorApi<WebbPolkadot, BridgeConfig> {
 
   async getCurrencies(): Promise<Currency[]> {
     const bridgeCurrenciesConfig = Object.values(this.inner.config.currencies).filter((i: CurrencyConfig) => {
-      const isValid = i.type === CurrencyType.ORML && i.role === CurrencyRole.Governable;
+      const isValid = i.type === CurrencyType.NATIVE || i.role === CurrencyRole.Governable;
       const isSupported = Object.keys(this.store.config).includes(i.id.toString());
 
       return isValid && isSupported;

--- a/packages/api-providers/src/polkadot/anchor-api.ts
+++ b/packages/api-providers/src/polkadot/anchor-api.ts
@@ -5,7 +5,7 @@ import { AnchorApi, AnchorBase } from '../abstracts';
 import { TypedChainId } from '../chains';
 import { AnchorConfigEntry } from '../types';
 import { BridgeConfig } from '../types/bridge-config.interface';
-import { CurrencyConfig, CurrencyRole, CurrencyType } from '../types/currency-config.interface';
+import { CurrencyConfig, CurrencyType } from '../types/currency-config.interface';
 import { Currency } from '../';
 import { WebbPolkadot } from './webb-provider';
 
@@ -21,7 +21,8 @@ export class PolkadotAnchorApi extends AnchorApi<WebbPolkadot, BridgeConfig> {
 
   async getCurrencies(): Promise<Currency[]> {
     const bridgeCurrenciesConfig = Object.values(this.inner.config.currencies).filter((i: CurrencyConfig) => {
-      const isValid = i.type === CurrencyType.NATIVE || i.role === CurrencyRole.Governable;
+      // TODO: Add check if required to restrict the options to some type/role of tokens
+      const isValid = i.type === CurrencyType.NATIVE || i.type === CurrencyType.ORML;
       const isSupported = Object.keys(this.store.config).includes(i.id.toString());
 
       return isValid && isSupported;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Bridge tokens for the substrate side are filtered for `Governable` and `ORML`

Issue Number: Closes #459 


## What is the new behavior?
Substrate tokens are now filtered based on the support provided by the config and type being  `OMRL` or `NATIVE`.

![image](https://user-images.githubusercontent.com/35463181/182378864-ed0c3f5b-6d7b-42e1-8df6-5f2aff0aeca8.png)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
