### PR TITLE
Fix provider not working after cancel a transaction

### DIFF
--- a/packages/api-providers/src/abstracts/anchor/vanchor-deposit.ts
+++ b/packages/api-providers/src/abstracts/anchor/vanchor-deposit.ts
@@ -75,6 +75,7 @@ export abstract class VAnchorDeposit<
 
   cancel(): Promise<void> {
     this.cancelToken.cancel();
+    this.state = TransactionState.Cancelling;
     this.emit('stateChange', TransactionState.Cancelling);
 
     return Promise.resolve(undefined);

--- a/packages/react-components/src/Transact/TransactionProcessingModal.tsx
+++ b/packages/react-components/src/Transact/TransactionProcessingModal.tsx
@@ -2,7 +2,7 @@ import { Button, Checkbox, Typography } from '@mui/material';
 import { TransactionState } from '@webb-dapp/api-providers';
 import { SpaceBox } from '@webb-dapp/ui-components/Box';
 import { Spinner } from '@webb-dapp/ui-components/Spinner/Spinner';
-import React from 'react';
+import React, { useMemo } from 'react';
 import styled from 'styled-components';
 
 type TxFlow = 'Deposit' | 'Withdraw' | 'Transfer';
@@ -115,6 +115,10 @@ export const TransactionProcessingModal: React.FC<TransactionProcessingModalProp
   state,
   txFlow,
 }) => {
+  const isCancelled = useMemo(() => {
+    return state === TransactionState.Cancelling;
+  }, [state]);
+
   return (
     <TransactionProcessingWrapper>
       <header className={'modal-header'}>
@@ -122,7 +126,7 @@ export const TransactionProcessingModal: React.FC<TransactionProcessingModalProp
           {txFlow}
         </Typography>
         <Typography variant={'h6'} color={'textPrimary'}>
-          {state === TransactionState.Cancelling ? 'Transaction is Canceld' : 'Processing...'}
+          {isCancelled ? 'Transaction is Canceld' : 'Processing...'}
         </Typography>
       </header>
       <TransactionSteps>
@@ -167,11 +171,11 @@ export const TransactionProcessingModal: React.FC<TransactionProcessingModalProp
         </Button>
         <Button
           onClick={() => {
-            cancel();
+            isCancelled ? hide() : cancel();
           }}
           className={'cancel-button'}
         >
-          Cancel
+          {isCancelled ? 'Close' : 'Cancel'}
         </Button>
       </div>
     </TransactionProcessingWrapper>

--- a/packages/react-components/src/Transact/TransactionProcessingModal.tsx
+++ b/packages/react-components/src/Transact/TransactionProcessingModal.tsx
@@ -126,7 +126,7 @@ export const TransactionProcessingModal: React.FC<TransactionProcessingModalProp
           {txFlow}
         </Typography>
         <Typography variant={'h6'} color={'textPrimary'}>
-          {isCancelled ? 'Transaction is Canceld' : 'Processing...'}
+          {isCancelled ? 'Transaction Cancelled' : 'Processing...'}
         </Typography>
       </header>
       <TransactionSteps>

--- a/packages/vbridge/src/components/Deposit/Deposit.tsx
+++ b/packages/vbridge/src/components/Deposit/Deposit.tsx
@@ -112,7 +112,7 @@ export const Deposit: React.FC<DepositProps> = () => {
 
   useEffect(() => {
     // If the stage is in a terminal transaction state, and the modal is hidden, reset to ideal.
-    if (stage > TransactionState.SendingTransaction && hideTxModal) {
+    if ((stage > TransactionState.SendingTransaction || stage === TransactionState.Cancelling) && hideTxModal) {
       setStage(TransactionState.Ideal);
       setHideTxModal(false);
     }


### PR DESCRIPTION
- fix: add missing set state in `cancel` function
- refactor: handle error when user cancel tx
- chore: improve the ui when user cancel tx
- fix: add missing terminal state to reset the state to ideal

## Summary of changes
- Fix the error after canceling a transaction the dApp would not be used
- Improve the UI when canceling a transaction


### Reference issue to close (if applicable)
- Closes https://github.com/webb-tools/webb-dapp/issues/484

-----
### Code Checklist 

- [x] Tested
- [ ] Documented

### Demo


https://user-images.githubusercontent.com/60747384/186150943-5d9c930a-4da3-4a29-9e29-24463140f30f.mp4


