### PR TITLE
New Button Component

### DIFF
--- a/packages/apps/webpack.base.js
+++ b/packages/apps/webpack.base.js
@@ -8,6 +8,7 @@ const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const webpack = require('webpack');
+const polkadotBabelWebpackConfig = require('@polkadot/dev/config/babel-config-webpack.cjs');
 
 const findPackages = require('../../scripts/findPackages');
 
@@ -111,7 +112,13 @@ function createWebpack(env, mode = 'production') {
             require.resolve('thread-loader'),
             {
               loader: require.resolve('babel-loader'),
-              options: require('@polkadot/dev/config/babel-config-webpack.cjs'),
+              options: {
+                ...polkadotBabelWebpackConfig,
+                plugins: [
+                  ...(polkadotBabelWebpackConfig.plugins ?? []),
+                  isDevelopment && require.resolve('react-refresh/babel'),
+                ].filter(Boolean),
+              },
             },
           ],
         },

--- a/packages/webb-ui-components/src/components/Avatar/types.d.ts
+++ b/packages/webb-ui-components/src/components/Avatar/types.d.ts
@@ -1,15 +1,13 @@
+import { WebbComponentBase } from '@webb-dapp/webb-ui-components/types';
+
 /**
  * Props for `Avatar` component
  */
-export interface AvatarProps {
+export interface AvatarProps extends WebbComponentBase {
   /**
    * Size of avatar, `md`: 24px, `lg`: 48px (default: "md")
    */
   size?: 'md' | 'lg';
-  /**
-   * Control darkMode using `js`, leave it's empty to control dark mode using `css`
-   */
-  darkMode?: boolean;
   /**
    * Source for avatar
    */
@@ -22,8 +20,4 @@ export interface AvatarProps {
    * Fallback if source image is unavailable
    */
   fallback?: string;
-  /**
-   * Outer class name
-   */
-  className?: string;
 }

--- a/packages/webb-ui-components/src/components/AvatarGroup/types.d.ts
+++ b/packages/webb-ui-components/src/components/AvatarGroup/types.d.ts
@@ -1,3 +1,5 @@
+import { WebbComponentBase } from '@webb-dapp/webb-ui-components/types';
+
 import { Avatar, AvatarProps } from '../Avatar';
 
 export type AvatarChildElement = ReactElement<AvatarProps, typeof Avatar>;
@@ -5,7 +7,7 @@ export type AvatarChildElement = ReactElement<AvatarProps, typeof Avatar>;
 /**
  * Avatar stack properties
  */
-export interface AvatarGroupProps {
+export interface AvatarGroupProps extends WebbComponentBase {
   /**
    * 	Max avatars to show before +n.
    * @default 3

--- a/packages/webb-ui-components/src/components/Button/Button.tsx
+++ b/packages/webb-ui-components/src/components/Button/Button.tsx
@@ -5,6 +5,29 @@ import { ButtonSpinner } from './ButtonSpinner';
 import { ButtonContentProps, ButtonProps } from './types';
 import { getButtonClassNameByVariant } from './utils';
 
+/**
+ * The Webb Button Component
+ *
+ * Props:
+ *
+ * - `isLoading`: If `true`, the button will show a spinner
+ * - `isDisabled`: If `true`, the button will be disabled
+ * - `loadingText`: The label to show in the button when `isLoading` is true. If no text is passed, it only shows the spinner
+ * - `variant`: The button variant (default `primary`)
+ * - `leftIcon`: If added, the button will show an icon before the button's label
+ * - `rightIcon`:If added, the button will show an icon after the button's label
+ * - `iconSpacing`: The space between the button icon and label, the spacing number will match the spacing in design sytem
+ * - `spinner`: Replace the spinner component when `isLoading` is set to `true`
+ * - `spinnerPlacement`: It determines the placement of the spinner when `isLoading` is `true`
+ * - `size`: The button size
+ *
+ * @example
+ *
+ * ```jsx
+ *  <Button variant="secondary">Button</Button>
+ *  <Button variant="utility" isLoading>Button</Button>
+ * ```
+ */
 export const Button: React.FC<ButtonProps> = (props) => {
   const {
     children,

--- a/packages/webb-ui-components/src/components/Button/Button.tsx
+++ b/packages/webb-ui-components/src/components/Button/Button.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { ButtonSpinner } from './ButtonSpinner';
+import { ButtonContentProps, ButtonProps } from './types';
+import { getButtonClassNameByVariant } from './utils';
+
+export const Button: React.FC<ButtonProps> = (props) => {
+  const {
+    children,
+    className,
+    iconSpacing = 2,
+    isDisabled,
+    isLoading,
+    leftIcon,
+    loadingText,
+    rightIcon,
+    size = 'md',
+    spinner,
+    spinnerPlacement = 'start',
+    varirant = 'primary',
+  } = props;
+
+  const mergedClassName = twMerge(getButtonClassNameByVariant(varirant, size), className);
+
+  const contentProps = { children, iconSpacing, leftIcon, rightIcon };
+
+  return (
+    <button disabled={isDisabled || isLoading} data-loading={isLoading} className={mergedClassName}>
+      {isLoading && spinnerPlacement === 'start' && (
+        <ButtonSpinner label={loadingText} spacing={iconSpacing}>
+          {spinner}
+        </ButtonSpinner>
+      )}
+
+      {isLoading ? (
+        loadingText || (
+          <span className='opacity-0'>
+            <ButtonContent {...contentProps} />
+          </span>
+        )
+      ) : (
+        <ButtonContent {...contentProps} />
+      )}
+
+      {isLoading && spinnerPlacement === 'end' && (
+        <ButtonSpinner label={loadingText} spacing={iconSpacing} placement='end'>
+          {spinner}
+        </ButtonSpinner>
+      )}
+    </button>
+  );
+};
+
+/***** Internal components */
+
+function ButtonContent(props: ButtonContentProps) {
+  const { children, iconSpacing = 2, leftIcon, rightIcon } = props;
+
+  return (
+    <>
+      {leftIcon && <span className={`mr-${iconSpacing}`}>{leftIcon}</span>}
+      {children}
+      {rightIcon && <span className={`mt-${iconSpacing}`}>{rightIcon}</span>}
+    </>
+  );
+}

--- a/packages/webb-ui-components/src/components/Button/ButtonSpinner.tsx
+++ b/packages/webb-ui-components/src/components/Button/ButtonSpinner.tsx
@@ -1,0 +1,24 @@
+import { Spinner } from '@webb-dapp/webb-ui-components/icons';
+import React from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { ButtonSpinnerProps } from './types';
+
+export const ButtonSpinner: React.FC<ButtonSpinnerProps> = (props) => {
+  const {
+    children = <Spinner darkMode={props.darkMode} size='lg' />,
+    className,
+    label,
+    placement = 'start',
+    spacing = 2,
+  } = props;
+
+  const mergedClassName = twMerge(
+    'flex items-center',
+    label ? 'relative' : 'absolute',
+    label ? (placement === 'start' ? `mr-${spacing}` : `ml-${spacing}`) : undefined,
+    className
+  );
+
+  return <div className={mergedClassName}>{children}</div>;
+};

--- a/packages/webb-ui-components/src/components/Button/index.ts
+++ b/packages/webb-ui-components/src/components/Button/index.ts
@@ -1,0 +1,1 @@
+export * from './Button';

--- a/packages/webb-ui-components/src/components/Button/types.d.ts
+++ b/packages/webb-ui-components/src/components/Button/types.d.ts
@@ -52,7 +52,7 @@ export interface ButtonProps extends WebbComponentBase {
    */
   spinnerPlacement?: ButtonSpinnerPlacement;
   /**
-   * The button sizes
+   * The button size
    * @default "md"
    */
   size?: ButtonSize;

--- a/packages/webb-ui-components/src/components/Button/types.d.ts
+++ b/packages/webb-ui-components/src/components/Button/types.d.ts
@@ -1,0 +1,93 @@
+import { WebbComponentBase } from '@webb-dapp/webb-ui-components/types';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'utility' | 'link';
+
+export type ButtonSize = 'sm' | 'md';
+
+export type ButtonSpinnerPlacement = 'start' | 'end';
+
+/**
+ * The Button component options
+ */
+export interface ButtonProps extends WebbComponentBase {
+  /**
+   * If `true`, the button will show a spinner
+   */
+  isLoading?: boolean;
+  /**
+   * If `true`, the button will be disabled
+   */
+  isDisabled?: boolean;
+  /**
+   * The label to show in the button when `isLoading` is true
+   * If no text is passed, it only shows the spinner
+   */
+  loadingText?: string;
+  /**
+   * The button variant
+   * @default "primary"
+   */
+  varirant?: ButtonVariant;
+  /**
+   * If added, the button will show an icon before the button's label
+   * @type React.ReactElement
+   */
+  leftIcon?: React.ReactElement;
+  /**
+   * If added, the button will show an icon after the button's label
+   */
+  rightIcon?: React.ReactElement;
+  /**
+   * The space between the button icon and label, the spacing number will match the spacing in design sytem
+   */
+  iconSpacing?: number;
+  /**
+   * Replace the spinner component when `isLoading` is set to `true`
+   * @type React.ReactElement
+   */
+  spinner?: React.ReactElement;
+  /**
+   * It determines the placement of the spinner when isLoading is true
+   * @default "start"
+   */
+  spinnerPlacement?: ButtonSpinnerPlacement;
+  /**
+   * The button sizes
+   * @default "md"
+   */
+  size?: ButtonSize;
+}
+
+export interface ButtonSpinnerProps extends WebbComponentBase {
+  /**
+   * The label to show when `isLoading` is `true`
+   */
+  label?: string;
+  /**
+   * The space between icon and label, the spacing number will match the spacing in design sytem
+   */
+  spacing?: number;
+  /**
+   * It determines the placement of the spinner when `isLoading` is `true`
+   */
+  placement?: ButtonSpinnerPlacement;
+}
+
+type ButtonContentPickKeys = 'leftIcon' | 'rightIcon' | 'iconSpacing' | 'children';
+type ButtonContentProps = Pick<ButtonProps, ButtonContentPickKeys>;
+
+type ButtonTextPickKeys = 'size' | 'variant' | 'darkMode' | 'children' | 'isLoading';
+type ButtonTextProps = Pick<ButtonProps, ButtonTextPickKeys>;
+
+type ButtonClassNames = {
+  [key in ButtonVariant]: {
+    base: {
+      common: string;
+      hover: string;
+      active: string;
+      disabled: string;
+    };
+    sm: string;
+    md: string;
+  };
+};

--- a/packages/webb-ui-components/src/components/Button/utils.ts
+++ b/packages/webb-ui-components/src/components/Button/utils.ts
@@ -1,0 +1,63 @@
+import { twMerge } from 'tailwind-merge';
+
+import { ButtonClassNames, ButtonSize, ButtonVariant } from './types';
+
+const classNames: ButtonClassNames = {
+  primary: {
+    base: {
+      common:
+        'rounded-full px-9 py-2 bg-mono-200 border-2 border-transparent text-mono-0 font-bold dark:bg-mono-180 dark:border-2 dark:border-mono-20 dark:text-mono-20',
+      hover: 'hover:bg-mono-160 dark:hover:bg-mono-160',
+      active: 'active:border-mono-200 dark:active:bg-mono-20 dark:active:border-mono-160 dark:active:text-mono-180',
+      disabled: 'disabled:bg-mono-80 dark:disabled:bg-mono-80 dark:disabled:border-transparent',
+    },
+    sm: 'body1',
+    md: 'body3',
+  },
+  secondary: {
+    base: {
+      common:
+        'rounded-full px-9 py-2 bg-mono-0 border-2 border-mono-200 text-mono-200 font-bold dark:bg-mono-140 dark:border-mono-140 dark:text-mono-20',
+      hover: 'hover:border-mono-140 hover:text-mono-140 dark:hover:bg-mono-100 dark:hover:border-mono-100',
+      active: 'active:bg-mono-20 dark:active:text-mono-0',
+      disabled:
+        'disabled:border-mono-100 disabled:text-mono-100 disabled:bg-mono-20 dark:disabled:border-mono-100 dark:disabled:text-mono-100 dark:disabled:bg-mono-20',
+    },
+    sm: 'body1',
+    md: 'body3',
+  },
+  utility: {
+    base: {
+      common:
+        'rounded-lg px-3 py-2 bg-blue-0 border border-transparent text-blue-70 dark:bg-blue-120 dark:text-blue-20',
+      hover: 'hover:bg-blue-10 hover:text-blue-90 dark:hover:bg-blue-110',
+      active: 'active:border-blue-50 dark:active:border-blue-50',
+      disabled:
+        'disabled:border-none disabled:bg-mono-40 disabled:text-mono-120 disabled:border-transparent dark:disabled:bg-mono-140 dark:disabled:text-mono-100',
+    },
+    sm: 'body1 font-semibold',
+    md: 'body4 font-bold',
+  },
+  link: {
+    base: {
+      common: 'text-blue border-b-[1.6px] border-transparent dark:text-blue-20',
+      hover: 'hover:border-blue dark:hover:text-blue-40 dark:hover:border-blue-40',
+      active: 'active:text-blue-90 active:border-blue-90 dark:active:text-blue dark:active:border-blue',
+      disabled: '',
+    },
+    sm: 'body1 font-semibold',
+    md: 'body4 bold',
+  },
+};
+
+/**
+ * Get the tailwind class name to style the button based on variant
+ * @param variant Represents the button variant
+ * @param darkMode Variable to control dark mode in `js`
+ * @returns tailwind className to style to button based on variant
+ */
+export function getButtonClassNameByVariant(variant: ButtonVariant, size: ButtonSize) {
+  const commonClsx = 'box-border disabled:pointer-events-none text-center';
+  const { active, common, disabled, hover } = classNames[variant]['base'];
+  return twMerge(commonClsx, common, hover, active, disabled, classNames[variant][size]);
+}

--- a/packages/webb-ui-components/src/components/index.ts
+++ b/packages/webb-ui-components/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './Avatar';
 export * from './AvatarGroup';
+export * from './Button';
 export * from './Logo';
 export * from './ThemeSwitcher';

--- a/packages/webb-ui-components/src/icons/Spinner.tsx
+++ b/packages/webb-ui-components/src/icons/Spinner.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { createIcon } from './create-icon';
+import { IconBase } from './types';
+
+export const Spinner: React.FC<IconBase> = (props) => {
+  // Spin animation attach to className
+  props.className = twMerge(props.className, 'animate-spin fill-none stroke-none');
+
+  return createIcon({
+    ...props,
+    path: [
+      <path
+        d='M10 1C14.9706 1 19 5.02944 19 10C19 14.9706 14.9706 19 10 19C5.02944 19 1 14.9706 1 10C1 5.02944 5.02944 1 10 1Z'
+        stroke='#D5E6FF'
+        stroke-width='2'
+        stroke-linecap='round'
+      />,
+      <path d='M10 1C14.9706 1 19 5.02944 19 10' stroke='#4E8CDF' stroke-width='2' stroke-linecap='round' />,
+    ],
+    displayName: 'Spinner',
+    viewBox: '0 0 20 20',
+  });
+};

--- a/packages/webb-ui-components/src/icons/index.ts
+++ b/packages/webb-ui-components/src/icons/index.ts
@@ -34,6 +34,7 @@ export * from './MoonLine';
 export * from './QRCode';
 export * from './Search';
 export * from './ShuffleLine';
+export * from './Spinner';
 export * from './SunLine';
 export * from './TelegramFill';
 export * from './TokenIcon';

--- a/packages/webb-ui-components/src/icons/types.d.ts
+++ b/packages/webb-ui-components/src/icons/types.d.ts
@@ -1,4 +1,5 @@
 import { DynamicSVGImportOptions } from '../hooks';
+import { WebbComponentBase } from '../types';
 
 type SVGBase = Omit<React.SVGProps<SVGSVGElement>, 'path' | 'd'>;
 
@@ -7,21 +8,12 @@ export type IconSize = 'md' | 'lg' | 'xl';
 /**
  * Base interface for Webb Icon
  */
-export interface IconBase extends SVGBase {
+export interface IconBase extends SVGBase, WebbComponentBase {
   /**
    * The icon size, possible values: `md` (16px), `lg` (24px), `xl` (48px)
    * @default "md"
    */
   size?: IconSize;
-  /**
-   * Use the icon in dark mode, this prop control theme mode with `js`.
-   * If it's empty, the theme mode will control by `css`
-   */
-  darkMode?: boolean;
-  /**
-   * Class name for svg props
-   */
-  className?: string;
 }
 
 /**

--- a/packages/webb-ui-components/src/types/index.d.ts
+++ b/packages/webb-ui-components/src/types/index.d.ts
@@ -15,4 +15,8 @@ export interface WebbComponentBase {
    * Control dark mode using `js`, if it's empty, the component will control dark mode in `css`
    */
   darkMode?: boolean;
+  /**
+   * Children node
+   */
+  children?: React.ReactNode;
 }

--- a/packages/webb-ui-components/src/types/index.d.ts
+++ b/packages/webb-ui-components/src/types/index.d.ts
@@ -2,3 +2,17 @@ declare module '*.svg' {
   const content: any;
   export default content;
 }
+
+/**
+ * The base interface required all component to extends in their props
+ */
+export interface WebbComponentBase {
+  /**
+   * The tailwindcss className to override the style
+   */
+  className?: string;
+  /**
+   * Control dark mode using `js`, if it's empty, the component will control dark mode in `css`
+   */
+  darkMode?: boolean;
+}

--- a/packages/webb-ui-components/src/typography/types.d.ts
+++ b/packages/webb-ui-components/src/typography/types.d.ts
@@ -1,5 +1,7 @@
 import { ReactHTML } from 'react';
 
+import { WebbComponentBase } from '../types';
+
 export type TypographyBaseProps = React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
 
 export type TypographyAlignValues = 'center' | 'justify' | 'right' | 'left';
@@ -22,7 +24,9 @@ export type WebbTypographyVariant = HeadingVariant | BodyVariant | MonospaceVari
  * - `ta`: Text align (default: `inherit`)
  * - `darkMode`: Control component dark mode display in `js`, leave it's empty if you want to control dark mode in `css`
  */
-export interface WebbTypographyProps<TypoVariant = WebbTypographyVariant> extends TypographyBaseProps {
+export interface WebbTypographyProps<TypoVariant = WebbTypographyVariant>
+  extends TypographyBaseProps,
+    WebbComponentBase {
   /**
    * Represent different variants of the component
    */
@@ -39,8 +43,4 @@ export interface WebbTypographyProps<TypoVariant = WebbTypographyVariant> extend
    * Text align
    */
   ta?: TypographyAlignValues;
-  /**
-   * Dark mode control for `js`, leave it's empty to control dark mode in `css`
-   */
-  darkMode?: boolean;
 }


### PR DESCRIPTION
- refactor: extract common props into `WebbComponentBase` interface
- chore: add `Spinner` icon for loading state
- feat: add new `Button` component
- fix: add missing config for `webpack` dev server

## Summary of changes
- setup new `Button` component
- Define base interface for all components
- Add missing config for `webpack` dev server.


### Reference issue to close (if applicable)
- Closes https://github.com/webb-tools/webb-dapp/issues/508

-----
### Code Checklist 

- [x] Tested
- [x] Documented

### Other info

I cannot test the component with the current app. Because it conflicts with the existing style from Material-UI.

We need an isolated sandbox to test new components.
