### PR TITLE
Include the previous and next  entity id for single view

### DIFF
--- a/packages/page-statistics/src/generated/graphql.tsx
+++ b/packages/page-statistics/src/generated/graphql.tsx
@@ -10053,6 +10053,13 @@ export type ProposalDetailsQueryVariables = Exact<{
 
 export type ProposalDetailsQuery = { __typename?: 'Query', session?: { __typename?: 'Session', id: string, sessionProposers: { __typename?: 'SessionProposersConnection', totalCount: number } } | null, proposalItem?: { __typename?: 'ProposalItem', id: string, data: string, signature?: string | null, type: ProposalType, status: string, proposalTimelineStatuses: { __typename?: 'ProposalTimelineStatusesConnection', nodes: Array<{ __typename?: 'ProposalTimelineStatus', id: string, status: ProposalStatus, blockNumber: any, timestamp: any } | null> }, votesFor: { __typename?: 'ProposalVotesConnection', totalCount: number }, totalVotes: { __typename?: 'ProposalVotesConnection', totalCount: number }, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null } | null };
 
+export type EnsureProposalsQueryVariables = Exact<{
+  ids: Array<Scalars['String']> | Scalars['String'];
+}>;
+
+
+export type EnsureProposalsQuery = { __typename?: 'Query', proposalItems?: { __typename?: 'ProposalItemsConnection', nodes: Array<{ __typename?: 'ProposalItem', id: string } | null> } | null };
+
 export type PublicKeysQueryVariables = Exact<{
   PerPage?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
@@ -10698,6 +10705,43 @@ export function useProposalDetailsLazyQuery(baseOptions?: Apollo.LazyQueryHookOp
 export type ProposalDetailsQueryHookResult = ReturnType<typeof useProposalDetailsQuery>;
 export type ProposalDetailsLazyQueryHookResult = ReturnType<typeof useProposalDetailsLazyQuery>;
 export type ProposalDetailsQueryResult = Apollo.QueryResult<ProposalDetailsQuery, ProposalDetailsQueryVariables>;
+export const EnsureProposalsDocument = gql`
+    query ensureProposals($ids: [String!]!) {
+  proposalItems(filter: {id: {in: $ids}}) {
+    nodes {
+      id
+    }
+  }
+}
+    `;
+
+/**
+ * __useEnsureProposalsQuery__
+ *
+ * To run a query within a React component, call `useEnsureProposalsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEnsureProposalsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useEnsureProposalsQuery({
+ *   variables: {
+ *      ids: // value for 'ids'
+ *   },
+ * });
+ */
+export function useEnsureProposalsQuery(baseOptions: Apollo.QueryHookOptions<EnsureProposalsQuery, EnsureProposalsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<EnsureProposalsQuery, EnsureProposalsQueryVariables>(EnsureProposalsDocument, options);
+      }
+export function useEnsureProposalsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EnsureProposalsQuery, EnsureProposalsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<EnsureProposalsQuery, EnsureProposalsQueryVariables>(EnsureProposalsDocument, options);
+        }
+export type EnsureProposalsQueryHookResult = ReturnType<typeof useEnsureProposalsQuery>;
+export type EnsureProposalsLazyQueryHookResult = ReturnType<typeof useEnsureProposalsLazyQuery>;
+export type EnsureProposalsQueryResult = Apollo.QueryResult<EnsureProposalsQuery, EnsureProposalsQueryVariables>;
 export const PublicKeysDocument = gql`
     query PublicKeys($PerPage: Int, $offset: Int) {
   publicKeys(

--- a/packages/page-statistics/src/generated/graphql.tsx
+++ b/packages/page-statistics/src/generated/graphql.tsx
@@ -47,6 +47,7 @@ export type Account = Node & {
   validators: ValidatorsConnection;
 };
 
+
 export type AccountAccountsByCreatorIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -56,6 +57,7 @@ export type AccountAccountsByCreatorIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<AccountsOrderBy>>;
 };
+
 
 export type AccountBlocksByAccountCreatorIdAndCreateAtBlockIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -67,6 +69,7 @@ export type AccountBlocksByAccountCreatorIdAndCreateAtBlockIdArgs = {
   orderBy?: InputMaybe<Array<BlocksOrderBy>>;
 };
 
+
 export type AccountBlocksByExtrinsicSignerIdAndBlockIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -76,6 +79,7 @@ export type AccountBlocksByExtrinsicSignerIdAndBlockIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<BlocksOrderBy>>;
 };
+
 
 export type AccountExtrinsicsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -87,6 +91,7 @@ export type AccountExtrinsicsArgs = {
   orderBy?: InputMaybe<Array<ExtrinsicsOrderBy>>;
 };
 
+
 export type AccountProposersArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -96,6 +101,7 @@ export type AccountProposersArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ProposersOrderBy>>;
 };
+
 
 export type AccountValidatorsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -131,6 +137,7 @@ export type AccountBlocksByAccountCreatorIdAndCreateAtBlockIdManyToManyConnectio
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Block` values, with data from `Account`. */
 export type AccountBlocksByAccountCreatorIdAndCreateAtBlockIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<BlocksGroupBy>;
@@ -147,6 +154,7 @@ export type AccountBlocksByAccountCreatorIdAndCreateAtBlockIdManyToManyEdge = {
   /** The `Block` at the end of the edge. */
   node?: Maybe<Block>;
 };
+
 
 /** A `Block` edge in the connection, with data from `Account`. */
 export type AccountBlocksByAccountCreatorIdAndCreateAtBlockIdManyToManyEdgeAccountsByCreateAtBlockIdArgs = {
@@ -176,6 +184,7 @@ export type AccountBlocksByExtrinsicSignerIdAndBlockIdManyToManyConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Block` values, with data from `Extrinsic`. */
 export type AccountBlocksByExtrinsicSignerIdAndBlockIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<BlocksGroupBy>;
@@ -192,6 +201,7 @@ export type AccountBlocksByExtrinsicSignerIdAndBlockIdManyToManyEdge = {
   /** The `Block` at the end of the edge. */
   node?: Maybe<Block>;
 };
+
 
 /** A `Block` edge in the connection, with data from `Extrinsic`. */
 export type AccountBlocksByExtrinsicSignerIdAndBlockIdManyToManyEdgeExtrinsicsArgs = {
@@ -251,6 +261,7 @@ export type AccountsConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Account` values. */
 export type AccountsConnectionGroupedAggregatesArgs = {
   groupBy: Array<AccountsGroupBy>;
@@ -270,7 +281,7 @@ export type AccountsEdge = {
 export enum AccountsGroupBy {
   CreatedAt = 'CREATED_AT',
   CreateAtBlockId = 'CREATE_AT_BLOCK_ID',
-  CreatorId = 'CREATOR_ID',
+  CreatorId = 'CREATOR_ID'
 }
 
 /** Conditions for `Account` aggregates. */
@@ -659,7 +670,7 @@ export enum AccountsOrderBy {
   ValidatorsVarianceSampleAuthorityIdAsc = 'VALIDATORS_VARIANCE_SAMPLE_AUTHORITY_ID_ASC',
   ValidatorsVarianceSampleAuthorityIdDesc = 'VALIDATORS_VARIANCE_SAMPLE_AUTHORITY_ID_DESC',
   ValidatorsVarianceSampleIdAsc = 'VALIDATORS_VARIANCE_SAMPLE_ID_ASC',
-  ValidatorsVarianceSampleIdDesc = 'VALIDATORS_VARIANCE_SAMPLE_ID_DESC',
+  ValidatorsVarianceSampleIdDesc = 'VALIDATORS_VARIANCE_SAMPLE_ID_DESC'
 }
 
 /** A connection to a list of `Authority` values. */
@@ -678,6 +689,7 @@ export type AuthoritiesConnection = {
   /** The count of *all* `Authority` you could get from the connection. */
   totalCount: Scalars['Int'];
 };
+
 
 /** A connection to a list of `Authority` values. */
 export type AuthoritiesConnectionGroupedAggregatesArgs = {
@@ -698,7 +710,7 @@ export type AuthoritiesEdge = {
 export enum AuthoritiesGroupBy {
   BlockId = 'BLOCK_ID',
   Current = 'CURRENT',
-  Next = 'NEXT',
+  Next = 'NEXT'
 }
 
 /** Conditions for `Authority` aggregates. */
@@ -719,7 +731,7 @@ export enum AuthoritiesOrderBy {
   NextAsc = 'NEXT_ASC',
   NextDesc = 'NEXT_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
 
 export type Authority = Node & {
@@ -849,6 +861,7 @@ export type Block = Node & {
   unsignedProposalsQueues: UnsignedProposalsQueuesConnection;
 };
 
+
 export type BlockAccountsByAccountCreateAtBlockIdAndCreatorIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -858,6 +871,7 @@ export type BlockAccountsByAccountCreateAtBlockIdAndCreatorIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<AccountsOrderBy>>;
 };
+
 
 export type BlockAccountsByCreateAtBlockIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -869,6 +883,7 @@ export type BlockAccountsByCreateAtBlockIdArgs = {
   orderBy?: InputMaybe<Array<AccountsOrderBy>>;
 };
 
+
 export type BlockAccountsByExtrinsicBlockIdAndSignerIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -878,6 +893,7 @@ export type BlockAccountsByExtrinsicBlockIdAndSignerIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<AccountsOrderBy>>;
 };
+
 
 export type BlockAuthoritiesArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -889,6 +905,7 @@ export type BlockAuthoritiesArgs = {
   orderBy?: InputMaybe<Array<AuthoritiesOrderBy>>;
 };
 
+
 export type BlockEventsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -898,6 +915,7 @@ export type BlockEventsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<EventsOrderBy>>;
 };
+
 
 export type BlockExtrinsicsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -909,6 +927,7 @@ export type BlockExtrinsicsArgs = {
   orderBy?: InputMaybe<Array<ExtrinsicsOrderBy>>;
 };
 
+
 export type BlockExtrinsicsByEventBlockIdAndExtrinsicIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -918,6 +937,7 @@ export type BlockExtrinsicsByEventBlockIdAndExtrinsicIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ExtrinsicsOrderBy>>;
 };
+
 
 export type BlockKeygenThresholdsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -929,6 +949,7 @@ export type BlockKeygenThresholdsArgs = {
   orderBy?: InputMaybe<Array<KeygenThresholdsOrderBy>>;
 };
 
+
 export type BlockProposalCountersArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -938,6 +959,7 @@ export type BlockProposalCountersArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ProposalCountersOrderBy>>;
 };
+
 
 export type BlockProposalItemsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -949,6 +971,7 @@ export type BlockProposalItemsArgs = {
   orderBy?: InputMaybe<Array<ProposalItemsOrderBy>>;
 };
 
+
 export type BlockProposalItemsByProposalVoteBlockIdAndProposalIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -958,6 +981,7 @@ export type BlockProposalItemsByProposalVoteBlockIdAndProposalIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ProposalItemsOrderBy>>;
 };
+
 
 export type BlockProposalVotesArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -969,6 +993,7 @@ export type BlockProposalVotesArgs = {
   orderBy?: InputMaybe<Array<ProposalVotesOrderBy>>;
 };
 
+
 export type BlockProposerThresholdsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -978,6 +1003,7 @@ export type BlockProposerThresholdsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ProposerThresholdsOrderBy>>;
 };
+
 
 export type BlockProposersByProposalVoteBlockIdAndVoterIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -989,6 +1015,7 @@ export type BlockProposersByProposalVoteBlockIdAndVoterIdArgs = {
   orderBy?: InputMaybe<Array<ProposersOrderBy>>;
 };
 
+
 export type BlockPublicKeysArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -998,6 +1025,7 @@ export type BlockPublicKeysArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<PublicKeysOrderBy>>;
 };
+
 
 export type BlockPublicKeysBySessionBlockIdAndPublicKeyIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1009,6 +1037,7 @@ export type BlockPublicKeysBySessionBlockIdAndPublicKeyIdArgs = {
   orderBy?: InputMaybe<Array<PublicKeysOrderBy>>;
 };
 
+
 export type BlockSessionsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -1019,6 +1048,7 @@ export type BlockSessionsArgs = {
   orderBy?: InputMaybe<Array<SessionsOrderBy>>;
 };
 
+
 export type BlockSignatureThresholdsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -1028,6 +1058,7 @@ export type BlockSignatureThresholdsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<SignatureThresholdsOrderBy>>;
 };
+
 
 export type BlockUnsignedProposalsQueuesArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1056,6 +1087,7 @@ export type BlockAccountsByAccountCreateAtBlockIdAndCreatorIdManyToManyConnectio
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Account` values, with data from `Account`. */
 export type BlockAccountsByAccountCreateAtBlockIdAndCreatorIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<AccountsGroupBy>;
@@ -1072,6 +1104,7 @@ export type BlockAccountsByAccountCreateAtBlockIdAndCreatorIdManyToManyEdge = {
   /** The `Account` at the end of the edge. */
   node?: Maybe<Account>;
 };
+
 
 /** A `Account` edge in the connection, with data from `Account`. */
 export type BlockAccountsByAccountCreateAtBlockIdAndCreatorIdManyToManyEdgeAccountsByCreatorIdArgs = {
@@ -1101,6 +1134,7 @@ export type BlockAccountsByExtrinsicBlockIdAndSignerIdManyToManyConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Account` values, with data from `Extrinsic`. */
 export type BlockAccountsByExtrinsicBlockIdAndSignerIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<AccountsGroupBy>;
@@ -1117,6 +1151,7 @@ export type BlockAccountsByExtrinsicBlockIdAndSignerIdManyToManyEdge = {
   /** The `Account` at the end of the edge. */
   node?: Maybe<Account>;
 };
+
 
 /** A `Account` edge in the connection, with data from `Extrinsic`. */
 export type BlockAccountsByExtrinsicBlockIdAndSignerIdManyToManyEdgeExtrinsicsArgs = {
@@ -1195,6 +1230,7 @@ export type BlockExtrinsicsByEventBlockIdAndExtrinsicIdManyToManyConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Extrinsic` values, with data from `Event`. */
 export type BlockExtrinsicsByEventBlockIdAndExtrinsicIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<ExtrinsicsGroupBy>;
@@ -1211,6 +1247,7 @@ export type BlockExtrinsicsByEventBlockIdAndExtrinsicIdManyToManyEdge = {
   /** The `Extrinsic` at the end of the edge. */
   node?: Maybe<Extrinsic>;
 };
+
 
 /** A `Extrinsic` edge in the connection, with data from `Event`. */
 export type BlockExtrinsicsByEventBlockIdAndExtrinsicIdManyToManyEdgeEventsArgs = {
@@ -1278,6 +1315,7 @@ export type BlockProposalItemsByProposalVoteBlockIdAndProposalIdManyToManyConnec
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `ProposalItem` values, with data from `ProposalVote`. */
 export type BlockProposalItemsByProposalVoteBlockIdAndProposalIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposalItemsGroupBy>;
@@ -1294,6 +1332,7 @@ export type BlockProposalItemsByProposalVoteBlockIdAndProposalIdManyToManyEdge =
   /** Reads and enables pagination through a set of `ProposalVote`. */
   proposalVotesByProposalId: ProposalVotesConnection;
 };
+
 
 /** A `ProposalItem` edge in the connection, with data from `ProposalVote`. */
 export type BlockProposalItemsByProposalVoteBlockIdAndProposalIdManyToManyEdgeProposalVotesByProposalIdArgs = {
@@ -1323,6 +1362,7 @@ export type BlockProposersByProposalVoteBlockIdAndVoterIdManyToManyConnection = 
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Proposer` values, with data from `ProposalVote`. */
 export type BlockProposersByProposalVoteBlockIdAndVoterIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposersGroupBy>;
@@ -1339,6 +1379,7 @@ export type BlockProposersByProposalVoteBlockIdAndVoterIdManyToManyEdge = {
   /** Reads and enables pagination through a set of `ProposalVote`. */
   proposalVotesByVoterId: ProposalVotesConnection;
 };
+
 
 /** A `Proposer` edge in the connection, with data from `ProposalVote`. */
 export type BlockProposersByProposalVoteBlockIdAndVoterIdManyToManyEdgeProposalVotesByVoterIdArgs = {
@@ -1368,6 +1409,7 @@ export type BlockPublicKeysBySessionBlockIdAndPublicKeyIdManyToManyConnection = 
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `PublicKey` values, with data from `Session`. */
 export type BlockPublicKeysBySessionBlockIdAndPublicKeyIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<PublicKeysGroupBy>;
@@ -1384,6 +1426,7 @@ export type BlockPublicKeysBySessionBlockIdAndPublicKeyIdManyToManyEdge = {
   /** Reads and enables pagination through a set of `Session`. */
   sessions: SessionsConnection;
 };
+
 
 /** A `PublicKey` edge in the connection, with data from `Session`. */
 export type BlockPublicKeysBySessionBlockIdAndPublicKeyIdManyToManyEdgeSessionsArgs = {
@@ -1443,6 +1486,7 @@ export type BlocksConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Block` values. */
 export type BlocksConnectionGroupedAggregatesArgs = {
   groupBy: Array<BlocksGroupBy>;
@@ -1467,7 +1511,7 @@ export enum BlocksGroupBy {
   StateRoot = 'STATE_ROOT',
   Timestamp = 'TIMESTAMP',
   TimestampTruncatedToDay = 'TIMESTAMP_TRUNCATED_TO_DAY',
-  TimestampTruncatedToHour = 'TIMESTAMP_TRUNCATED_TO_HOUR',
+  TimestampTruncatedToHour = 'TIMESTAMP_TRUNCATED_TO_HOUR'
 }
 
 export type BlocksHavingAverageInput = {
@@ -3034,7 +3078,7 @@ export enum BlocksOrderBy {
   UnsignedProposalsQueuesVarianceSampleBlockNumberAsc = 'UNSIGNED_PROPOSALS_QUEUES_VARIANCE_SAMPLE_BLOCK_NUMBER_ASC',
   UnsignedProposalsQueuesVarianceSampleBlockNumberDesc = 'UNSIGNED_PROPOSALS_QUEUES_VARIANCE_SAMPLE_BLOCK_NUMBER_DESC',
   UnsignedProposalsQueuesVarianceSampleIdAsc = 'UNSIGNED_PROPOSALS_QUEUES_VARIANCE_SAMPLE_ID_ASC',
-  UnsignedProposalsQueuesVarianceSampleIdDesc = 'UNSIGNED_PROPOSALS_QUEUES_VARIANCE_SAMPLE_ID_DESC',
+  UnsignedProposalsQueuesVarianceSampleIdDesc = 'UNSIGNED_PROPOSALS_QUEUES_VARIANCE_SAMPLE_ID_DESC'
 }
 
 /** A filter to be used against Boolean fields. All fields are combined with a logical ‘and.’ */
@@ -3272,6 +3316,7 @@ export type EventsConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Event` values. */
 export type EventsConnectionGroupedAggregatesArgs = {
   groupBy: Array<EventsGroupBy>;
@@ -3300,7 +3345,7 @@ export enum EventsGroupBy {
   Module = 'MODULE',
   Timestamp = 'TIMESTAMP',
   TimestampTruncatedToDay = 'TIMESTAMP_TRUNCATED_TO_DAY',
-  TimestampTruncatedToHour = 'TIMESTAMP_TRUNCATED_TO_HOUR',
+  TimestampTruncatedToHour = 'TIMESTAMP_TRUNCATED_TO_HOUR'
 }
 
 export type EventsHavingAverageInput = {
@@ -3398,7 +3443,7 @@ export enum EventsOrderBy {
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
   TimestampAsc = 'TIMESTAMP_ASC',
-  TimestampDesc = 'TIMESTAMP_DESC',
+  TimestampDesc = 'TIMESTAMP_DESC'
 }
 
 export type Extrinsic = Node & {
@@ -3426,6 +3471,7 @@ export type Extrinsic = Node & {
   signerId?: Maybe<Scalars['String']>;
 };
 
+
 export type ExtrinsicBlocksByEventExtrinsicIdAndBlockIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -3435,6 +3481,7 @@ export type ExtrinsicBlocksByEventExtrinsicIdAndBlockIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<BlocksOrderBy>>;
 };
+
 
 export type ExtrinsicEventsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -3494,6 +3541,7 @@ export type ExtrinsicBlocksByEventExtrinsicIdAndBlockIdManyToManyConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Block` values, with data from `Event`. */
 export type ExtrinsicBlocksByEventExtrinsicIdAndBlockIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<BlocksGroupBy>;
@@ -3510,6 +3558,7 @@ export type ExtrinsicBlocksByEventExtrinsicIdAndBlockIdManyToManyEdge = {
   /** The `Block` at the end of the edge. */
   node?: Maybe<Block>;
 };
+
 
 /** A `Block` edge in the connection, with data from `Event`. */
 export type ExtrinsicBlocksByEventExtrinsicIdAndBlockIdManyToManyEdgeEventsArgs = {
@@ -3653,6 +3702,7 @@ export type ExtrinsicsConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Extrinsic` values. */
 export type ExtrinsicsConnectionGroupedAggregatesArgs = {
   groupBy: Array<ExtrinsicsGroupBy>;
@@ -3679,7 +3729,7 @@ export enum ExtrinsicsGroupBy {
   IsSuccess = 'IS_SUCCESS',
   Method = 'METHOD',
   Module = 'MODULE',
-  SignerId = 'SIGNER_ID',
+  SignerId = 'SIGNER_ID'
 }
 
 export type ExtrinsicsHavingAverageInput = {
@@ -3968,7 +4018,7 @@ export enum ExtrinsicsOrderBy {
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
   SignerIdAsc = 'SIGNER_ID_ASC',
-  SignerIdDesc = 'SIGNER_ID_DESC',
+  SignerIdDesc = 'SIGNER_ID_DESC'
 }
 
 export type HavingBigfloatFilter = {
@@ -4227,6 +4277,7 @@ export type KeygenThresholdsConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `KeygenThreshold` values. */
 export type KeygenThresholdsConnectionGroupedAggregatesArgs = {
   groupBy: Array<KeygenThresholdsGroupBy>;
@@ -4247,7 +4298,7 @@ export enum KeygenThresholdsGroupBy {
   BlockId = 'BLOCK_ID',
   Current = 'CURRENT',
   Next = 'NEXT',
-  Pending = 'PENDING',
+  Pending = 'PENDING'
 }
 
 export type KeygenThresholdsHavingAverageInput = {
@@ -4333,7 +4384,7 @@ export enum KeygenThresholdsOrderBy {
   PendingAsc = 'PENDING_ASC',
   PendingDesc = 'PENDING_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
 
 /** An object with a globally unique `ID`. */
@@ -4537,6 +4588,7 @@ export type ProposalCountersConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `ProposalCounter` values. */
 export type ProposalCountersConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposalCountersGroupBy>;
@@ -4560,7 +4612,7 @@ export enum ProposalCountersGroupBy {
   SignedProposalsMap = 'SIGNED_PROPOSALS_MAP',
   StatusMap = 'STATUS_MAP',
   UnSignedProposalsCount = 'UN_SIGNED_PROPOSALS_COUNT',
-  UnSignedProposalsMap = 'UN_SIGNED_PROPOSALS_MAP',
+  UnSignedProposalsMap = 'UN_SIGNED_PROPOSALS_MAP'
 }
 
 export type ProposalCountersHavingAverageInput = {
@@ -4652,7 +4704,7 @@ export enum ProposalCountersOrderBy {
   UnSignedProposalsCountAsc = 'UN_SIGNED_PROPOSALS_COUNT_ASC',
   UnSignedProposalsCountDesc = 'UN_SIGNED_PROPOSALS_COUNT_DESC',
   UnSignedProposalsMapAsc = 'UN_SIGNED_PROPOSALS_MAP_ASC',
-  UnSignedProposalsMapDesc = 'UN_SIGNED_PROPOSALS_MAP_DESC',
+  UnSignedProposalsMapDesc = 'UN_SIGNED_PROPOSALS_MAP_DESC'
 }
 
 export type ProposalItem = Node & {
@@ -4684,6 +4736,7 @@ export type ProposalItem = Node & {
   unsignedProposalsQueuesByUnsignedProposalsQueueItemProposalIdAndQueueId: ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemProposalIdAndQueueIdManyToManyConnection;
 };
 
+
 export type ProposalItemBlocksByProposalVoteProposalIdAndBlockIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -4693,6 +4746,7 @@ export type ProposalItemBlocksByProposalVoteProposalIdAndBlockIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<BlocksOrderBy>>;
 };
+
 
 export type ProposalItemProposalTimelineStatusesArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -4704,6 +4758,7 @@ export type ProposalItemProposalTimelineStatusesArgs = {
   orderBy?: InputMaybe<Array<ProposalTimelineStatusesOrderBy>>;
 };
 
+
 export type ProposalItemProposalVotesByProposalIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -4713,6 +4768,7 @@ export type ProposalItemProposalVotesByProposalIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ProposalVotesOrderBy>>;
 };
+
 
 export type ProposalItemProposersByProposalVoteProposalIdAndVoterIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -4724,6 +4780,7 @@ export type ProposalItemProposersByProposalVoteProposalIdAndVoterIdArgs = {
   orderBy?: InputMaybe<Array<ProposersOrderBy>>;
 };
 
+
 export type ProposalItemUnsignedProposalsQueueItemsByProposalIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -4733,6 +4790,7 @@ export type ProposalItemUnsignedProposalsQueueItemsByProposalIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<UnsignedProposalsQueueItemsOrderBy>>;
 };
+
 
 export type ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemProposalIdAndQueueIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -4792,6 +4850,7 @@ export type ProposalItemBlocksByProposalVoteProposalIdAndBlockIdManyToManyConnec
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Block` values, with data from `ProposalVote`. */
 export type ProposalItemBlocksByProposalVoteProposalIdAndBlockIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<BlocksGroupBy>;
@@ -4808,6 +4867,7 @@ export type ProposalItemBlocksByProposalVoteProposalIdAndBlockIdManyToManyEdge =
   /** Reads and enables pagination through a set of `ProposalVote`. */
   proposalVotes: ProposalVotesConnection;
 };
+
 
 /** A `Block` edge in the connection, with data from `ProposalVote`. */
 export type ProposalItemBlocksByProposalVoteProposalIdAndBlockIdManyToManyEdgeProposalVotesArgs = {
@@ -4903,6 +4963,7 @@ export type ProposalItemProposersByProposalVoteProposalIdAndVoterIdManyToManyCon
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Proposer` values, with data from `ProposalVote`. */
 export type ProposalItemProposersByProposalVoteProposalIdAndVoterIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposersGroupBy>;
@@ -4919,6 +4980,7 @@ export type ProposalItemProposersByProposalVoteProposalIdAndVoterIdManyToManyEdg
   /** Reads and enables pagination through a set of `ProposalVote`. */
   proposalVotesByVoterId: ProposalVotesConnection;
 };
+
 
 /** A `Proposer` edge in the connection, with data from `ProposalVote`. */
 export type ProposalItemProposersByProposalVoteProposalIdAndVoterIdManyToManyEdgeProposalVotesByVoterIdArgs = {
@@ -4972,12 +5034,12 @@ export type ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemPropo
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `UnsignedProposalsQueue` values, with data from `UnsignedProposalsQueueItem`. */
-export type ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemProposalIdAndQueueIdManyToManyConnectionGroupedAggregatesArgs =
-  {
-    groupBy: Array<UnsignedProposalsQueuesGroupBy>;
-    having?: InputMaybe<UnsignedProposalsQueuesHavingInput>;
-  };
+export type ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemProposalIdAndQueueIdManyToManyConnectionGroupedAggregatesArgs = {
+  groupBy: Array<UnsignedProposalsQueuesGroupBy>;
+  having?: InputMaybe<UnsignedProposalsQueuesHavingInput>;
+};
 
 /** A `UnsignedProposalsQueue` edge in the connection, with data from `UnsignedProposalsQueueItem`. */
 export type ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemProposalIdAndQueueIdManyToManyEdge = {
@@ -4990,17 +5052,17 @@ export type ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemPropo
   unsignedProposalsQueueItemsByQueueId: UnsignedProposalsQueueItemsConnection;
 };
 
+
 /** A `UnsignedProposalsQueue` edge in the connection, with data from `UnsignedProposalsQueueItem`. */
-export type ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemProposalIdAndQueueIdManyToManyEdgeUnsignedProposalsQueueItemsByQueueIdArgs =
-  {
-    after?: InputMaybe<Scalars['Cursor']>;
-    before?: InputMaybe<Scalars['Cursor']>;
-    filter?: InputMaybe<UnsignedProposalsQueueItemFilter>;
-    first?: InputMaybe<Scalars['Int']>;
-    last?: InputMaybe<Scalars['Int']>;
-    offset?: InputMaybe<Scalars['Int']>;
-    orderBy?: InputMaybe<Array<UnsignedProposalsQueueItemsOrderBy>>;
-  };
+export type ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemProposalIdAndQueueIdManyToManyEdgeUnsignedProposalsQueueItemsByQueueIdArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  filter?: InputMaybe<UnsignedProposalsQueueItemFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<UnsignedProposalsQueueItemsOrderBy>>;
+};
 
 export type ProposalItemVariancePopulationAggregates = {
   __typename?: 'ProposalItemVariancePopulationAggregates';
@@ -5035,6 +5097,7 @@ export type ProposalItemsConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `ProposalItem` values. */
 export type ProposalItemsConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposalItemsGroupBy>;
@@ -5059,7 +5122,7 @@ export enum ProposalItemsGroupBy {
   Removed = 'REMOVED',
   Signature = 'SIGNATURE',
   Status = 'STATUS',
-  Type = 'TYPE',
+  Type = 'TYPE'
 }
 
 export type ProposalItemsHavingAverageInput = {
@@ -5438,7 +5501,7 @@ export enum ProposalItemsOrderBy {
   UnsignedProposalsQueueItemsByProposalIdVarianceSampleProposalIdAsc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_PROPOSAL_ID_VARIANCE_SAMPLE_PROPOSAL_ID_ASC',
   UnsignedProposalsQueueItemsByProposalIdVarianceSampleProposalIdDesc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_PROPOSAL_ID_VARIANCE_SAMPLE_PROPOSAL_ID_DESC',
   UnsignedProposalsQueueItemsByProposalIdVarianceSampleQueueIdAsc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_PROPOSAL_ID_VARIANCE_SAMPLE_QUEUE_ID_ASC',
-  UnsignedProposalsQueueItemsByProposalIdVarianceSampleQueueIdDesc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_PROPOSAL_ID_VARIANCE_SAMPLE_QUEUE_ID_DESC',
+  UnsignedProposalsQueueItemsByProposalIdVarianceSampleQueueIdDesc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_PROPOSAL_ID_VARIANCE_SAMPLE_QUEUE_ID_DESC'
 }
 
 export enum ProposalStatus {
@@ -5448,7 +5511,7 @@ export enum ProposalStatus {
   Open = 'Open',
   Rejected = 'Rejected',
   Removed = 'Removed',
-  Signed = 'Signed',
+  Signed = 'Signed'
 }
 
 /** A filter to be used against ProposalStatus fields. All fields are combined with a logical ‘and.’ */
@@ -5617,6 +5680,7 @@ export type ProposalTimelineStatusesConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `ProposalTimelineStatus` values. */
 export type ProposalTimelineStatusesConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposalTimelineStatusesGroupBy>;
@@ -5640,7 +5704,7 @@ export enum ProposalTimelineStatusesGroupBy {
   Timestamp = 'TIMESTAMP',
   TimestampTruncatedToDay = 'TIMESTAMP_TRUNCATED_TO_DAY',
   TimestampTruncatedToHour = 'TIMESTAMP_TRUNCATED_TO_HOUR',
-  TxHash = 'TX_HASH',
+  TxHash = 'TX_HASH'
 }
 
 export type ProposalTimelineStatusesHavingAverageInput = {
@@ -5719,7 +5783,7 @@ export enum ProposalTimelineStatusesOrderBy {
   TimestampAsc = 'TIMESTAMP_ASC',
   TimestampDesc = 'TIMESTAMP_DESC',
   TxHashAsc = 'TX_HASH_ASC',
-  TxHashDesc = 'TX_HASH_DESC',
+  TxHashDesc = 'TX_HASH_DESC'
 }
 
 export enum ProposalType {
@@ -5738,7 +5802,7 @@ export enum ProposalType {
   TokenAddProposal = 'TokenAddProposal',
   TokenRemoveProposal = 'TokenRemoveProposal',
   Unknown = 'Unknown',
-  WrappingFeeUpdateProposal = 'WrappingFeeUpdateProposal',
+  WrappingFeeUpdateProposal = 'WrappingFeeUpdateProposal'
 }
 
 /** A filter to be used against ProposalType fields. All fields are combined with a logical ‘and.’ */
@@ -5911,6 +5975,7 @@ export type ProposalVotesConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `ProposalVote` values. */
 export type ProposalVotesConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposalVotesGroupBy>;
@@ -5932,7 +5997,7 @@ export enum ProposalVotesGroupBy {
   BlockNumber = 'BLOCK_NUMBER',
   For = 'FOR',
   ProposalId = 'PROPOSAL_ID',
-  VoterId = 'VOTER_ID',
+  VoterId = 'VOTER_ID'
 }
 
 export type ProposalVotesHavingAverageInput = {
@@ -6002,7 +6067,7 @@ export enum ProposalVotesOrderBy {
   ProposalIdAsc = 'PROPOSAL_ID_ASC',
   ProposalIdDesc = 'PROPOSAL_ID_DESC',
   VoterIdAsc = 'VOTER_ID_ASC',
-  VoterIdDesc = 'VOTER_ID_DESC',
+  VoterIdDesc = 'VOTER_ID_DESC'
 }
 
 export type Proposer = Node & {
@@ -6025,6 +6090,7 @@ export type Proposer = Node & {
   sessionsBySessionProposerProposerIdAndSessionId: ProposerSessionsBySessionProposerProposerIdAndSessionIdManyToManyConnection;
 };
 
+
 export type ProposerBlocksByProposalVoteVoterIdAndBlockIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -6034,6 +6100,7 @@ export type ProposerBlocksByProposalVoteVoterIdAndBlockIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<BlocksOrderBy>>;
 };
+
 
 export type ProposerProposalItemsByProposalVoteVoterIdAndProposalIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -6045,6 +6112,7 @@ export type ProposerProposalItemsByProposalVoteVoterIdAndProposalIdArgs = {
   orderBy?: InputMaybe<Array<ProposalItemsOrderBy>>;
 };
 
+
 export type ProposerProposalVotesByVoterIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -6055,6 +6123,7 @@ export type ProposerProposalVotesByVoterIdArgs = {
   orderBy?: InputMaybe<Array<ProposalVotesOrderBy>>;
 };
 
+
 export type ProposerSessionProposersArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -6064,6 +6133,7 @@ export type ProposerSessionProposersArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<SessionProposersOrderBy>>;
 };
+
 
 export type ProposerSessionsBySessionProposerProposerIdAndSessionIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -6099,6 +6169,7 @@ export type ProposerBlocksByProposalVoteVoterIdAndBlockIdManyToManyConnection = 
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Block` values, with data from `ProposalVote`. */
 export type ProposerBlocksByProposalVoteVoterIdAndBlockIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<BlocksGroupBy>;
@@ -6115,6 +6186,7 @@ export type ProposerBlocksByProposalVoteVoterIdAndBlockIdManyToManyEdge = {
   /** Reads and enables pagination through a set of `ProposalVote`. */
   proposalVotes: ProposalVotesConnection;
 };
+
 
 /** A `Block` edge in the connection, with data from `ProposalVote`. */
 export type ProposerBlocksByProposalVoteVoterIdAndBlockIdManyToManyEdgeProposalVotesArgs = {
@@ -6166,6 +6238,7 @@ export type ProposerProposalItemsByProposalVoteVoterIdAndProposalIdManyToManyCon
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `ProposalItem` values, with data from `ProposalVote`. */
 export type ProposerProposalItemsByProposalVoteVoterIdAndProposalIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposalItemsGroupBy>;
@@ -6182,6 +6255,7 @@ export type ProposerProposalItemsByProposalVoteVoterIdAndProposalIdManyToManyEdg
   /** Reads and enables pagination through a set of `ProposalVote`. */
   proposalVotesByProposalId: ProposalVotesConnection;
 };
+
 
 /** A `ProposalItem` edge in the connection, with data from `ProposalVote`. */
 export type ProposerProposalItemsByProposalVoteVoterIdAndProposalIdManyToManyEdgeProposalVotesByProposalIdArgs = {
@@ -6211,6 +6285,7 @@ export type ProposerSessionsBySessionProposerProposerIdAndSessionIdManyToManyCon
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Session` values, with data from `SessionProposer`. */
 export type ProposerSessionsBySessionProposerProposerIdAndSessionIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<SessionsGroupBy>;
@@ -6227,6 +6302,7 @@ export type ProposerSessionsBySessionProposerProposerIdAndSessionIdManyToManyEdg
   /** Reads and enables pagination through a set of `SessionProposer`. */
   sessionProposers: SessionProposersConnection;
 };
+
 
 /** A `Session` edge in the connection, with data from `SessionProposer`. */
 export type ProposerSessionsBySessionProposerProposerIdAndSessionIdManyToManyEdgeSessionProposersArgs = {
@@ -6364,6 +6440,7 @@ export type ProposerThresholdsConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `ProposerThreshold` values. */
 export type ProposerThresholdsConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposerThresholdsGroupBy>;
@@ -6382,7 +6459,7 @@ export type ProposerThresholdsEdge = {
 /** Grouping methods for `ProposerThreshold` for usage during aggregation. */
 export enum ProposerThresholdsGroupBy {
   BlockId = 'BLOCK_ID',
-  Value = 'VALUE',
+  Value = 'VALUE'
 }
 
 export type ProposerThresholdsHavingAverageInput = {
@@ -6446,7 +6523,7 @@ export enum ProposerThresholdsOrderBy {
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
   ValueAsc = 'VALUE_ASC',
-  ValueDesc = 'VALUE_DESC',
+  ValueDesc = 'VALUE_DESC'
 }
 
 /** A connection to a list of `Proposer` values. */
@@ -6466,6 +6543,7 @@ export type ProposersConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Proposer` values. */
 export type ProposersConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposersGroupBy>;
@@ -6483,7 +6561,7 @@ export type ProposersEdge = {
 
 /** Grouping methods for `Proposer` for usage during aggregation. */
 export enum ProposersGroupBy {
-  AccountId = 'ACCOUNT_ID',
+  AccountId = 'ACCOUNT_ID'
 }
 
 /** Conditions for `Proposer` aggregates. */
@@ -6666,7 +6744,7 @@ export enum ProposersOrderBy {
   SessionProposersVarianceSampleProposerIdAsc = 'SESSION_PROPOSERS_VARIANCE_SAMPLE_PROPOSER_ID_ASC',
   SessionProposersVarianceSampleProposerIdDesc = 'SESSION_PROPOSERS_VARIANCE_SAMPLE_PROPOSER_ID_DESC',
   SessionProposersVarianceSampleSessionIdAsc = 'SESSION_PROPOSERS_VARIANCE_SAMPLE_SESSION_ID_ASC',
-  SessionProposersVarianceSampleSessionIdDesc = 'SESSION_PROPOSERS_VARIANCE_SAMPLE_SESSION_ID_DESC',
+  SessionProposersVarianceSampleSessionIdDesc = 'SESSION_PROPOSERS_VARIANCE_SAMPLE_SESSION_ID_DESC'
 }
 
 export type PublicKey = Node & {
@@ -6686,6 +6764,7 @@ export type PublicKey = Node & {
   uncompressed?: Maybe<Scalars['String']>;
 };
 
+
 export type PublicKeyBlocksBySessionPublicKeyIdAndBlockIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -6695,6 +6774,7 @@ export type PublicKeyBlocksBySessionPublicKeyIdAndBlockIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<BlocksOrderBy>>;
 };
+
 
 export type PublicKeySessionsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -6730,6 +6810,7 @@ export type PublicKeyBlocksBySessionPublicKeyIdAndBlockIdManyToManyConnection = 
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Block` values, with data from `Session`. */
 export type PublicKeyBlocksBySessionPublicKeyIdAndBlockIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<BlocksGroupBy>;
@@ -6746,6 +6827,7 @@ export type PublicKeyBlocksBySessionPublicKeyIdAndBlockIdManyToManyEdge = {
   /** Reads and enables pagination through a set of `Session`. */
   sessions: SessionsConnection;
 };
+
 
 /** A `Block` edge in the connection, with data from `Session`. */
 export type PublicKeyBlocksBySessionPublicKeyIdAndBlockIdManyToManyEdgeSessionsArgs = {
@@ -6809,6 +6891,7 @@ export type PublicKeysConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `PublicKey` values. */
 export type PublicKeysConnectionGroupedAggregatesArgs = {
   groupBy: Array<PublicKeysGroupBy>;
@@ -6828,7 +6911,7 @@ export type PublicKeysEdge = {
 export enum PublicKeysGroupBy {
   BlockId = 'BLOCK_ID',
   Compressed = 'COMPRESSED',
-  History = 'HISTORY',
+  History = 'HISTORY'
 }
 
 /** Conditions for `PublicKey` aggregates. */
@@ -6979,7 +7062,7 @@ export enum PublicKeysOrderBy {
   SessionsVarianceSampleSignatureThresholdAsc = 'SESSIONS_VARIANCE_SAMPLE_SIGNATURE_THRESHOLD_ASC',
   SessionsVarianceSampleSignatureThresholdDesc = 'SESSIONS_VARIANCE_SAMPLE_SIGNATURE_THRESHOLD_DESC',
   UncompressedAsc = 'UNCOMPRESSED_ASC',
-  UncompressedDesc = 'UNCOMPRESSED_DESC',
+  UncompressedDesc = 'UNCOMPRESSED_DESC'
 }
 
 /** The root query type which gives access points into the data universe. */
@@ -7097,15 +7180,18 @@ export type Query = Node & {
   validators?: Maybe<ValidatorsConnection>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryAccountArgs = {
   id: Scalars['String'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryAccountByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryAccountsArgs = {
@@ -7118,6 +7204,7 @@ export type QueryAccountsArgs = {
   orderBy?: InputMaybe<Array<AccountsOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryAuthoritiesArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -7129,25 +7216,30 @@ export type QueryAuthoritiesArgs = {
   orderBy?: InputMaybe<Array<AuthoritiesOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryAuthorityArgs = {
   id: Scalars['String'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryAuthorityByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryBlockArgs = {
   id: Scalars['String'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryBlockByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryBlocksArgs = {
@@ -7160,15 +7252,18 @@ export type QueryBlocksArgs = {
   orderBy?: InputMaybe<Array<BlocksOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryEventArgs = {
   id: Scalars['String'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryEventByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryEventsArgs = {
@@ -7181,15 +7276,18 @@ export type QueryEventsArgs = {
   orderBy?: InputMaybe<Array<EventsOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryExtrinsicArgs = {
   id: Scalars['String'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryExtrinsicByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryExtrinsicsArgs = {
@@ -7202,15 +7300,18 @@ export type QueryExtrinsicsArgs = {
   orderBy?: InputMaybe<Array<ExtrinsicsOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryKeygenThresholdArgs = {
   id: Scalars['String'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryKeygenThresholdByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryKeygenThresholdsArgs = {
@@ -7223,20 +7324,24 @@ export type QueryKeygenThresholdsArgs = {
   orderBy?: InputMaybe<Array<KeygenThresholdsOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryNodeArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalCounterArgs = {
   id: Scalars['String'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalCounterByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalCountersArgs = {
@@ -7249,15 +7354,18 @@ export type QueryProposalCountersArgs = {
   orderBy?: InputMaybe<Array<ProposalCountersOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalItemArgs = {
   id: Scalars['String'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalItemByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalItemsArgs = {
@@ -7270,15 +7378,18 @@ export type QueryProposalItemsArgs = {
   orderBy?: InputMaybe<Array<ProposalItemsOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalTimelineStatusArgs = {
   id: Scalars['String'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalTimelineStatusByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalTimelineStatusesArgs = {
@@ -7291,15 +7402,18 @@ export type QueryProposalTimelineStatusesArgs = {
   orderBy?: InputMaybe<Array<ProposalTimelineStatusesOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalVoteArgs = {
   id: Scalars['String'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalVoteByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalVotesArgs = {
@@ -7312,25 +7426,30 @@ export type QueryProposalVotesArgs = {
   orderBy?: InputMaybe<Array<ProposalVotesOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryProposerArgs = {
   id: Scalars['String'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryProposerByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryProposerThresholdArgs = {
   id: Scalars['String'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryProposerThresholdByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryProposerThresholdsArgs = {
@@ -7343,6 +7462,7 @@ export type QueryProposerThresholdsArgs = {
   orderBy?: InputMaybe<Array<ProposerThresholdsOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryProposersArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -7354,15 +7474,18 @@ export type QueryProposersArgs = {
   orderBy?: InputMaybe<Array<ProposersOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryPublicKeyArgs = {
   id: Scalars['String'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryPublicKeyByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryPublicKeysArgs = {
@@ -7375,25 +7498,30 @@ export type QueryPublicKeysArgs = {
   orderBy?: InputMaybe<Array<PublicKeysOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionArgs = {
   id: Scalars['String'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionProposerArgs = {
   id: Scalars['String'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionProposerByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionProposersArgs = {
@@ -7406,15 +7534,18 @@ export type QuerySessionProposersArgs = {
   orderBy?: InputMaybe<Array<SessionProposersOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionValidatorArgs = {
   id: Scalars['String'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionValidatorByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionValidatorsArgs = {
@@ -7427,6 +7558,7 @@ export type QuerySessionValidatorsArgs = {
   orderBy?: InputMaybe<Array<SessionValidatorsOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -7438,15 +7570,18 @@ export type QuerySessionsArgs = {
   orderBy?: InputMaybe<Array<SessionsOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QuerySignatureThresholdArgs = {
   id: Scalars['String'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QuerySignatureThresholdByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QuerySignatureThresholdsArgs = {
@@ -7459,25 +7594,30 @@ export type QuerySignatureThresholdsArgs = {
   orderBy?: InputMaybe<Array<SignatureThresholdsOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryUnsignedProposalsQueueArgs = {
   id: Scalars['String'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryUnsignedProposalsQueueByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryUnsignedProposalsQueueItemArgs = {
   id: Scalars['String'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryUnsignedProposalsQueueItemByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryUnsignedProposalsQueueItemsArgs = {
@@ -7490,6 +7630,7 @@ export type QueryUnsignedProposalsQueueItemsArgs = {
   orderBy?: InputMaybe<Array<UnsignedProposalsQueueItemsOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryUnsignedProposalsQueuesArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -7501,15 +7642,18 @@ export type QueryUnsignedProposalsQueuesArgs = {
   orderBy?: InputMaybe<Array<UnsignedProposalsQueuesOrderBy>>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryValidatorArgs = {
   id: Scalars['String'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryValidatorByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryValidatorsArgs = {
@@ -7547,6 +7691,7 @@ export type Session = Node & {
   validatorsBySessionValidatorSessionIdAndValidatorId: SessionValidatorsBySessionValidatorSessionIdAndValidatorIdManyToManyConnection;
 };
 
+
 export type SessionProposersBySessionProposerSessionIdAndProposerIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -7556,6 +7701,7 @@ export type SessionProposersBySessionProposerSessionIdAndProposerIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ProposersOrderBy>>;
 };
+
 
 export type SessionSessionProposersArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -7567,6 +7713,7 @@ export type SessionSessionProposersArgs = {
   orderBy?: InputMaybe<Array<SessionProposersOrderBy>>;
 };
 
+
 export type SessionSessionValidatorsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -7576,6 +7723,7 @@ export type SessionSessionValidatorsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<SessionValidatorsOrderBy>>;
 };
+
 
 export type SessionValidatorsBySessionValidatorSessionIdAndValidatorIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -7733,6 +7881,7 @@ export type SessionProposersBySessionProposerSessionIdAndProposerIdManyToManyCon
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Proposer` values, with data from `SessionProposer`. */
 export type SessionProposersBySessionProposerSessionIdAndProposerIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposersGroupBy>;
@@ -7749,6 +7898,7 @@ export type SessionProposersBySessionProposerSessionIdAndProposerIdManyToManyEdg
   /** Reads and enables pagination through a set of `SessionProposer`. */
   sessionProposers: SessionProposersConnection;
 };
+
 
 /** A `Proposer` edge in the connection, with data from `SessionProposer`. */
 export type SessionProposersBySessionProposerSessionIdAndProposerIdManyToManyEdgeSessionProposersArgs = {
@@ -7778,6 +7928,7 @@ export type SessionProposersConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `SessionProposer` values. */
 export type SessionProposersConnectionGroupedAggregatesArgs = {
   groupBy: Array<SessionProposersGroupBy>;
@@ -7796,7 +7947,7 @@ export type SessionProposersEdge = {
 /** Grouping methods for `SessionProposer` for usage during aggregation. */
 export enum SessionProposersGroupBy {
   ProposerId = 'PROPOSER_ID',
-  SessionId = 'SESSION_ID',
+  SessionId = 'SESSION_ID'
 }
 
 /** Conditions for `SessionProposer` aggregates. */
@@ -7815,7 +7966,7 @@ export enum SessionProposersOrderBy {
   ProposerIdAsc = 'PROPOSER_ID_ASC',
   ProposerIdDesc = 'PROPOSER_ID_DESC',
   SessionIdAsc = 'SESSION_ID_ASC',
-  SessionIdDesc = 'SESSION_ID_DESC',
+  SessionIdDesc = 'SESSION_ID_DESC'
 }
 
 export type SessionStddevPopulationAggregates = {
@@ -8009,6 +8160,7 @@ export type SessionValidatorsBySessionValidatorSessionIdAndValidatorIdManyToMany
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Validator` values, with data from `SessionValidator`. */
 export type SessionValidatorsBySessionValidatorSessionIdAndValidatorIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<ValidatorsGroupBy>;
@@ -8025,6 +8177,7 @@ export type SessionValidatorsBySessionValidatorSessionIdAndValidatorIdManyToMany
   /** Reads and enables pagination through a set of `SessionValidator`. */
   sessionValidators: SessionValidatorsConnection;
 };
+
 
 /** A `Validator` edge in the connection, with data from `SessionValidator`. */
 export type SessionValidatorsBySessionValidatorSessionIdAndValidatorIdManyToManyEdgeSessionValidatorsArgs = {
@@ -8054,6 +8207,7 @@ export type SessionValidatorsConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `SessionValidator` values. */
 export type SessionValidatorsConnectionGroupedAggregatesArgs = {
   groupBy: Array<SessionValidatorsGroupBy>;
@@ -8078,7 +8232,7 @@ export enum SessionValidatorsGroupBy {
   NextBestOrder = 'NEXT_BEST_ORDER',
   Reputation = 'REPUTATION',
   SessionId = 'SESSION_ID',
-  ValidatorId = 'VALIDATOR_ID',
+  ValidatorId = 'VALIDATOR_ID'
 }
 
 export type SessionValidatorsHavingAverageInput = {
@@ -8163,7 +8317,7 @@ export enum SessionValidatorsOrderBy {
   SessionIdAsc = 'SESSION_ID_ASC',
   SessionIdDesc = 'SESSION_ID_DESC',
   ValidatorIdAsc = 'VALIDATOR_ID_ASC',
-  ValidatorIdDesc = 'VALIDATOR_ID_DESC',
+  ValidatorIdDesc = 'VALIDATOR_ID_DESC'
 }
 
 export type SessionVariancePopulationAggregates = {
@@ -8195,6 +8349,7 @@ export type SessionsConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Session` values. */
 export type SessionsConnectionGroupedAggregatesArgs = {
   groupBy: Array<SessionsGroupBy>;
@@ -8217,7 +8372,7 @@ export enum SessionsGroupBy {
   KeyGenThreshold = 'KEY_GEN_THRESHOLD',
   ProposerThreshold = 'PROPOSER_THRESHOLD',
   PublicKeyId = 'PUBLIC_KEY_ID',
-  SignatureThreshold = 'SIGNATURE_THRESHOLD',
+  SignatureThreshold = 'SIGNATURE_THRESHOLD'
 }
 
 export type SessionsHavingAverageInput = {
@@ -8509,7 +8664,7 @@ export enum SessionsOrderBy {
   SessionValidatorsVarianceSampleValidatorIdAsc = 'SESSION_VALIDATORS_VARIANCE_SAMPLE_VALIDATOR_ID_ASC',
   SessionValidatorsVarianceSampleValidatorIdDesc = 'SESSION_VALIDATORS_VARIANCE_SAMPLE_VALIDATOR_ID_DESC',
   SignatureThresholdAsc = 'SIGNATURE_THRESHOLD_ASC',
-  SignatureThresholdDesc = 'SIGNATURE_THRESHOLD_DESC',
+  SignatureThresholdDesc = 'SIGNATURE_THRESHOLD_DESC'
 }
 
 export type SignatureThreshold = Node & {
@@ -8679,6 +8834,7 @@ export type SignatureThresholdsConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `SignatureThreshold` values. */
 export type SignatureThresholdsConnectionGroupedAggregatesArgs = {
   groupBy: Array<SignatureThresholdsGroupBy>;
@@ -8699,7 +8855,7 @@ export enum SignatureThresholdsGroupBy {
   BlockId = 'BLOCK_ID',
   Current = 'CURRENT',
   Next = 'NEXT',
-  Pending = 'PENDING',
+  Pending = 'PENDING'
 }
 
 export type SignatureThresholdsHavingAverageInput = {
@@ -8785,7 +8941,7 @@ export enum SignatureThresholdsOrderBy {
   PendingAsc = 'PENDING_ASC',
   PendingDesc = 'PENDING_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
 
 /** A filter to be used against String fields. All fields are combined with a logical ‘and.’ */
@@ -8887,6 +9043,7 @@ export type UnsignedProposalsQueue = Node & {
   unsignedProposalsQueueItemsByQueueId: UnsignedProposalsQueueItemsConnection;
 };
 
+
 export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueueIdAndProposalIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -8896,6 +9053,7 @@ export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueue
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ProposalItemsOrderBy>>;
 };
+
 
 export type UnsignedProposalsQueueUnsignedProposalsQueueItemsByQueueIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -9094,6 +9252,7 @@ export type UnsignedProposalsQueueItemsConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `UnsignedProposalsQueueItem` values. */
 export type UnsignedProposalsQueueItemsConnectionGroupedAggregatesArgs = {
   groupBy: Array<UnsignedProposalsQueueItemsGroupBy>;
@@ -9113,7 +9272,7 @@ export type UnsignedProposalsQueueItemsEdge = {
 export enum UnsignedProposalsQueueItemsGroupBy {
   BlockNumber = 'BLOCK_NUMBER',
   ProposalId = 'PROPOSAL_ID',
-  QueueId = 'QUEUE_ID',
+  QueueId = 'QUEUE_ID'
 }
 
 export type UnsignedProposalsQueueItemsHavingAverageInput = {
@@ -9179,7 +9338,7 @@ export enum UnsignedProposalsQueueItemsOrderBy {
   ProposalIdAsc = 'PROPOSAL_ID_ASC',
   ProposalIdDesc = 'PROPOSAL_ID_DESC',
   QueueIdAsc = 'QUEUE_ID_ASC',
-  QueueIdDesc = 'QUEUE_ID_DESC',
+  QueueIdDesc = 'QUEUE_ID_DESC'
 }
 
 export type UnsignedProposalsQueueMaxAggregates = {
@@ -9211,12 +9370,12 @@ export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueue
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `ProposalItem` values, with data from `UnsignedProposalsQueueItem`. */
-export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueueIdAndProposalIdManyToManyConnectionGroupedAggregatesArgs =
-  {
-    groupBy: Array<ProposalItemsGroupBy>;
-    having?: InputMaybe<ProposalItemsHavingInput>;
-  };
+export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueueIdAndProposalIdManyToManyConnectionGroupedAggregatesArgs = {
+  groupBy: Array<ProposalItemsGroupBy>;
+  having?: InputMaybe<ProposalItemsHavingInput>;
+};
 
 /** A `ProposalItem` edge in the connection, with data from `UnsignedProposalsQueueItem`. */
 export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueueIdAndProposalIdManyToManyEdge = {
@@ -9229,17 +9388,17 @@ export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueue
   unsignedProposalsQueueItemsByProposalId: UnsignedProposalsQueueItemsConnection;
 };
 
+
 /** A `ProposalItem` edge in the connection, with data from `UnsignedProposalsQueueItem`. */
-export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueueIdAndProposalIdManyToManyEdgeUnsignedProposalsQueueItemsByProposalIdArgs =
-  {
-    after?: InputMaybe<Scalars['Cursor']>;
-    before?: InputMaybe<Scalars['Cursor']>;
-    filter?: InputMaybe<UnsignedProposalsQueueItemFilter>;
-    first?: InputMaybe<Scalars['Int']>;
-    last?: InputMaybe<Scalars['Int']>;
-    offset?: InputMaybe<Scalars['Int']>;
-    orderBy?: InputMaybe<Array<UnsignedProposalsQueueItemsOrderBy>>;
-  };
+export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueueIdAndProposalIdManyToManyEdgeUnsignedProposalsQueueItemsByProposalIdArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  filter?: InputMaybe<UnsignedProposalsQueueItemFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<UnsignedProposalsQueueItemsOrderBy>>;
+};
 
 export type UnsignedProposalsQueueStddevPopulationAggregates = {
   __typename?: 'UnsignedProposalsQueueStddevPopulationAggregates';
@@ -9288,6 +9447,7 @@ export type UnsignedProposalsQueuesConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `UnsignedProposalsQueue` values. */
 export type UnsignedProposalsQueuesConnectionGroupedAggregatesArgs = {
   groupBy: Array<UnsignedProposalsQueuesGroupBy>;
@@ -9306,7 +9466,7 @@ export type UnsignedProposalsQueuesEdge = {
 /** Grouping methods for `UnsignedProposalsQueue` for usage during aggregation. */
 export enum UnsignedProposalsQueuesGroupBy {
   BlockId = 'BLOCK_ID',
-  BlockNumber = 'BLOCK_NUMBER',
+  BlockNumber = 'BLOCK_NUMBER'
 }
 
 export type UnsignedProposalsQueuesHavingAverageInput = {
@@ -9444,7 +9604,7 @@ export enum UnsignedProposalsQueuesOrderBy {
   UnsignedProposalsQueueItemsByQueueIdVarianceSampleProposalIdAsc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_QUEUE_ID_VARIANCE_SAMPLE_PROPOSAL_ID_ASC',
   UnsignedProposalsQueueItemsByQueueIdVarianceSampleProposalIdDesc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_QUEUE_ID_VARIANCE_SAMPLE_PROPOSAL_ID_DESC',
   UnsignedProposalsQueueItemsByQueueIdVarianceSampleQueueIdAsc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_QUEUE_ID_VARIANCE_SAMPLE_QUEUE_ID_ASC',
-  UnsignedProposalsQueueItemsByQueueIdVarianceSampleQueueIdDesc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_QUEUE_ID_VARIANCE_SAMPLE_QUEUE_ID_DESC',
+  UnsignedProposalsQueueItemsByQueueIdVarianceSampleQueueIdDesc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_QUEUE_ID_VARIANCE_SAMPLE_QUEUE_ID_DESC'
 }
 
 export type Validator = Node & {
@@ -9462,6 +9622,7 @@ export type Validator = Node & {
   sessionsBySessionValidatorValidatorIdAndSessionId: ValidatorSessionsBySessionValidatorValidatorIdAndSessionIdManyToManyConnection;
 };
 
+
 export type ValidatorSessionValidatorsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -9471,6 +9632,7 @@ export type ValidatorSessionValidatorsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<SessionValidatorsOrderBy>>;
 };
+
 
 export type ValidatorSessionsBySessionValidatorValidatorIdAndSessionIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -9532,6 +9694,7 @@ export type ValidatorSessionsBySessionValidatorValidatorIdAndSessionIdManyToMany
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Session` values, with data from `SessionValidator`. */
 export type ValidatorSessionsBySessionValidatorValidatorIdAndSessionIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<SessionsGroupBy>;
@@ -9548,6 +9711,7 @@ export type ValidatorSessionsBySessionValidatorValidatorIdAndSessionIdManyToMany
   /** Reads and enables pagination through a set of `SessionValidator`. */
   sessionValidators: SessionValidatorsConnection;
 };
+
 
 /** A `Session` edge in the connection, with data from `SessionValidator`. */
 export type ValidatorSessionsBySessionValidatorValidatorIdAndSessionIdManyToManyEdgeSessionValidatorsArgs = {
@@ -9577,6 +9741,7 @@ export type ValidatorsConnection = {
   totalCount: Scalars['Int'];
 };
 
+
 /** A connection to a list of `Validator` values. */
 export type ValidatorsConnectionGroupedAggregatesArgs = {
   groupBy: Array<ValidatorsGroupBy>;
@@ -9594,7 +9759,7 @@ export type ValidatorsEdge = {
 
 /** Grouping methods for `Validator` for usage during aggregation. */
 export enum ValidatorsGroupBy {
-  AccountId = 'ACCOUNT_ID',
+  AccountId = 'ACCOUNT_ID'
 }
 
 /** Conditions for `Validator` aggregates. */
@@ -9777,7 +9942,7 @@ export enum ValidatorsOrderBy {
   SessionValidatorsVarianceSampleSessionIdAsc = 'SESSION_VALIDATORS_VARIANCE_SAMPLE_SESSION_ID_ASC',
   SessionValidatorsVarianceSampleSessionIdDesc = 'SESSION_VALIDATORS_VARIANCE_SAMPLE_SESSION_ID_DESC',
   SessionValidatorsVarianceSampleValidatorIdAsc = 'SESSION_VALIDATORS_VARIANCE_SAMPLE_VALIDATOR_ID_ASC',
-  SessionValidatorsVarianceSampleValidatorIdDesc = 'SESSION_VALIDATORS_VARIANCE_SAMPLE_VALIDATOR_ID_DESC',
+  SessionValidatorsVarianceSampleValidatorIdDesc = 'SESSION_VALIDATORS_VARIANCE_SAMPLE_VALIDATOR_ID_DESC'
 }
 
 export type _Metadata = {
@@ -9801,43 +9966,8 @@ export type ValidatorListingQueryVariables = Exact<{
   offset: Scalars['Int'];
 }>;
 
-export type ValidatorListingQuery = {
-  __typename?: 'Query';
-  validators?: {
-    __typename?: 'ValidatorsConnection';
-    totalCount: number;
-    nodes: Array<{
-      __typename?: 'Validator';
-      authorityId: string;
-      id: string;
-      sessionValidators: {
-        __typename?: 'SessionValidatorsConnection';
-        edges: Array<{
-          __typename?: 'SessionValidatorsEdge';
-          node?: {
-            __typename?: 'SessionValidator';
-            id: string;
-            sessionId: string;
-            reputation: string;
-            isBest: boolean;
-            isNext: boolean;
-            isNextBest: boolean;
-            bestOrder: number;
-            nextBestOrder: number;
-            validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
-          } | null;
-        }>;
-      };
-    } | null>;
-    pageInfo: {
-      __typename?: 'PageInfo';
-      endCursor?: any | null;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      startCursor?: any | null;
-    };
-  } | null;
-};
+
+export type ValidatorListingQuery = { __typename?: 'Query', validators?: { __typename?: 'ValidatorsConnection', totalCount: number, nodes: Array<{ __typename?: 'Validator', authorityId: string, id: string, sessionValidators: { __typename?: 'SessionValidatorsConnection', edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> } } | null>, pageInfo: { __typename?: 'PageInfo', endCursor?: any | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: any | null } } | null };
 
 export type ValidatorSessionsQueryVariables = Exact<{
   keyGen?: InputMaybe<Scalars['Boolean']>;
@@ -9846,249 +9976,55 @@ export type ValidatorSessionsQueryVariables = Exact<{
   offset: Scalars['Int'];
 }>;
 
-export type ValidatorSessionsQuery = {
-  __typename?: 'Query';
-  sessionValidators?: {
-    __typename?: 'SessionValidatorsConnection';
-    totalCount: number;
-    nodes: Array<{
-      __typename?: 'SessionValidator';
-      validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
-      session?: {
-        __typename?: 'Session';
-        id: string;
-        publicKey?: {
-          __typename?: 'PublicKey';
-          id: string;
-          compressed?: string | null;
-          uncompressed?: string | null;
-        } | null;
-        sessionValidators: {
-          __typename?: 'SessionValidatorsConnection';
-          totalCount: number;
-          edges: Array<{
-            __typename?: 'SessionValidatorsEdge';
-            node?: {
-              __typename?: 'SessionValidator';
-              id: string;
-              sessionId: string;
-              reputation: string;
-              isBest: boolean;
-              isNext: boolean;
-              isNextBest: boolean;
-              bestOrder: number;
-              nextBestOrder: number;
-              validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
-            } | null;
-          }>;
-        };
-      } | null;
-    } | null>;
-    pageInfo: {
-      __typename?: 'PageInfo';
-      endCursor?: any | null;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      startCursor?: any | null;
-    };
-  } | null;
-};
+
+export type ValidatorSessionsQuery = { __typename?: 'Query', sessionValidators?: { __typename?: 'SessionValidatorsConnection', totalCount: number, nodes: Array<{ __typename?: 'SessionValidator', validator?: { __typename?: 'Validator', authorityId: string, id: string } | null, session?: { __typename?: 'Session', id: string, publicKey?: { __typename?: 'PublicKey', id: string, compressed?: string | null, uncompressed?: string | null } | null, sessionValidators: { __typename?: 'SessionValidatorsConnection', totalCount: number, edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> } } | null } | null>, pageInfo: { __typename?: 'PageInfo', endCursor?: any | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: any | null } } | null };
 
 export type ValidatorOfSessionQueryVariables = Exact<{
   validatorId: Scalars['String'];
   sessionValidatorId: Scalars['String'];
 }>;
 
-export type ValidatorOfSessionQuery = {
-  __typename?: 'Query';
-  sessionValidator?: {
-    __typename?: 'SessionValidator';
-    id: string;
-    sessionId: string;
-    reputation: string;
-    isBest: boolean;
-    isNext: boolean;
-    isNextBest: boolean;
-    bestOrder: number;
-    nextBestOrder: number;
-    session?: { __typename?: 'Session'; keyGenThreshold?: any | null } | null;
-    validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
-  } | null;
-  sessionValidators?: {
-    __typename?: 'SessionValidatorsConnection';
-    aggregates?: {
-      __typename?: 'SessionValidatorAggregates';
-      distinctCount?: { __typename?: 'SessionValidatorDistinctCountAggregates'; id?: any | null } | null;
-    } | null;
-  } | null;
-};
 
-export type ValidatorMetaFragment = { __typename?: 'Validator'; authorityId: string; id: string };
+export type ValidatorOfSessionQuery = { __typename?: 'Query', sessionValidator?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, session?: { __typename?: 'Session', keyGenThreshold?: any | null } | null, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null, sessionValidators?: { __typename?: 'SessionValidatorsConnection', aggregates?: { __typename?: 'SessionValidatorAggregates', distinctCount?: { __typename?: 'SessionValidatorDistinctCountAggregates', id?: any | null } | null } | null } | null };
 
-export type PageInfoMetaFragment = {
-  __typename?: 'PageInfo';
-  endCursor?: any | null;
-  hasNextPage: boolean;
-  hasPreviousPage: boolean;
-  startCursor?: any | null;
-};
+export type ValidatorMetaFragment = { __typename?: 'Validator', authorityId: string, id: string };
 
-export type SessionAuthValidatorNodeFragment = {
-  __typename?: 'SessionValidator';
-  id: string;
-  sessionId: string;
-  reputation: string;
-  isBest: boolean;
-  isNext: boolean;
-  isNextBest: boolean;
-  bestOrder: number;
-  nextBestOrder: number;
-  validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
-};
+export type PageInfoMetaFragment = { __typename?: 'PageInfo', endCursor?: any | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: any | null };
 
-export type SessionAuthValidatorFragment = {
-  __typename?: 'SessionValidatorsConnection';
-  edges: Array<{
-    __typename?: 'SessionValidatorsEdge';
-    node?: {
-      __typename?: 'SessionValidator';
-      id: string;
-      sessionId: string;
-      reputation: string;
-      isBest: boolean;
-      isNext: boolean;
-      isNextBest: boolean;
-      bestOrder: number;
-      nextBestOrder: number;
-      validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
-    } | null;
-  }>;
-};
+export type SessionAuthValidatorNodeFragment = { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null };
 
-export type SessionAuthFragment = {
-  __typename?: 'Session';
-  sessionValidators: {
-    __typename?: 'SessionValidatorsConnection';
-    edges: Array<{
-      __typename?: 'SessionValidatorsEdge';
-      node?: {
-        __typename?: 'SessionValidator';
-        id: string;
-        sessionId: string;
-        reputation: string;
-        isBest: boolean;
-        isNext: boolean;
-        isNextBest: boolean;
-        bestOrder: number;
-        nextBestOrder: number;
-        validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
-      } | null;
-    }>;
-  };
-};
+export type SessionAuthValidatorFragment = { __typename?: 'SessionValidatorsConnection', edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> };
 
-export type MetaDataQueryVariables = Exact<{ [key: string]: never }>;
+export type SessionAuthFragment = { __typename?: 'Session', sessionValidators: { __typename?: 'SessionValidatorsConnection', edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> } };
 
-export type MetaDataQuery = {
-  __typename?: 'Query';
-  _metadata?: { __typename?: '_Metadata'; targetHeight?: number | null; lastProcessedHeight?: number | null } | null;
-};
+export type ProposalListViewFragment = { __typename?: 'ProposalItem', id: string, data: string, signature?: string | null, type: ProposalType, status: string, proposalVotesByProposalId: { __typename?: 'ProposalVotesConnection', totalCount: number, nodes: Array<{ __typename?: 'ProposalVote', id: string, voterId: string, voter?: { __typename?: 'Proposer', id: string } | null } | null> }, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null };
 
-export type ProposalCounterQueryVariables = Exact<{ [key: string]: never }>;
+export type ProposalsVoteListViewFragment = { __typename?: 'ProposalVote', id: string, voterId: string, for: boolean, txHash: string, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null };
 
-export type ProposalCounterQuery = {
-  __typename?: 'Query';
-  proposalCounters?: {
-    __typename?: 'ProposalCountersConnection';
-    nodes: Array<{
-      __typename?: 'ProposalCounter';
-      id: string;
-      blockNumber: number;
-      unSignedProposalsCount: number;
-      signedProposalsCount: number;
-      statusMap?: any | null;
-      unSignedProposalsMap?: any | null;
-      signedProposalsMap?: any | null;
-    } | null>;
-  } | null;
-};
+export type MetaDataQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type MetaDataQuery = { __typename?: 'Query', _metadata?: { __typename?: '_Metadata', targetHeight?: number | null, lastProcessedHeight?: number | null } | null };
+
+export type ProposalCounterQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type ProposalCounterQuery = { __typename?: 'Query', proposalCounters?: { __typename?: 'ProposalCountersConnection', nodes: Array<{ __typename?: 'ProposalCounter', id: string, blockNumber: number, unSignedProposalsCount: number, signedProposalsCount: number, statusMap?: any | null, unSignedProposalsMap?: any | null, signedProposalsMap?: any | null } | null> } | null };
 
 export type ProposalsQueryVariables = Exact<{
   perPage: Scalars['Int'];
   offset: Scalars['Int'];
 }>;
 
-export type ProposalsQuery = {
-  __typename?: 'Query';
-  proposalItems?: {
-    __typename?: 'ProposalItemsConnection';
-    totalCount: number;
-    nodes: Array<{
-      __typename?: 'ProposalItem';
-      id: string;
-      data: string;
-      signature?: string | null;
-      type: ProposalType;
-      status: string;
-      proposalVotesByProposalId: {
-        __typename?: 'ProposalVotesConnection';
-        totalCount: number;
-        nodes: Array<{
-          __typename?: 'ProposalVote';
-          id: string;
-          voterId: string;
-          voter?: { __typename?: 'Proposer'; id: string } | null;
-        } | null>;
-      };
-      block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
-    } | null>;
-    pageInfo: {
-      __typename?: 'PageInfo';
-      endCursor?: any | null;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      startCursor?: any | null;
-    };
-  } | null;
-};
+
+export type ProposalsQuery = { __typename?: 'Query', proposalItems?: { __typename?: 'ProposalItemsConnection', totalCount: number, nodes: Array<{ __typename?: 'ProposalItem', id: string, data: string, signature?: string | null, type: ProposalType, status: string, proposalVotesByProposalId: { __typename?: 'ProposalVotesConnection', totalCount: number, nodes: Array<{ __typename?: 'ProposalVote', id: string, voterId: string, voter?: { __typename?: 'Proposer', id: string } | null } | null> }, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null } | null>, pageInfo: { __typename?: 'PageInfo', endCursor?: any | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: any | null } } | null };
 
 export type ProposalsCounterQueryVariables = Exact<{
   id: Scalars['String'];
 }>;
 
-export type ProposalsCounterQuery = {
-  __typename?: 'Query';
-  proposalCounter?: {
-    __typename?: 'ProposalCounter';
-    id: string;
-    signedProposalsMap?: any | null;
-    unSignedProposalsMap?: any | null;
-    signedProposalsCount: number;
-    unSignedProposalsCount: number;
-    statusMap?: any | null;
-    block?: { __typename?: 'Block'; number: any; timestamp?: any | null } | null;
-  } | null;
-};
 
-export type ProposalListViewFragment = {
-  __typename?: 'ProposalItem';
-  id: string;
-  data: string;
-  signature?: string | null;
-  type: ProposalType;
-  status: string;
-  proposalVotesByProposalId: {
-    __typename?: 'ProposalVotesConnection';
-    totalCount: number;
-    nodes: Array<{
-      __typename?: 'ProposalVote';
-      id: string;
-      voterId: string;
-      voter?: { __typename?: 'Proposer'; id: string } | null;
-    } | null>;
-  };
-  block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
-};
+export type ProposalsCounterQuery = { __typename?: 'Query', proposalCounter?: { __typename?: 'ProposalCounter', id: string, signedProposalsMap?: any | null, unSignedProposalsMap?: any | null, signedProposalsCount: number, unSignedProposalsCount: number, statusMap?: any | null, block?: { __typename?: 'Block', number: any, timestamp?: any | null } | null } | null };
 
 export type ProposalsOverviewQueryVariables = Exact<{
   startRange: BigFloatFilter;
@@ -10096,59 +10032,8 @@ export type ProposalsOverviewQueryVariables = Exact<{
   sessionId: Scalars['String'];
 }>;
 
-export type ProposalsOverviewQuery = {
-  __typename?: 'Query';
-  session?: {
-    __typename?: 'Session';
-    id: string;
-    proposerThreshold?: any | null;
-    sessionProposers: { __typename?: 'SessionProposersConnection'; totalCount: number };
-    sessionValidators: { __typename?: 'SessionValidatorsConnection'; totalCount: number };
-  } | null;
-  openProposals?: {
-    __typename?: 'ProposalItemsConnection';
-    totalCount: number;
-    nodes: Array<{
-      __typename?: 'ProposalItem';
-      id: string;
-      data: string;
-      signature?: string | null;
-      type: ProposalType;
-      status: string;
-      proposalVotesByProposalId: {
-        __typename?: 'ProposalVotesConnection';
-        totalCount: number;
-        nodes: Array<{
-          __typename?: 'ProposalVote';
-          id: string;
-          voterId: string;
-          voter?: { __typename?: 'Proposer'; id: string } | null;
-        } | null>;
-      };
-      block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
-    } | null>;
-    pageInfo: {
-      __typename?: 'PageInfo';
-      endCursor?: any | null;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      startCursor?: any | null;
-    };
-  } | null;
-  open?: { __typename?: 'ProposalTimelineStatusesConnection'; totalCount: number } | null;
-  signed?: { __typename?: 'ProposalTimelineStatusesConnection'; totalCount: number } | null;
-  reject?: { __typename?: 'ProposalTimelineStatusesConnection'; totalCount: number } | null;
-  accepted?: { __typename?: 'ProposalTimelineStatusesConnection'; totalCount: number } | null;
-};
 
-export type ProposalsVoteListViewFragment = {
-  __typename?: 'ProposalVote';
-  id: string;
-  voterId: string;
-  for: boolean;
-  txHash: string;
-  block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
-};
+export type ProposalsOverviewQuery = { __typename?: 'Query', session?: { __typename?: 'Session', id: string, proposerThreshold?: any | null, sessionProposers: { __typename?: 'SessionProposersConnection', totalCount: number }, sessionValidators: { __typename?: 'SessionValidatorsConnection', totalCount: number } } | null, openProposals?: { __typename?: 'ProposalItemsConnection', totalCount: number, nodes: Array<{ __typename?: 'ProposalItem', id: string, data: string, signature?: string | null, type: ProposalType, status: string, proposalVotesByProposalId: { __typename?: 'ProposalVotesConnection', totalCount: number, nodes: Array<{ __typename?: 'ProposalVote', id: string, voterId: string, voter?: { __typename?: 'Proposer', id: string } | null } | null> }, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null } | null>, pageInfo: { __typename?: 'PageInfo', endCursor?: any | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: any | null } } | null, open?: { __typename?: 'ProposalTimelineStatusesConnection', totalCount: number } | null, signed?: { __typename?: 'ProposalTimelineStatusesConnection', totalCount: number } | null, reject?: { __typename?: 'ProposalTimelineStatusesConnection', totalCount: number } | null, accepted?: { __typename?: 'ProposalTimelineStatusesConnection', totalCount: number } | null };
 
 export type ProposalVotesQueryVariables = Exact<{
   perPage: Scalars['Int'];
@@ -10157,408 +10042,164 @@ export type ProposalVotesQueryVariables = Exact<{
   for?: InputMaybe<BooleanFilter>;
 }>;
 
-export type ProposalVotesQuery = {
-  __typename?: 'Query';
-  proposalVotes?: {
-    __typename?: 'ProposalVotesConnection';
-    totalCount: number;
-    nodes: Array<{
-      __typename?: 'ProposalVote';
-      id: string;
-      voterId: string;
-      for: boolean;
-      txHash: string;
-      block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
-    } | null>;
-    pageInfo: {
-      __typename?: 'PageInfo';
-      endCursor?: any | null;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      startCursor?: any | null;
-    };
-  } | null;
-};
+
+export type ProposalVotesQuery = { __typename?: 'Query', proposalVotes?: { __typename?: 'ProposalVotesConnection', totalCount: number, nodes: Array<{ __typename?: 'ProposalVote', id: string, voterId: string, for: boolean, txHash: string, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null } | null>, pageInfo: { __typename?: 'PageInfo', endCursor?: any | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: any | null } } | null };
 
 export type ProposalDetailsQueryVariables = Exact<{
   id: Scalars['String'];
   targetSessionId: Scalars['String'];
 }>;
 
-export type ProposalDetailsQuery = {
-  __typename?: 'Query';
-  session?: {
-    __typename?: 'Session';
-    id: string;
-    sessionProposers: { __typename?: 'SessionProposersConnection'; totalCount: number };
-  } | null;
-  proposalItem?: {
-    __typename?: 'ProposalItem';
-    id: string;
-    data: string;
-    signature?: string | null;
-    type: ProposalType;
-    status: string;
-    proposalTimelineStatuses: {
-      __typename?: 'ProposalTimelineStatusesConnection';
-      nodes: Array<{
-        __typename?: 'ProposalTimelineStatus';
-        id: string;
-        status: ProposalStatus;
-        blockNumber: any;
-        timestamp: any;
-      } | null>;
-    };
-    votesFor: { __typename?: 'ProposalVotesConnection'; totalCount: number };
-    totalVotes: { __typename?: 'ProposalVotesConnection'; totalCount: number };
-    block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
-  } | null;
-};
+
+export type ProposalDetailsQuery = { __typename?: 'Query', session?: { __typename?: 'Session', id: string, sessionProposers: { __typename?: 'SessionProposersConnection', totalCount: number } } | null, proposalItem?: { __typename?: 'ProposalItem', id: string, data: string, signature?: string | null, type: ProposalType, status: string, proposalTimelineStatuses: { __typename?: 'ProposalTimelineStatusesConnection', nodes: Array<{ __typename?: 'ProposalTimelineStatus', id: string, status: ProposalStatus, blockNumber: any, timestamp: any } | null> }, votesFor: { __typename?: 'ProposalVotesConnection', totalCount: number }, totalVotes: { __typename?: 'ProposalVotesConnection', totalCount: number }, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null } | null };
 
 export type PublicKeysQueryVariables = Exact<{
   PerPage?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 }>;
 
-export type PublicKeysQuery = {
-  __typename?: 'Query';
-  publicKeys?: {
-    __typename?: 'PublicKeysConnection';
-    totalCount: number;
-    nodes: Array<{
-      __typename?: 'PublicKey';
-      id: string;
-      compressed?: string | null;
-      uncompressed?: string | null;
-      history: any;
-      block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
-      sessions: {
-        __typename?: 'SessionsConnection';
-        nodes: Array<{
-          __typename?: 'Session';
-          id: string;
-          keyGenThreshold?: any | null;
-          signatureThreshold?: any | null;
-          sessionValidators: {
-            __typename?: 'SessionValidatorsConnection';
-            edges: Array<{
-              __typename?: 'SessionValidatorsEdge';
-              node?: {
-                __typename?: 'SessionValidator';
-                id: string;
-                sessionId: string;
-                reputation: string;
-                isBest: boolean;
-                isNext: boolean;
-                isNextBest: boolean;
-                bestOrder: number;
-                nextBestOrder: number;
-                validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
-              } | null;
-            }>;
-          };
-        } | null>;
-      };
-    } | null>;
-    pageInfo: {
-      __typename?: 'PageInfo';
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      startCursor?: any | null;
-      endCursor?: any | null;
-    };
-  } | null;
-};
+
+export type PublicKeysQuery = { __typename?: 'Query', publicKeys?: { __typename?: 'PublicKeysConnection', totalCount: number, nodes: Array<{ __typename?: 'PublicKey', id: string, compressed?: string | null, uncompressed?: string | null, history: any, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null, sessions: { __typename?: 'SessionsConnection', nodes: Array<{ __typename?: 'Session', id: string, keyGenThreshold?: any | null, signatureThreshold?: any | null, sessionValidators: { __typename?: 'SessionValidatorsConnection', edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> } } | null> } } | null>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: any | null, endCursor?: any | null } } | null };
 
 export type PublicKeyQueryVariables = Exact<{
   id: Scalars['String'];
 }>;
 
-export type PublicKeyQuery = {
-  __typename?: 'Query';
-  publicKey?: {
-    __typename?: 'PublicKey';
-    id: string;
-    compressed?: string | null;
-    uncompressed?: string | null;
-    history: any;
-    block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
-    sessions: {
-      __typename?: 'SessionsConnection';
-      nodes: Array<{
-        __typename?: 'Session';
-        id: string;
-        keyGenThreshold?: any | null;
-        signatureThreshold?: any | null;
-        sessionValidators: {
-          __typename?: 'SessionValidatorsConnection';
-          edges: Array<{
-            __typename?: 'SessionValidatorsEdge';
-            node?: {
-              __typename?: 'SessionValidator';
-              id: string;
-              sessionId: string;
-              reputation: string;
-              isBest: boolean;
-              isNext: boolean;
-              isNextBest: boolean;
-              bestOrder: number;
-              nextBestOrder: number;
-              validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
-            } | null;
-          }>;
-        };
-      } | null>;
-    };
-  } | null;
-};
 
-export type CurrentSessionAuthoritiesQueryVariables = Exact<{ [key: string]: never }>;
+export type PublicKeyQuery = { __typename?: 'Query', publicKey?: { __typename?: 'PublicKey', id: string, compressed?: string | null, uncompressed?: string | null, history: any, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null, sessions: { __typename?: 'SessionsConnection', nodes: Array<{ __typename?: 'Session', id: string, keyGenThreshold?: any | null, signatureThreshold?: any | null, sessionValidators: { __typename?: 'SessionValidatorsConnection', edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> } } | null> } } | null };
 
-export type CurrentSessionAuthoritiesQuery = {
-  __typename?: 'Query';
-  sessions?: {
-    __typename?: 'SessionsConnection';
-    nodes: Array<{
-      __typename?: 'Session';
-      id: string;
-      blockId: string;
-      signatureThreshold?: any | null;
-      keyGenThreshold?: any | null;
-      proposerThreshold?: any | null;
-      publicKey?: { __typename?: 'PublicKey'; compressed?: string | null } | null;
-      block?: { __typename?: 'Block'; id: string; timestamp?: any | null } | null;
-      sessionValidators: {
-        __typename?: 'SessionValidatorsConnection';
-        edges: Array<{
-          __typename?: 'SessionValidatorsEdge';
-          node?: {
-            __typename?: 'SessionValidator';
-            id: string;
-            sessionId: string;
-            reputation: string;
-            isBest: boolean;
-            isNext: boolean;
-            isNextBest: boolean;
-            bestOrder: number;
-            nextBestOrder: number;
-            validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
-          } | null;
-        }>;
-      };
-    } | null>;
-  } | null;
-};
+export type SessionKeyIdsQueryVariables = Exact<{
+  keys: Array<Scalars['String']> | Scalars['String'];
+}>;
+
+
+export type SessionKeyIdsQuery = { __typename?: 'Query', sessions?: { __typename?: 'SessionsConnection', nodes: Array<{ __typename?: 'Session', id: string, publicKey?: { __typename?: 'PublicKey', id: string } | null } | null> } | null };
+
+export type CurrentSessionAuthoritiesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type CurrentSessionAuthoritiesQuery = { __typename?: 'Query', sessions?: { __typename?: 'SessionsConnection', nodes: Array<{ __typename?: 'Session', id: string, blockId: string, signatureThreshold?: any | null, keyGenThreshold?: any | null, proposerThreshold?: any | null, publicKey?: { __typename?: 'PublicKey', compressed?: string | null } | null, block?: { __typename?: 'Block', id: string, timestamp?: any | null } | null, sessionValidators: { __typename?: 'SessionValidatorsConnection', edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> } } | null> } | null };
 
 export type SessionKeysQueryVariables = Exact<{
   SessionId: Array<Scalars['String']> | Scalars['String'];
 }>;
 
-export type SessionKeysQuery = {
-  __typename?: 'Query';
-  sessions?: {
-    __typename?: 'SessionsConnection';
-    nodes: Array<{
-      __typename?: 'Session';
-      id: string;
-      publicKey?: {
-        __typename?: 'PublicKey';
-        id: string;
-        compressed?: string | null;
-        uncompressed?: string | null;
-        block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
-      } | null;
-      sessionValidators: {
-        __typename?: 'SessionValidatorsConnection';
-        edges: Array<{
-          __typename?: 'SessionValidatorsEdge';
-          node?: {
-            __typename?: 'SessionValidator';
-            id: string;
-            sessionId: string;
-            reputation: string;
-            isBest: boolean;
-            isNext: boolean;
-            isNextBest: boolean;
-            bestOrder: number;
-            nextBestOrder: number;
-            validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
-          } | null;
-        }>;
-      };
-    } | null>;
-  } | null;
-};
+
+export type SessionKeysQuery = { __typename?: 'Query', sessions?: { __typename?: 'SessionsConnection', nodes: Array<{ __typename?: 'Session', id: string, publicKey?: { __typename?: 'PublicKey', id: string, compressed?: string | null, uncompressed?: string | null, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null } | null, sessionValidators: { __typename?: 'SessionValidatorsConnection', edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> } } | null> } | null };
 
 export type SessionThresholdHistoryQueryVariables = Exact<{
   offset: Scalars['Int'];
   perPage: Scalars['Int'];
 }>;
 
-export type SessionThresholdHistoryQuery = {
-  __typename?: 'Query';
-  sessions?: {
-    __typename?: 'SessionsConnection';
-    totalCount: number;
-    nodes: Array<{
-      __typename?: 'Session';
-      id: string;
-      signatureThreshold?: any | null;
-      keyGenThreshold?: any | null;
-      block?: { __typename?: 'Block'; id: string; timestamp?: any | null } | null;
-    } | null>;
-    pageInfo: {
-      __typename?: 'PageInfo';
-      endCursor?: any | null;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      startCursor?: any | null;
-    };
-  } | null;
-};
+
+export type SessionThresholdHistoryQuery = { __typename?: 'Query', sessions?: { __typename?: 'SessionsConnection', totalCount: number, nodes: Array<{ __typename?: 'Session', id: string, signatureThreshold?: any | null, keyGenThreshold?: any | null, block?: { __typename?: 'Block', id: string, timestamp?: any | null } | null } | null>, pageInfo: { __typename?: 'PageInfo', endCursor?: any | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: any | null } } | null };
 
 export type SessionThresholdsQueryVariables = Exact<{
   sessionId: Scalars['String'];
 }>;
 
-export type SessionThresholdsQuery = {
-  __typename?: 'Query';
-  session?: {
-    __typename?: 'Session';
-    id: string;
-    signatureThreshold?: any | null;
-    keyGenThreshold?: any | null;
-    proposersCount: { __typename?: 'SessionProposersConnection'; totalCount: number };
-    publicKey?: {
-      __typename?: 'PublicKey';
-      id: string;
-      compressed?: string | null;
-      uncompressed?: string | null;
-      block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
-    } | null;
-    sessionValidators: {
-      __typename?: 'SessionValidatorsConnection';
-      edges: Array<{
-        __typename?: 'SessionValidatorsEdge';
-        node?: {
-          __typename?: 'SessionValidator';
-          id: string;
-          sessionId: string;
-          reputation: string;
-          isBest: boolean;
-          isNext: boolean;
-          isNextBest: boolean;
-          bestOrder: number;
-          nextBestOrder: number;
-          validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
-        } | null;
-      }>;
-    };
-  } | null;
-};
+
+export type SessionThresholdsQuery = { __typename?: 'Query', session?: { __typename?: 'Session', id: string, signatureThreshold?: any | null, keyGenThreshold?: any | null, proposersCount: { __typename?: 'SessionProposersConnection', totalCount: number }, publicKey?: { __typename?: 'PublicKey', id: string, compressed?: string | null, uncompressed?: string | null, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null } | null, sessionValidators: { __typename?: 'SessionValidatorsConnection', edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> } } | null };
 
 export const PageInfoMetaFragmentDoc = gql`
-  fragment PageInfoMeta on PageInfo {
-    endCursor
-    hasNextPage
-    hasPreviousPage
-    startCursor
-  }
-`;
+    fragment PageInfoMeta on PageInfo {
+  endCursor
+  hasNextPage
+  hasPreviousPage
+  startCursor
+}
+    `;
 export const ValidatorMetaFragmentDoc = gql`
-  fragment ValidatorMeta on Validator {
-    authorityId
-    id
-  }
-`;
+    fragment ValidatorMeta on Validator {
+  authorityId
+  id
+}
+    `;
 export const SessionAuthValidatorNodeFragmentDoc = gql`
-  fragment SessionAuthValidatorNode on SessionValidator {
-    id
-    sessionId
-    validator {
-      ...ValidatorMeta
-    }
-    reputation
-    isBest
-    isNext
-    isNextBest
-    bestOrder
-    nextBestOrder
+    fragment SessionAuthValidatorNode on SessionValidator {
+  id
+  sessionId
+  validator {
+    ...ValidatorMeta
   }
-  ${ValidatorMetaFragmentDoc}
-`;
+  reputation
+  isBest
+  isNext
+  isNextBest
+  bestOrder
+  nextBestOrder
+}
+    ${ValidatorMetaFragmentDoc}`;
 export const SessionAuthValidatorFragmentDoc = gql`
-  fragment SessionAuthValidator on SessionValidatorsConnection {
-    edges {
-      node {
-        ...SessionAuthValidatorNode
-      }
+    fragment SessionAuthValidator on SessionValidatorsConnection {
+  edges {
+    node {
+      ...SessionAuthValidatorNode
     }
   }
-  ${SessionAuthValidatorNodeFragmentDoc}
-`;
+}
+    ${SessionAuthValidatorNodeFragmentDoc}`;
 export const SessionAuthFragmentDoc = gql`
-  fragment SessionAuth on Session {
-    sessionValidators {
-      ...SessionAuthValidator
-    }
+    fragment SessionAuth on Session {
+  sessionValidators {
+    ...SessionAuthValidator
   }
-  ${SessionAuthValidatorFragmentDoc}
-`;
+}
+    ${SessionAuthValidatorFragmentDoc}`;
 export const ProposalListViewFragmentDoc = gql`
-  fragment ProposalListView on ProposalItem {
-    id
-    data
-    signature
-    type
-    status
-    proposalVotesByProposalId(orderBy: [BLOCK_NUMBER_DESC], first: 3) {
-      nodes {
+    fragment ProposalListView on ProposalItem {
+  id
+  data
+  signature
+  type
+  status
+  proposalVotesByProposalId(orderBy: [BLOCK_NUMBER_DESC], first: 3) {
+    nodes {
+      id
+      voterId
+      voter {
         id
-        voterId
-        voter {
-          id
-        }
       }
-      totalCount
     }
-    block {
-      timestamp
-      number
-    }
+    totalCount
   }
-`;
+  block {
+    timestamp
+    number
+  }
+}
+    `;
 export const ProposalsVoteListViewFragmentDoc = gql`
-  fragment ProposalsVoteListView on ProposalVote {
-    id
-    voterId
-    for
-    txHash: voterId
-    block {
-      timestamp
-      number
-    }
+    fragment ProposalsVoteListView on ProposalVote {
+  id
+  voterId
+  for
+  txHash: voterId
+  block {
+    timestamp
+    number
   }
-`;
+}
+    `;
 export const ValidatorListingDocument = gql`
-  query ValidatorListing($sessionId: String!, $perPage: Int!, $offset: Int!) {
-    validators(offset: $offset, first: $perPage) {
-      nodes {
-        ...ValidatorMeta
-        sessionValidators(first: 1, filter: { sessionId: { equalTo: $sessionId } }) {
-          ...SessionAuthValidator
-        }
-      }
-      totalCount
-      pageInfo {
-        ...PageInfoMeta
+    query ValidatorListing($sessionId: String!, $perPage: Int!, $offset: Int!) {
+  validators(offset: $offset, first: $perPage) {
+    nodes {
+      ...ValidatorMeta
+      sessionValidators(first: 1, filter: {sessionId: {equalTo: $sessionId}}) {
+        ...SessionAuthValidator
       }
     }
+    totalCount
+    pageInfo {
+      ...PageInfoMeta
+    }
   }
-  ${ValidatorMetaFragmentDoc}
-  ${SessionAuthValidatorFragmentDoc}
-  ${PageInfoMetaFragmentDoc}
-`;
+}
+    ${ValidatorMetaFragmentDoc}
+${SessionAuthValidatorFragmentDoc}
+${PageInfoMetaFragmentDoc}`;
 
 /**
  * __useValidatorListingQuery__
@@ -10578,55 +10219,50 @@ export const ValidatorListingDocument = gql`
  *   },
  * });
  */
-export function useValidatorListingQuery(
-  baseOptions: Apollo.QueryHookOptions<ValidatorListingQuery, ValidatorListingQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<ValidatorListingQuery, ValidatorListingQueryVariables>(ValidatorListingDocument, options);
-}
-export function useValidatorListingLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<ValidatorListingQuery, ValidatorListingQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<ValidatorListingQuery, ValidatorListingQueryVariables>(ValidatorListingDocument, options);
-}
+export function useValidatorListingQuery(baseOptions: Apollo.QueryHookOptions<ValidatorListingQuery, ValidatorListingQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ValidatorListingQuery, ValidatorListingQueryVariables>(ValidatorListingDocument, options);
+      }
+export function useValidatorListingLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ValidatorListingQuery, ValidatorListingQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ValidatorListingQuery, ValidatorListingQueryVariables>(ValidatorListingDocument, options);
+        }
 export type ValidatorListingQueryHookResult = ReturnType<typeof useValidatorListingQuery>;
 export type ValidatorListingLazyQueryHookResult = ReturnType<typeof useValidatorListingLazyQuery>;
 export type ValidatorListingQueryResult = Apollo.QueryResult<ValidatorListingQuery, ValidatorListingQueryVariables>;
 export const ValidatorSessionsDocument = gql`
-  query ValidatorSessions($keyGen: Boolean, $validatorId: String!, $perPage: Int!, $offset: Int!) {
-    sessionValidators(
-      filter: { isBest: { equalTo: $keyGen }, validatorId: { equalTo: $validatorId } }
-      offset: $offset
-      first: $perPage
-    ) {
-      nodes {
-        validator {
-          ...ValidatorMeta
-        }
-        session {
-          id
-          publicKey {
-            id
-            compressed
-            uncompressed
-          }
-          sessionValidators(first: 3) {
-            ...SessionAuthValidator
-            totalCount
-          }
-        }
+    query ValidatorSessions($keyGen: Boolean, $validatorId: String!, $perPage: Int!, $offset: Int!) {
+  sessionValidators(
+    filter: {isBest: {equalTo: $keyGen}, validatorId: {equalTo: $validatorId}}
+    offset: $offset
+    first: $perPage
+  ) {
+    nodes {
+      validator {
+        ...ValidatorMeta
       }
-      totalCount
-      pageInfo {
-        ...PageInfoMeta
+      session {
+        id
+        publicKey {
+          id
+          compressed
+          uncompressed
+        }
+        sessionValidators(first: 3) {
+          ...SessionAuthValidator
+          totalCount
+        }
       }
     }
+    totalCount
+    pageInfo {
+      ...PageInfoMeta
+    }
   }
-  ${ValidatorMetaFragmentDoc}
-  ${SessionAuthValidatorFragmentDoc}
-  ${PageInfoMetaFragmentDoc}
-`;
+}
+    ${ValidatorMetaFragmentDoc}
+${SessionAuthValidatorFragmentDoc}
+${PageInfoMetaFragmentDoc}`;
 
 /**
  * __useValidatorSessionsQuery__
@@ -10647,42 +10283,36 @@ export const ValidatorSessionsDocument = gql`
  *   },
  * });
  */
-export function useValidatorSessionsQuery(
-  baseOptions: Apollo.QueryHookOptions<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>(ValidatorSessionsDocument, options);
-}
-export function useValidatorSessionsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>(
-    ValidatorSessionsDocument,
-    options
-  );
-}
+export function useValidatorSessionsQuery(baseOptions: Apollo.QueryHookOptions<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>(ValidatorSessionsDocument, options);
+      }
+export function useValidatorSessionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>(ValidatorSessionsDocument, options);
+        }
 export type ValidatorSessionsQueryHookResult = ReturnType<typeof useValidatorSessionsQuery>;
 export type ValidatorSessionsLazyQueryHookResult = ReturnType<typeof useValidatorSessionsLazyQuery>;
 export type ValidatorSessionsQueryResult = Apollo.QueryResult<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>;
 export const ValidatorOfSessionDocument = gql`
-  query ValidatorOfSession($validatorId: String!, $sessionValidatorId: String!) {
-    sessionValidator(id: $sessionValidatorId) {
-      ...SessionAuthValidatorNode
-      session {
-        keyGenThreshold
-      }
+    query ValidatorOfSession($validatorId: String!, $sessionValidatorId: String!) {
+  sessionValidator(id: $sessionValidatorId) {
+    ...SessionAuthValidatorNode
+    session {
+      keyGenThreshold
     }
-    sessionValidators(filter: { validatorId: { equalTo: $validatorId }, isBest: { equalTo: true } }) {
-      aggregates {
-        distinctCount {
-          id
-        }
+  }
+  sessionValidators(
+    filter: {validatorId: {equalTo: $validatorId}, isBest: {equalTo: true}}
+  ) {
+    aggregates {
+      distinctCount {
+        id
       }
     }
   }
-  ${SessionAuthValidatorNodeFragmentDoc}
-`;
+}
+    ${SessionAuthValidatorNodeFragmentDoc}`;
 
 /**
  * __useValidatorOfSessionQuery__
@@ -10701,38 +10331,25 @@ export const ValidatorOfSessionDocument = gql`
  *   },
  * });
  */
-export function useValidatorOfSessionQuery(
-  baseOptions: Apollo.QueryHookOptions<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>(
-    ValidatorOfSessionDocument,
-    options
-  );
-}
-export function useValidatorOfSessionLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>(
-    ValidatorOfSessionDocument,
-    options
-  );
-}
+export function useValidatorOfSessionQuery(baseOptions: Apollo.QueryHookOptions<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>(ValidatorOfSessionDocument, options);
+      }
+export function useValidatorOfSessionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>(ValidatorOfSessionDocument, options);
+        }
 export type ValidatorOfSessionQueryHookResult = ReturnType<typeof useValidatorOfSessionQuery>;
 export type ValidatorOfSessionLazyQueryHookResult = ReturnType<typeof useValidatorOfSessionLazyQuery>;
-export type ValidatorOfSessionQueryResult = Apollo.QueryResult<
-  ValidatorOfSessionQuery,
-  ValidatorOfSessionQueryVariables
->;
+export type ValidatorOfSessionQueryResult = Apollo.QueryResult<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>;
 export const MetaDataDocument = gql`
-  query MetaData {
-    _metadata {
-      targetHeight
-      lastProcessedHeight
-    }
+    query MetaData {
+  _metadata {
+    targetHeight
+    lastProcessedHeight
   }
-`;
+}
+    `;
 
 /**
  * __useMetaDataQuery__
@@ -10750,31 +10367,31 @@ export const MetaDataDocument = gql`
  * });
  */
 export function useMetaDataQuery(baseOptions?: Apollo.QueryHookOptions<MetaDataQuery, MetaDataQueryVariables>) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<MetaDataQuery, MetaDataQueryVariables>(MetaDataDocument, options);
-}
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<MetaDataQuery, MetaDataQueryVariables>(MetaDataDocument, options);
+      }
 export function useMetaDataLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MetaDataQuery, MetaDataQueryVariables>) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<MetaDataQuery, MetaDataQueryVariables>(MetaDataDocument, options);
-}
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<MetaDataQuery, MetaDataQueryVariables>(MetaDataDocument, options);
+        }
 export type MetaDataQueryHookResult = ReturnType<typeof useMetaDataQuery>;
 export type MetaDataLazyQueryHookResult = ReturnType<typeof useMetaDataLazyQuery>;
 export type MetaDataQueryResult = Apollo.QueryResult<MetaDataQuery, MetaDataQueryVariables>;
 export const ProposalCounterDocument = gql`
-  query ProposalCounter {
-    proposalCounters(first: 2, offset: 1, orderBy: [BLOCK_NUMBER_DESC]) {
-      nodes {
-        id
-        blockNumber
-        unSignedProposalsCount
-        signedProposalsCount
-        statusMap
-        unSignedProposalsMap
-        signedProposalsMap
-      }
+    query ProposalCounter {
+  proposalCounters(first: 2, offset: 1, orderBy: [BLOCK_NUMBER_DESC]) {
+    nodes {
+      id
+      blockNumber
+      unSignedProposalsCount
+      signedProposalsCount
+      statusMap
+      unSignedProposalsMap
+      signedProposalsMap
     }
   }
-`;
+}
+    `;
 
 /**
  * __useProposalCounterQuery__
@@ -10791,36 +10408,31 @@ export const ProposalCounterDocument = gql`
  *   },
  * });
  */
-export function useProposalCounterQuery(
-  baseOptions?: Apollo.QueryHookOptions<ProposalCounterQuery, ProposalCounterQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<ProposalCounterQuery, ProposalCounterQueryVariables>(ProposalCounterDocument, options);
-}
-export function useProposalCounterLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<ProposalCounterQuery, ProposalCounterQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<ProposalCounterQuery, ProposalCounterQueryVariables>(ProposalCounterDocument, options);
-}
+export function useProposalCounterQuery(baseOptions?: Apollo.QueryHookOptions<ProposalCounterQuery, ProposalCounterQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ProposalCounterQuery, ProposalCounterQueryVariables>(ProposalCounterDocument, options);
+      }
+export function useProposalCounterLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProposalCounterQuery, ProposalCounterQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ProposalCounterQuery, ProposalCounterQueryVariables>(ProposalCounterDocument, options);
+        }
 export type ProposalCounterQueryHookResult = ReturnType<typeof useProposalCounterQuery>;
 export type ProposalCounterLazyQueryHookResult = ReturnType<typeof useProposalCounterLazyQuery>;
 export type ProposalCounterQueryResult = Apollo.QueryResult<ProposalCounterQuery, ProposalCounterQueryVariables>;
 export const ProposalsDocument = gql`
-  query Proposals($perPage: Int!, $offset: Int!) {
-    proposalItems(first: $perPage, offset: $offset) {
-      nodes {
-        ...ProposalListView
-      }
-      totalCount
-      pageInfo {
-        ...PageInfoMeta
-      }
+    query Proposals($perPage: Int!, $offset: Int!) {
+  proposalItems(first: $perPage, offset: $offset) {
+    nodes {
+      ...ProposalListView
+    }
+    totalCount
+    pageInfo {
+      ...PageInfoMeta
     }
   }
-  ${ProposalListViewFragmentDoc}
-  ${PageInfoMetaFragmentDoc}
-`;
+}
+    ${ProposalListViewFragmentDoc}
+${PageInfoMetaFragmentDoc}`;
 
 /**
  * __useProposalsQuery__
@@ -10840,34 +10452,32 @@ export const ProposalsDocument = gql`
  * });
  */
 export function useProposalsQuery(baseOptions: Apollo.QueryHookOptions<ProposalsQuery, ProposalsQueryVariables>) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<ProposalsQuery, ProposalsQueryVariables>(ProposalsDocument, options);
-}
-export function useProposalsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<ProposalsQuery, ProposalsQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<ProposalsQuery, ProposalsQueryVariables>(ProposalsDocument, options);
-}
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ProposalsQuery, ProposalsQueryVariables>(ProposalsDocument, options);
+      }
+export function useProposalsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProposalsQuery, ProposalsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ProposalsQuery, ProposalsQueryVariables>(ProposalsDocument, options);
+        }
 export type ProposalsQueryHookResult = ReturnType<typeof useProposalsQuery>;
 export type ProposalsLazyQueryHookResult = ReturnType<typeof useProposalsLazyQuery>;
 export type ProposalsQueryResult = Apollo.QueryResult<ProposalsQuery, ProposalsQueryVariables>;
 export const ProposalsCounterDocument = gql`
-  query ProposalsCounter($id: String!) {
-    proposalCounter(id: $id) {
-      id
-      signedProposalsMap
-      unSignedProposalsMap
-      signedProposalsCount
-      unSignedProposalsCount
-      statusMap
-      block {
-        number
-        timestamp
-      }
+    query ProposalsCounter($id: String!) {
+  proposalCounter(id: $id) {
+    id
+    signedProposalsMap
+    unSignedProposalsMap
+    signedProposalsCount
+    unSignedProposalsCount
+    statusMap
+    block {
+      number
+      timestamp
     }
   }
-`;
+}
+    `;
 
 /**
  * __useProposalsCounterQuery__
@@ -10885,66 +10495,65 @@ export const ProposalsCounterDocument = gql`
  *   },
  * });
  */
-export function useProposalsCounterQuery(
-  baseOptions: Apollo.QueryHookOptions<ProposalsCounterQuery, ProposalsCounterQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<ProposalsCounterQuery, ProposalsCounterQueryVariables>(ProposalsCounterDocument, options);
-}
-export function useProposalsCounterLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<ProposalsCounterQuery, ProposalsCounterQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<ProposalsCounterQuery, ProposalsCounterQueryVariables>(ProposalsCounterDocument, options);
-}
+export function useProposalsCounterQuery(baseOptions: Apollo.QueryHookOptions<ProposalsCounterQuery, ProposalsCounterQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ProposalsCounterQuery, ProposalsCounterQueryVariables>(ProposalsCounterDocument, options);
+      }
+export function useProposalsCounterLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProposalsCounterQuery, ProposalsCounterQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ProposalsCounterQuery, ProposalsCounterQueryVariables>(ProposalsCounterDocument, options);
+        }
 export type ProposalsCounterQueryHookResult = ReturnType<typeof useProposalsCounterQuery>;
 export type ProposalsCounterLazyQueryHookResult = ReturnType<typeof useProposalsCounterLazyQuery>;
 export type ProposalsCounterQueryResult = Apollo.QueryResult<ProposalsCounterQuery, ProposalsCounterQueryVariables>;
 export const ProposalsOverviewDocument = gql`
-  query ProposalsOverview($startRange: BigFloatFilter!, $endRange: BigFloatFilter!, $sessionId: String!) {
-    session(id: $sessionId) {
-      id
-      proposerThreshold
-      sessionProposers {
-        totalCount
-      }
-      sessionValidators {
-        totalCount
-      }
-    }
-    openProposals: proposalItems(filter: { status: { equalTo: "Open" } }, orderBy: [BLOCK_NUMBER_DESC], first: 10) {
-      nodes {
-        ...ProposalListView
-      }
-      pageInfo {
-        ...PageInfoMeta
-      }
+    query ProposalsOverview($startRange: BigFloatFilter!, $endRange: BigFloatFilter!, $sessionId: String!) {
+  session(id: $sessionId) {
+    id
+    proposerThreshold
+    sessionProposers {
       totalCount
     }
-    open: proposalTimelineStatuses(
-      filter: { status: { equalTo: Open }, and: [{ blockNumber: $startRange }, { blockNumber: $endRange }] }
-    ) {
-      totalCount
-    }
-    signed: proposalTimelineStatuses(
-      filter: { status: { equalTo: Signed }, and: [{ blockNumber: $startRange }, { blockNumber: $endRange }] }
-    ) {
-      totalCount
-    }
-    reject: proposalTimelineStatuses(
-      filter: { status: { equalTo: Rejected }, and: [{ blockNumber: $startRange }, { blockNumber: $endRange }] }
-    ) {
-      totalCount
-    }
-    accepted: proposalTimelineStatuses(
-      filter: { status: { equalTo: Accepted }, and: [{ blockNumber: $startRange }, { blockNumber: $endRange }] }
-    ) {
+    sessionValidators {
       totalCount
     }
   }
-  ${ProposalListViewFragmentDoc}
-  ${PageInfoMetaFragmentDoc}
-`;
+  openProposals: proposalItems(
+    filter: {status: {equalTo: "Open"}}
+    orderBy: [BLOCK_NUMBER_DESC]
+    first: 10
+  ) {
+    nodes {
+      ...ProposalListView
+    }
+    pageInfo {
+      ...PageInfoMeta
+    }
+    totalCount
+  }
+  open: proposalTimelineStatuses(
+    filter: {status: {equalTo: Open}, and: [{blockNumber: $startRange}, {blockNumber: $endRange}]}
+  ) {
+    totalCount
+  }
+  signed: proposalTimelineStatuses(
+    filter: {status: {equalTo: Signed}, and: [{blockNumber: $startRange}, {blockNumber: $endRange}]}
+  ) {
+    totalCount
+  }
+  reject: proposalTimelineStatuses(
+    filter: {status: {equalTo: Rejected}, and: [{blockNumber: $startRange}, {blockNumber: $endRange}]}
+  ) {
+    totalCount
+  }
+  accepted: proposalTimelineStatuses(
+    filter: {status: {equalTo: Accepted}, and: [{blockNumber: $startRange}, {blockNumber: $endRange}]}
+  ) {
+    totalCount
+  }
+}
+    ${ProposalListViewFragmentDoc}
+${PageInfoMetaFragmentDoc}`;
 
 /**
  * __useProposalsOverviewQuery__
@@ -10964,44 +10573,36 @@ export const ProposalsOverviewDocument = gql`
  *   },
  * });
  */
-export function useProposalsOverviewQuery(
-  baseOptions: Apollo.QueryHookOptions<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>(ProposalsOverviewDocument, options);
-}
-export function useProposalsOverviewLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>(
-    ProposalsOverviewDocument,
-    options
-  );
-}
+export function useProposalsOverviewQuery(baseOptions: Apollo.QueryHookOptions<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>(ProposalsOverviewDocument, options);
+      }
+export function useProposalsOverviewLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>(ProposalsOverviewDocument, options);
+        }
 export type ProposalsOverviewQueryHookResult = ReturnType<typeof useProposalsOverviewQuery>;
 export type ProposalsOverviewLazyQueryHookResult = ReturnType<typeof useProposalsOverviewLazyQuery>;
 export type ProposalsOverviewQueryResult = Apollo.QueryResult<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>;
 export const ProposalVotesDocument = gql`
-  query ProposalVotes($perPage: Int!, $offset: Int!, $proposalId: String!, $for: BooleanFilter) {
-    proposalVotes(
-      filter: { proposalId: { equalTo: $proposalId }, for: $for }
-      orderBy: [BLOCK_NUMBER_DESC]
-      first: $perPage
-      offset: $offset
-    ) {
-      nodes {
-        ...ProposalsVoteListView
-      }
-      totalCount
-      pageInfo {
-        ...PageInfoMeta
-      }
+    query ProposalVotes($perPage: Int!, $offset: Int!, $proposalId: String!, $for: BooleanFilter) {
+  proposalVotes(
+    filter: {proposalId: {equalTo: $proposalId}, for: $for}
+    orderBy: [BLOCK_NUMBER_DESC]
+    first: $perPage
+    offset: $offset
+  ) {
+    nodes {
+      ...ProposalsVoteListView
+    }
+    totalCount
+    pageInfo {
+      ...PageInfoMeta
     }
   }
-  ${ProposalsVoteListViewFragmentDoc}
-  ${PageInfoMetaFragmentDoc}
-`;
+}
+    ${ProposalsVoteListViewFragmentDoc}
+${PageInfoMetaFragmentDoc}`;
 
 /**
  * __useProposalVotesQuery__
@@ -11022,56 +10623,52 @@ export const ProposalVotesDocument = gql`
  *   },
  * });
  */
-export function useProposalVotesQuery(
-  baseOptions: Apollo.QueryHookOptions<ProposalVotesQuery, ProposalVotesQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<ProposalVotesQuery, ProposalVotesQueryVariables>(ProposalVotesDocument, options);
-}
-export function useProposalVotesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<ProposalVotesQuery, ProposalVotesQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<ProposalVotesQuery, ProposalVotesQueryVariables>(ProposalVotesDocument, options);
-}
+export function useProposalVotesQuery(baseOptions: Apollo.QueryHookOptions<ProposalVotesQuery, ProposalVotesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ProposalVotesQuery, ProposalVotesQueryVariables>(ProposalVotesDocument, options);
+      }
+export function useProposalVotesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProposalVotesQuery, ProposalVotesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ProposalVotesQuery, ProposalVotesQueryVariables>(ProposalVotesDocument, options);
+        }
 export type ProposalVotesQueryHookResult = ReturnType<typeof useProposalVotesQuery>;
 export type ProposalVotesLazyQueryHookResult = ReturnType<typeof useProposalVotesLazyQuery>;
 export type ProposalVotesQueryResult = Apollo.QueryResult<ProposalVotesQuery, ProposalVotesQueryVariables>;
 export const ProposalDetailsDocument = gql`
-  query ProposalDetails($id: String!, $targetSessionId: String!) {
-    session(id: $targetSessionId) {
-      id
-      sessionProposers {
-        totalCount
-      }
-    }
-    proposalItem(id: $id) {
-      id
-      data
-      signature
-      type
-      status
-      proposalTimelineStatuses {
-        nodes {
-          id
-          status
-          blockNumber
-          timestamp
-        }
-      }
-      votesFor: proposalVotesByProposalId(filter: { for: { equalTo: true } }) {
-        totalCount
-      }
-      totalVotes: proposalVotesByProposalId {
-        totalCount
-      }
-      block {
-        timestamp
-        number
-      }
+    query ProposalDetails($id: String!, $targetSessionId: String!) {
+  session(id: $targetSessionId) {
+    id
+    sessionProposers {
+      totalCount
     }
   }
-`;
+  proposalItem(id: $id) {
+    id
+    data
+    signature
+    type
+    status
+    proposalTimelineStatuses {
+      nodes {
+        id
+        status
+        blockNumber
+        timestamp
+      }
+    }
+    votesFor: proposalVotesByProposalId(filter: {for: {equalTo: true}}) {
+      totalCount
+    }
+    totalVotes: proposalVotesByProposalId {
+      totalCount
+    }
+    block {
+      timestamp
+      number
+    }
+  }
+}
+    `;
 
 /**
  * __useProposalDetailsQuery__
@@ -11090,53 +10687,52 @@ export const ProposalDetailsDocument = gql`
  *   },
  * });
  */
-export function useProposalDetailsQuery(
-  baseOptions: Apollo.QueryHookOptions<ProposalDetailsQuery, ProposalDetailsQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<ProposalDetailsQuery, ProposalDetailsQueryVariables>(ProposalDetailsDocument, options);
-}
-export function useProposalDetailsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<ProposalDetailsQuery, ProposalDetailsQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<ProposalDetailsQuery, ProposalDetailsQueryVariables>(ProposalDetailsDocument, options);
-}
+export function useProposalDetailsQuery(baseOptions: Apollo.QueryHookOptions<ProposalDetailsQuery, ProposalDetailsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ProposalDetailsQuery, ProposalDetailsQueryVariables>(ProposalDetailsDocument, options);
+      }
+export function useProposalDetailsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProposalDetailsQuery, ProposalDetailsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ProposalDetailsQuery, ProposalDetailsQueryVariables>(ProposalDetailsDocument, options);
+        }
 export type ProposalDetailsQueryHookResult = ReturnType<typeof useProposalDetailsQuery>;
 export type ProposalDetailsLazyQueryHookResult = ReturnType<typeof useProposalDetailsLazyQuery>;
 export type ProposalDetailsQueryResult = Apollo.QueryResult<ProposalDetailsQuery, ProposalDetailsQueryVariables>;
 export const PublicKeysDocument = gql`
-  query PublicKeys($PerPage: Int, $offset: Int) {
-    publicKeys(first: $PerPage, offset: $offset, orderBy: [SESSIONS_SUM_BLOCK_NUMBER_ASC]) {
-      nodes {
-        id
-        compressed
-        uncompressed
-        history
-        block {
-          timestamp
-          number
-        }
-        sessions(first: 1) {
-          nodes {
-            id
-            ...SessionAuth
-            keyGenThreshold
-            signatureThreshold
-          }
+    query PublicKeys($PerPage: Int, $offset: Int) {
+  publicKeys(
+    first: $PerPage
+    offset: $offset
+    orderBy: [SESSIONS_SUM_BLOCK_NUMBER_ASC]
+  ) {
+    nodes {
+      id
+      compressed
+      uncompressed
+      history
+      block {
+        timestamp
+        number
+      }
+      sessions(first: 1) {
+        nodes {
+          id
+          ...SessionAuth
+          keyGenThreshold
+          signatureThreshold
         }
       }
-      pageInfo {
-        hasNextPage
-        hasPreviousPage
-        startCursor
-        endCursor
-      }
-      totalCount
     }
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+    totalCount
   }
-  ${SessionAuthFragmentDoc}
-`;
+}
+    ${SessionAuthFragmentDoc}`;
 
 /**
  * __usePublicKeysQuery__
@@ -11156,41 +10752,38 @@ export const PublicKeysDocument = gql`
  * });
  */
 export function usePublicKeysQuery(baseOptions?: Apollo.QueryHookOptions<PublicKeysQuery, PublicKeysQueryVariables>) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<PublicKeysQuery, PublicKeysQueryVariables>(PublicKeysDocument, options);
-}
-export function usePublicKeysLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<PublicKeysQuery, PublicKeysQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<PublicKeysQuery, PublicKeysQueryVariables>(PublicKeysDocument, options);
-}
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<PublicKeysQuery, PublicKeysQueryVariables>(PublicKeysDocument, options);
+      }
+export function usePublicKeysLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PublicKeysQuery, PublicKeysQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<PublicKeysQuery, PublicKeysQueryVariables>(PublicKeysDocument, options);
+        }
 export type PublicKeysQueryHookResult = ReturnType<typeof usePublicKeysQuery>;
 export type PublicKeysLazyQueryHookResult = ReturnType<typeof usePublicKeysLazyQuery>;
 export type PublicKeysQueryResult = Apollo.QueryResult<PublicKeysQuery, PublicKeysQueryVariables>;
 export const PublicKeyDocument = gql`
-  query PublicKey($id: String!) {
-    publicKey(id: $id) {
-      id
-      compressed
-      uncompressed
-      history
-      block {
-        timestamp
-        number
-      }
-      sessions(first: 1) {
-        nodes {
-          id
-          ...SessionAuth
-          keyGenThreshold
-          signatureThreshold
-        }
+    query PublicKey($id: String!) {
+  publicKey(id: $id) {
+    id
+    compressed
+    uncompressed
+    history
+    block {
+      timestamp
+      number
+    }
+    sessions(first: 1) {
+      nodes {
+        id
+        ...SessionAuth
+        keyGenThreshold
+        signatureThreshold
       }
     }
   }
-  ${SessionAuthFragmentDoc}
-`;
+}
+    ${SessionAuthFragmentDoc}`;
 
 /**
  * __usePublicKeyQuery__
@@ -11209,40 +10802,77 @@ export const PublicKeyDocument = gql`
  * });
  */
 export function usePublicKeyQuery(baseOptions: Apollo.QueryHookOptions<PublicKeyQuery, PublicKeyQueryVariables>) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<PublicKeyQuery, PublicKeyQueryVariables>(PublicKeyDocument, options);
-}
-export function usePublicKeyLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<PublicKeyQuery, PublicKeyQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<PublicKeyQuery, PublicKeyQueryVariables>(PublicKeyDocument, options);
-}
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<PublicKeyQuery, PublicKeyQueryVariables>(PublicKeyDocument, options);
+      }
+export function usePublicKeyLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PublicKeyQuery, PublicKeyQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<PublicKeyQuery, PublicKeyQueryVariables>(PublicKeyDocument, options);
+        }
 export type PublicKeyQueryHookResult = ReturnType<typeof usePublicKeyQuery>;
 export type PublicKeyLazyQueryHookResult = ReturnType<typeof usePublicKeyLazyQuery>;
 export type PublicKeyQueryResult = Apollo.QueryResult<PublicKeyQuery, PublicKeyQueryVariables>;
-export const CurrentSessionAuthoritiesDocument = gql`
-  query CurrentSessionAuthorities {
-    sessions(last: 1, orderBy: [BLOCK_NUMBER_DESC]) {
-      nodes {
+export const SessionKeyIdsDocument = gql`
+    query SessionKeyIds($keys: [String!]!) {
+  sessions(filter: {id: {in: $keys}}) {
+    nodes {
+      id
+      publicKey {
         id
-        blockId
-        ...SessionAuth
-        publicKey {
-          compressed
-        }
-        signatureThreshold
-        keyGenThreshold
-        proposerThreshold
-        block {
-          id
-          timestamp
-        }
       }
     }
   }
-  ${SessionAuthFragmentDoc}
-`;
+}
+    `;
+
+/**
+ * __useSessionKeyIdsQuery__
+ *
+ * To run a query within a React component, call `useSessionKeyIdsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSessionKeyIdsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSessionKeyIdsQuery({
+ *   variables: {
+ *      keys: // value for 'keys'
+ *   },
+ * });
+ */
+export function useSessionKeyIdsQuery(baseOptions: Apollo.QueryHookOptions<SessionKeyIdsQuery, SessionKeyIdsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SessionKeyIdsQuery, SessionKeyIdsQueryVariables>(SessionKeyIdsDocument, options);
+      }
+export function useSessionKeyIdsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SessionKeyIdsQuery, SessionKeyIdsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SessionKeyIdsQuery, SessionKeyIdsQueryVariables>(SessionKeyIdsDocument, options);
+        }
+export type SessionKeyIdsQueryHookResult = ReturnType<typeof useSessionKeyIdsQuery>;
+export type SessionKeyIdsLazyQueryHookResult = ReturnType<typeof useSessionKeyIdsLazyQuery>;
+export type SessionKeyIdsQueryResult = Apollo.QueryResult<SessionKeyIdsQuery, SessionKeyIdsQueryVariables>;
+export const CurrentSessionAuthoritiesDocument = gql`
+    query CurrentSessionAuthorities {
+  sessions(last: 1, orderBy: [BLOCK_NUMBER_DESC]) {
+    nodes {
+      id
+      blockId
+      ...SessionAuth
+      publicKey {
+        compressed
+      }
+      signatureThreshold
+      keyGenThreshold
+      proposerThreshold
+      block {
+        id
+        timestamp
+      }
+    }
+  }
+}
+    ${SessionAuthFragmentDoc}`;
 
 /**
  * __useCurrentSessionAuthoritiesQuery__
@@ -11259,50 +10889,36 @@ export const CurrentSessionAuthoritiesDocument = gql`
  *   },
  * });
  */
-export function useCurrentSessionAuthoritiesQuery(
-  baseOptions?: Apollo.QueryHookOptions<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>(
-    CurrentSessionAuthoritiesDocument,
-    options
-  );
-}
-export function useCurrentSessionAuthoritiesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>(
-    CurrentSessionAuthoritiesDocument,
-    options
-  );
-}
+export function useCurrentSessionAuthoritiesQuery(baseOptions?: Apollo.QueryHookOptions<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>(CurrentSessionAuthoritiesDocument, options);
+      }
+export function useCurrentSessionAuthoritiesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>(CurrentSessionAuthoritiesDocument, options);
+        }
 export type CurrentSessionAuthoritiesQueryHookResult = ReturnType<typeof useCurrentSessionAuthoritiesQuery>;
 export type CurrentSessionAuthoritiesLazyQueryHookResult = ReturnType<typeof useCurrentSessionAuthoritiesLazyQuery>;
-export type CurrentSessionAuthoritiesQueryResult = Apollo.QueryResult<
-  CurrentSessionAuthoritiesQuery,
-  CurrentSessionAuthoritiesQueryVariables
->;
+export type CurrentSessionAuthoritiesQueryResult = Apollo.QueryResult<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>;
 export const SessionKeysDocument = gql`
-  query SessionKeys($SessionId: [String!]!) {
-    sessions(filter: { id: { in: $SessionId } }) {
-      nodes {
+    query SessionKeys($SessionId: [String!]!) {
+  sessions(filter: {id: {in: $SessionId}}) {
+    nodes {
+      id
+      ...SessionAuth
+      publicKey {
         id
-        ...SessionAuth
-        publicKey {
-          id
-          compressed
-          uncompressed
-          block {
-            timestamp
-            number
-          }
+        compressed
+        uncompressed
+        block {
+          timestamp
+          number
         }
       }
     }
   }
-  ${SessionAuthFragmentDoc}
-`;
+}
+    ${SessionAuthFragmentDoc}`;
 
 /**
  * __useSessionKeysQuery__
@@ -11321,38 +10937,35 @@ export const SessionKeysDocument = gql`
  * });
  */
 export function useSessionKeysQuery(baseOptions: Apollo.QueryHookOptions<SessionKeysQuery, SessionKeysQueryVariables>) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<SessionKeysQuery, SessionKeysQueryVariables>(SessionKeysDocument, options);
-}
-export function useSessionKeysLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<SessionKeysQuery, SessionKeysQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<SessionKeysQuery, SessionKeysQueryVariables>(SessionKeysDocument, options);
-}
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SessionKeysQuery, SessionKeysQueryVariables>(SessionKeysDocument, options);
+      }
+export function useSessionKeysLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SessionKeysQuery, SessionKeysQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SessionKeysQuery, SessionKeysQueryVariables>(SessionKeysDocument, options);
+        }
 export type SessionKeysQueryHookResult = ReturnType<typeof useSessionKeysQuery>;
 export type SessionKeysLazyQueryHookResult = ReturnType<typeof useSessionKeysLazyQuery>;
 export type SessionKeysQueryResult = Apollo.QueryResult<SessionKeysQuery, SessionKeysQueryVariables>;
 export const SessionThresholdHistoryDocument = gql`
-  query SessionThresholdHistory($offset: Int!, $perPage: Int!) {
-    sessions(first: $perPage, offset: $offset, orderBy: [BLOCK_NUMBER_DESC]) {
-      nodes {
+    query SessionThresholdHistory($offset: Int!, $perPage: Int!) {
+  sessions(first: $perPage, offset: $offset, orderBy: [BLOCK_NUMBER_DESC]) {
+    nodes {
+      id
+      signatureThreshold
+      keyGenThreshold
+      block {
         id
-        signatureThreshold
-        keyGenThreshold
-        block {
-          id
-          timestamp
-        }
+        timestamp
       }
-      pageInfo {
-        ...PageInfoMeta
-      }
-      totalCount
     }
+    pageInfo {
+      ...PageInfoMeta
+    }
+    totalCount
   }
-  ${PageInfoMetaFragmentDoc}
-`;
+}
+    ${PageInfoMetaFragmentDoc}`;
 
 /**
  * __useSessionThresholdHistoryQuery__
@@ -11371,53 +10984,39 @@ export const SessionThresholdHistoryDocument = gql`
  *   },
  * });
  */
-export function useSessionThresholdHistoryQuery(
-  baseOptions: Apollo.QueryHookOptions<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>(
-    SessionThresholdHistoryDocument,
-    options
-  );
-}
-export function useSessionThresholdHistoryLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>(
-    SessionThresholdHistoryDocument,
-    options
-  );
-}
+export function useSessionThresholdHistoryQuery(baseOptions: Apollo.QueryHookOptions<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>(SessionThresholdHistoryDocument, options);
+      }
+export function useSessionThresholdHistoryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>(SessionThresholdHistoryDocument, options);
+        }
 export type SessionThresholdHistoryQueryHookResult = ReturnType<typeof useSessionThresholdHistoryQuery>;
 export type SessionThresholdHistoryLazyQueryHookResult = ReturnType<typeof useSessionThresholdHistoryLazyQuery>;
-export type SessionThresholdHistoryQueryResult = Apollo.QueryResult<
-  SessionThresholdHistoryQuery,
-  SessionThresholdHistoryQueryVariables
->;
+export type SessionThresholdHistoryQueryResult = Apollo.QueryResult<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>;
 export const SessionThresholdsDocument = gql`
-  query SessionThresholds($sessionId: String!) {
-    session(id: $sessionId) {
+    query SessionThresholds($sessionId: String!) {
+  session(id: $sessionId) {
+    id
+    signatureThreshold
+    keyGenThreshold
+    proposersCount: sessionProposers {
+      totalCount
+    }
+    ...SessionAuth
+    publicKey {
       id
-      signatureThreshold
-      keyGenThreshold
-      proposersCount: sessionProposers {
-        totalCount
-      }
-      ...SessionAuth
-      publicKey {
-        id
-        compressed
-        uncompressed
-        block {
-          timestamp
-          number
-        }
+      compressed
+      uncompressed
+      block {
+        timestamp
+        number
       }
     }
   }
-  ${SessionAuthFragmentDoc}
-`;
+}
+    ${SessionAuthFragmentDoc}`;
 
 /**
  * __useSessionThresholdsQuery__
@@ -11435,21 +11034,14 @@ export const SessionThresholdsDocument = gql`
  *   },
  * });
  */
-export function useSessionThresholdsQuery(
-  baseOptions: Apollo.QueryHookOptions<SessionThresholdsQuery, SessionThresholdsQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<SessionThresholdsQuery, SessionThresholdsQueryVariables>(SessionThresholdsDocument, options);
-}
-export function useSessionThresholdsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<SessionThresholdsQuery, SessionThresholdsQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<SessionThresholdsQuery, SessionThresholdsQueryVariables>(
-    SessionThresholdsDocument,
-    options
-  );
-}
+export function useSessionThresholdsQuery(baseOptions: Apollo.QueryHookOptions<SessionThresholdsQuery, SessionThresholdsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SessionThresholdsQuery, SessionThresholdsQueryVariables>(SessionThresholdsDocument, options);
+      }
+export function useSessionThresholdsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SessionThresholdsQuery, SessionThresholdsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SessionThresholdsQuery, SessionThresholdsQueryVariables>(SessionThresholdsDocument, options);
+        }
 export type SessionThresholdsQueryHookResult = ReturnType<typeof useSessionThresholdsQuery>;
 export type SessionThresholdsLazyQueryHookResult = ReturnType<typeof useSessionThresholdsLazyQuery>;
 export type SessionThresholdsQueryResult = Apollo.QueryResult<SessionThresholdsQuery, SessionThresholdsQueryVariables>;

--- a/packages/page-statistics/src/generated/graphql.tsx
+++ b/packages/page-statistics/src/generated/graphql.tsx
@@ -47,7 +47,6 @@ export type Account = Node & {
   validators: ValidatorsConnection;
 };
 
-
 export type AccountAccountsByCreatorIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -57,7 +56,6 @@ export type AccountAccountsByCreatorIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<AccountsOrderBy>>;
 };
-
 
 export type AccountBlocksByAccountCreatorIdAndCreateAtBlockIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -69,7 +67,6 @@ export type AccountBlocksByAccountCreatorIdAndCreateAtBlockIdArgs = {
   orderBy?: InputMaybe<Array<BlocksOrderBy>>;
 };
 
-
 export type AccountBlocksByExtrinsicSignerIdAndBlockIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -79,7 +76,6 @@ export type AccountBlocksByExtrinsicSignerIdAndBlockIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<BlocksOrderBy>>;
 };
-
 
 export type AccountExtrinsicsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -91,7 +87,6 @@ export type AccountExtrinsicsArgs = {
   orderBy?: InputMaybe<Array<ExtrinsicsOrderBy>>;
 };
 
-
 export type AccountProposersArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -101,7 +96,6 @@ export type AccountProposersArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ProposersOrderBy>>;
 };
-
 
 export type AccountValidatorsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -137,7 +131,6 @@ export type AccountBlocksByAccountCreatorIdAndCreateAtBlockIdManyToManyConnectio
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Block` values, with data from `Account`. */
 export type AccountBlocksByAccountCreatorIdAndCreateAtBlockIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<BlocksGroupBy>;
@@ -154,7 +147,6 @@ export type AccountBlocksByAccountCreatorIdAndCreateAtBlockIdManyToManyEdge = {
   /** The `Block` at the end of the edge. */
   node?: Maybe<Block>;
 };
-
 
 /** A `Block` edge in the connection, with data from `Account`. */
 export type AccountBlocksByAccountCreatorIdAndCreateAtBlockIdManyToManyEdgeAccountsByCreateAtBlockIdArgs = {
@@ -184,7 +176,6 @@ export type AccountBlocksByExtrinsicSignerIdAndBlockIdManyToManyConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Block` values, with data from `Extrinsic`. */
 export type AccountBlocksByExtrinsicSignerIdAndBlockIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<BlocksGroupBy>;
@@ -201,7 +192,6 @@ export type AccountBlocksByExtrinsicSignerIdAndBlockIdManyToManyEdge = {
   /** The `Block` at the end of the edge. */
   node?: Maybe<Block>;
 };
-
 
 /** A `Block` edge in the connection, with data from `Extrinsic`. */
 export type AccountBlocksByExtrinsicSignerIdAndBlockIdManyToManyEdgeExtrinsicsArgs = {
@@ -261,7 +251,6 @@ export type AccountsConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Account` values. */
 export type AccountsConnectionGroupedAggregatesArgs = {
   groupBy: Array<AccountsGroupBy>;
@@ -281,7 +270,7 @@ export type AccountsEdge = {
 export enum AccountsGroupBy {
   CreatedAt = 'CREATED_AT',
   CreateAtBlockId = 'CREATE_AT_BLOCK_ID',
-  CreatorId = 'CREATOR_ID'
+  CreatorId = 'CREATOR_ID',
 }
 
 /** Conditions for `Account` aggregates. */
@@ -670,7 +659,7 @@ export enum AccountsOrderBy {
   ValidatorsVarianceSampleAuthorityIdAsc = 'VALIDATORS_VARIANCE_SAMPLE_AUTHORITY_ID_ASC',
   ValidatorsVarianceSampleAuthorityIdDesc = 'VALIDATORS_VARIANCE_SAMPLE_AUTHORITY_ID_DESC',
   ValidatorsVarianceSampleIdAsc = 'VALIDATORS_VARIANCE_SAMPLE_ID_ASC',
-  ValidatorsVarianceSampleIdDesc = 'VALIDATORS_VARIANCE_SAMPLE_ID_DESC'
+  ValidatorsVarianceSampleIdDesc = 'VALIDATORS_VARIANCE_SAMPLE_ID_DESC',
 }
 
 /** A connection to a list of `Authority` values. */
@@ -689,7 +678,6 @@ export type AuthoritiesConnection = {
   /** The count of *all* `Authority` you could get from the connection. */
   totalCount: Scalars['Int'];
 };
-
 
 /** A connection to a list of `Authority` values. */
 export type AuthoritiesConnectionGroupedAggregatesArgs = {
@@ -710,7 +698,7 @@ export type AuthoritiesEdge = {
 export enum AuthoritiesGroupBy {
   BlockId = 'BLOCK_ID',
   Current = 'CURRENT',
-  Next = 'NEXT'
+  Next = 'NEXT',
 }
 
 /** Conditions for `Authority` aggregates. */
@@ -731,7 +719,7 @@ export enum AuthoritiesOrderBy {
   NextAsc = 'NEXT_ASC',
   NextDesc = 'NEXT_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
 }
 
 export type Authority = Node & {
@@ -861,7 +849,6 @@ export type Block = Node & {
   unsignedProposalsQueues: UnsignedProposalsQueuesConnection;
 };
 
-
 export type BlockAccountsByAccountCreateAtBlockIdAndCreatorIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -871,7 +858,6 @@ export type BlockAccountsByAccountCreateAtBlockIdAndCreatorIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<AccountsOrderBy>>;
 };
-
 
 export type BlockAccountsByCreateAtBlockIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -883,7 +869,6 @@ export type BlockAccountsByCreateAtBlockIdArgs = {
   orderBy?: InputMaybe<Array<AccountsOrderBy>>;
 };
 
-
 export type BlockAccountsByExtrinsicBlockIdAndSignerIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -893,7 +878,6 @@ export type BlockAccountsByExtrinsicBlockIdAndSignerIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<AccountsOrderBy>>;
 };
-
 
 export type BlockAuthoritiesArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -905,7 +889,6 @@ export type BlockAuthoritiesArgs = {
   orderBy?: InputMaybe<Array<AuthoritiesOrderBy>>;
 };
 
-
 export type BlockEventsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -915,7 +898,6 @@ export type BlockEventsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<EventsOrderBy>>;
 };
-
 
 export type BlockExtrinsicsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -927,7 +909,6 @@ export type BlockExtrinsicsArgs = {
   orderBy?: InputMaybe<Array<ExtrinsicsOrderBy>>;
 };
 
-
 export type BlockExtrinsicsByEventBlockIdAndExtrinsicIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -937,7 +918,6 @@ export type BlockExtrinsicsByEventBlockIdAndExtrinsicIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ExtrinsicsOrderBy>>;
 };
-
 
 export type BlockKeygenThresholdsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -949,7 +929,6 @@ export type BlockKeygenThresholdsArgs = {
   orderBy?: InputMaybe<Array<KeygenThresholdsOrderBy>>;
 };
 
-
 export type BlockProposalCountersArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -959,7 +938,6 @@ export type BlockProposalCountersArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ProposalCountersOrderBy>>;
 };
-
 
 export type BlockProposalItemsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -971,7 +949,6 @@ export type BlockProposalItemsArgs = {
   orderBy?: InputMaybe<Array<ProposalItemsOrderBy>>;
 };
 
-
 export type BlockProposalItemsByProposalVoteBlockIdAndProposalIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -981,7 +958,6 @@ export type BlockProposalItemsByProposalVoteBlockIdAndProposalIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ProposalItemsOrderBy>>;
 };
-
 
 export type BlockProposalVotesArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -993,7 +969,6 @@ export type BlockProposalVotesArgs = {
   orderBy?: InputMaybe<Array<ProposalVotesOrderBy>>;
 };
 
-
 export type BlockProposerThresholdsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -1003,7 +978,6 @@ export type BlockProposerThresholdsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ProposerThresholdsOrderBy>>;
 };
-
 
 export type BlockProposersByProposalVoteBlockIdAndVoterIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1015,7 +989,6 @@ export type BlockProposersByProposalVoteBlockIdAndVoterIdArgs = {
   orderBy?: InputMaybe<Array<ProposersOrderBy>>;
 };
 
-
 export type BlockPublicKeysArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -1025,7 +998,6 @@ export type BlockPublicKeysArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<PublicKeysOrderBy>>;
 };
-
 
 export type BlockPublicKeysBySessionBlockIdAndPublicKeyIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1037,7 +1009,6 @@ export type BlockPublicKeysBySessionBlockIdAndPublicKeyIdArgs = {
   orderBy?: InputMaybe<Array<PublicKeysOrderBy>>;
 };
 
-
 export type BlockSessionsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -1048,7 +1019,6 @@ export type BlockSessionsArgs = {
   orderBy?: InputMaybe<Array<SessionsOrderBy>>;
 };
 
-
 export type BlockSignatureThresholdsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -1058,7 +1028,6 @@ export type BlockSignatureThresholdsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<SignatureThresholdsOrderBy>>;
 };
-
 
 export type BlockUnsignedProposalsQueuesArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1087,7 +1056,6 @@ export type BlockAccountsByAccountCreateAtBlockIdAndCreatorIdManyToManyConnectio
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Account` values, with data from `Account`. */
 export type BlockAccountsByAccountCreateAtBlockIdAndCreatorIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<AccountsGroupBy>;
@@ -1104,7 +1072,6 @@ export type BlockAccountsByAccountCreateAtBlockIdAndCreatorIdManyToManyEdge = {
   /** The `Account` at the end of the edge. */
   node?: Maybe<Account>;
 };
-
 
 /** A `Account` edge in the connection, with data from `Account`. */
 export type BlockAccountsByAccountCreateAtBlockIdAndCreatorIdManyToManyEdgeAccountsByCreatorIdArgs = {
@@ -1134,7 +1101,6 @@ export type BlockAccountsByExtrinsicBlockIdAndSignerIdManyToManyConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Account` values, with data from `Extrinsic`. */
 export type BlockAccountsByExtrinsicBlockIdAndSignerIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<AccountsGroupBy>;
@@ -1151,7 +1117,6 @@ export type BlockAccountsByExtrinsicBlockIdAndSignerIdManyToManyEdge = {
   /** The `Account` at the end of the edge. */
   node?: Maybe<Account>;
 };
-
 
 /** A `Account` edge in the connection, with data from `Extrinsic`. */
 export type BlockAccountsByExtrinsicBlockIdAndSignerIdManyToManyEdgeExtrinsicsArgs = {
@@ -1230,7 +1195,6 @@ export type BlockExtrinsicsByEventBlockIdAndExtrinsicIdManyToManyConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Extrinsic` values, with data from `Event`. */
 export type BlockExtrinsicsByEventBlockIdAndExtrinsicIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<ExtrinsicsGroupBy>;
@@ -1247,7 +1211,6 @@ export type BlockExtrinsicsByEventBlockIdAndExtrinsicIdManyToManyEdge = {
   /** The `Extrinsic` at the end of the edge. */
   node?: Maybe<Extrinsic>;
 };
-
 
 /** A `Extrinsic` edge in the connection, with data from `Event`. */
 export type BlockExtrinsicsByEventBlockIdAndExtrinsicIdManyToManyEdgeEventsArgs = {
@@ -1315,7 +1278,6 @@ export type BlockProposalItemsByProposalVoteBlockIdAndProposalIdManyToManyConnec
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `ProposalItem` values, with data from `ProposalVote`. */
 export type BlockProposalItemsByProposalVoteBlockIdAndProposalIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposalItemsGroupBy>;
@@ -1332,7 +1294,6 @@ export type BlockProposalItemsByProposalVoteBlockIdAndProposalIdManyToManyEdge =
   /** Reads and enables pagination through a set of `ProposalVote`. */
   proposalVotesByProposalId: ProposalVotesConnection;
 };
-
 
 /** A `ProposalItem` edge in the connection, with data from `ProposalVote`. */
 export type BlockProposalItemsByProposalVoteBlockIdAndProposalIdManyToManyEdgeProposalVotesByProposalIdArgs = {
@@ -1362,7 +1323,6 @@ export type BlockProposersByProposalVoteBlockIdAndVoterIdManyToManyConnection = 
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Proposer` values, with data from `ProposalVote`. */
 export type BlockProposersByProposalVoteBlockIdAndVoterIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposersGroupBy>;
@@ -1379,7 +1339,6 @@ export type BlockProposersByProposalVoteBlockIdAndVoterIdManyToManyEdge = {
   /** Reads and enables pagination through a set of `ProposalVote`. */
   proposalVotesByVoterId: ProposalVotesConnection;
 };
-
 
 /** A `Proposer` edge in the connection, with data from `ProposalVote`. */
 export type BlockProposersByProposalVoteBlockIdAndVoterIdManyToManyEdgeProposalVotesByVoterIdArgs = {
@@ -1409,7 +1368,6 @@ export type BlockPublicKeysBySessionBlockIdAndPublicKeyIdManyToManyConnection = 
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `PublicKey` values, with data from `Session`. */
 export type BlockPublicKeysBySessionBlockIdAndPublicKeyIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<PublicKeysGroupBy>;
@@ -1426,7 +1384,6 @@ export type BlockPublicKeysBySessionBlockIdAndPublicKeyIdManyToManyEdge = {
   /** Reads and enables pagination through a set of `Session`. */
   sessions: SessionsConnection;
 };
-
 
 /** A `PublicKey` edge in the connection, with data from `Session`. */
 export type BlockPublicKeysBySessionBlockIdAndPublicKeyIdManyToManyEdgeSessionsArgs = {
@@ -1486,7 +1443,6 @@ export type BlocksConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Block` values. */
 export type BlocksConnectionGroupedAggregatesArgs = {
   groupBy: Array<BlocksGroupBy>;
@@ -1511,7 +1467,7 @@ export enum BlocksGroupBy {
   StateRoot = 'STATE_ROOT',
   Timestamp = 'TIMESTAMP',
   TimestampTruncatedToDay = 'TIMESTAMP_TRUNCATED_TO_DAY',
-  TimestampTruncatedToHour = 'TIMESTAMP_TRUNCATED_TO_HOUR'
+  TimestampTruncatedToHour = 'TIMESTAMP_TRUNCATED_TO_HOUR',
 }
 
 export type BlocksHavingAverageInput = {
@@ -3078,7 +3034,7 @@ export enum BlocksOrderBy {
   UnsignedProposalsQueuesVarianceSampleBlockNumberAsc = 'UNSIGNED_PROPOSALS_QUEUES_VARIANCE_SAMPLE_BLOCK_NUMBER_ASC',
   UnsignedProposalsQueuesVarianceSampleBlockNumberDesc = 'UNSIGNED_PROPOSALS_QUEUES_VARIANCE_SAMPLE_BLOCK_NUMBER_DESC',
   UnsignedProposalsQueuesVarianceSampleIdAsc = 'UNSIGNED_PROPOSALS_QUEUES_VARIANCE_SAMPLE_ID_ASC',
-  UnsignedProposalsQueuesVarianceSampleIdDesc = 'UNSIGNED_PROPOSALS_QUEUES_VARIANCE_SAMPLE_ID_DESC'
+  UnsignedProposalsQueuesVarianceSampleIdDesc = 'UNSIGNED_PROPOSALS_QUEUES_VARIANCE_SAMPLE_ID_DESC',
 }
 
 /** A filter to be used against Boolean fields. All fields are combined with a logical ‘and.’ */
@@ -3316,7 +3272,6 @@ export type EventsConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Event` values. */
 export type EventsConnectionGroupedAggregatesArgs = {
   groupBy: Array<EventsGroupBy>;
@@ -3345,7 +3300,7 @@ export enum EventsGroupBy {
   Module = 'MODULE',
   Timestamp = 'TIMESTAMP',
   TimestampTruncatedToDay = 'TIMESTAMP_TRUNCATED_TO_DAY',
-  TimestampTruncatedToHour = 'TIMESTAMP_TRUNCATED_TO_HOUR'
+  TimestampTruncatedToHour = 'TIMESTAMP_TRUNCATED_TO_HOUR',
 }
 
 export type EventsHavingAverageInput = {
@@ -3443,7 +3398,7 @@ export enum EventsOrderBy {
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
   TimestampAsc = 'TIMESTAMP_ASC',
-  TimestampDesc = 'TIMESTAMP_DESC'
+  TimestampDesc = 'TIMESTAMP_DESC',
 }
 
 export type Extrinsic = Node & {
@@ -3471,7 +3426,6 @@ export type Extrinsic = Node & {
   signerId?: Maybe<Scalars['String']>;
 };
 
-
 export type ExtrinsicBlocksByEventExtrinsicIdAndBlockIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -3481,7 +3435,6 @@ export type ExtrinsicBlocksByEventExtrinsicIdAndBlockIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<BlocksOrderBy>>;
 };
-
 
 export type ExtrinsicEventsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -3541,7 +3494,6 @@ export type ExtrinsicBlocksByEventExtrinsicIdAndBlockIdManyToManyConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Block` values, with data from `Event`. */
 export type ExtrinsicBlocksByEventExtrinsicIdAndBlockIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<BlocksGroupBy>;
@@ -3558,7 +3510,6 @@ export type ExtrinsicBlocksByEventExtrinsicIdAndBlockIdManyToManyEdge = {
   /** The `Block` at the end of the edge. */
   node?: Maybe<Block>;
 };
-
 
 /** A `Block` edge in the connection, with data from `Event`. */
 export type ExtrinsicBlocksByEventExtrinsicIdAndBlockIdManyToManyEdgeEventsArgs = {
@@ -3702,7 +3653,6 @@ export type ExtrinsicsConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Extrinsic` values. */
 export type ExtrinsicsConnectionGroupedAggregatesArgs = {
   groupBy: Array<ExtrinsicsGroupBy>;
@@ -3729,7 +3679,7 @@ export enum ExtrinsicsGroupBy {
   IsSuccess = 'IS_SUCCESS',
   Method = 'METHOD',
   Module = 'MODULE',
-  SignerId = 'SIGNER_ID'
+  SignerId = 'SIGNER_ID',
 }
 
 export type ExtrinsicsHavingAverageInput = {
@@ -4018,7 +3968,7 @@ export enum ExtrinsicsOrderBy {
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
   SignerIdAsc = 'SIGNER_ID_ASC',
-  SignerIdDesc = 'SIGNER_ID_DESC'
+  SignerIdDesc = 'SIGNER_ID_DESC',
 }
 
 export type HavingBigfloatFilter = {
@@ -4277,7 +4227,6 @@ export type KeygenThresholdsConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `KeygenThreshold` values. */
 export type KeygenThresholdsConnectionGroupedAggregatesArgs = {
   groupBy: Array<KeygenThresholdsGroupBy>;
@@ -4298,7 +4247,7 @@ export enum KeygenThresholdsGroupBy {
   BlockId = 'BLOCK_ID',
   Current = 'CURRENT',
   Next = 'NEXT',
-  Pending = 'PENDING'
+  Pending = 'PENDING',
 }
 
 export type KeygenThresholdsHavingAverageInput = {
@@ -4384,7 +4333,7 @@ export enum KeygenThresholdsOrderBy {
   PendingAsc = 'PENDING_ASC',
   PendingDesc = 'PENDING_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
 }
 
 /** An object with a globally unique `ID`. */
@@ -4588,7 +4537,6 @@ export type ProposalCountersConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `ProposalCounter` values. */
 export type ProposalCountersConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposalCountersGroupBy>;
@@ -4612,7 +4560,7 @@ export enum ProposalCountersGroupBy {
   SignedProposalsMap = 'SIGNED_PROPOSALS_MAP',
   StatusMap = 'STATUS_MAP',
   UnSignedProposalsCount = 'UN_SIGNED_PROPOSALS_COUNT',
-  UnSignedProposalsMap = 'UN_SIGNED_PROPOSALS_MAP'
+  UnSignedProposalsMap = 'UN_SIGNED_PROPOSALS_MAP',
 }
 
 export type ProposalCountersHavingAverageInput = {
@@ -4704,7 +4652,7 @@ export enum ProposalCountersOrderBy {
   UnSignedProposalsCountAsc = 'UN_SIGNED_PROPOSALS_COUNT_ASC',
   UnSignedProposalsCountDesc = 'UN_SIGNED_PROPOSALS_COUNT_DESC',
   UnSignedProposalsMapAsc = 'UN_SIGNED_PROPOSALS_MAP_ASC',
-  UnSignedProposalsMapDesc = 'UN_SIGNED_PROPOSALS_MAP_DESC'
+  UnSignedProposalsMapDesc = 'UN_SIGNED_PROPOSALS_MAP_DESC',
 }
 
 export type ProposalItem = Node & {
@@ -4736,7 +4684,6 @@ export type ProposalItem = Node & {
   unsignedProposalsQueuesByUnsignedProposalsQueueItemProposalIdAndQueueId: ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemProposalIdAndQueueIdManyToManyConnection;
 };
 
-
 export type ProposalItemBlocksByProposalVoteProposalIdAndBlockIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -4746,7 +4693,6 @@ export type ProposalItemBlocksByProposalVoteProposalIdAndBlockIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<BlocksOrderBy>>;
 };
-
 
 export type ProposalItemProposalTimelineStatusesArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -4758,7 +4704,6 @@ export type ProposalItemProposalTimelineStatusesArgs = {
   orderBy?: InputMaybe<Array<ProposalTimelineStatusesOrderBy>>;
 };
 
-
 export type ProposalItemProposalVotesByProposalIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -4768,7 +4713,6 @@ export type ProposalItemProposalVotesByProposalIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ProposalVotesOrderBy>>;
 };
-
 
 export type ProposalItemProposersByProposalVoteProposalIdAndVoterIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -4780,7 +4724,6 @@ export type ProposalItemProposersByProposalVoteProposalIdAndVoterIdArgs = {
   orderBy?: InputMaybe<Array<ProposersOrderBy>>;
 };
 
-
 export type ProposalItemUnsignedProposalsQueueItemsByProposalIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -4790,7 +4733,6 @@ export type ProposalItemUnsignedProposalsQueueItemsByProposalIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<UnsignedProposalsQueueItemsOrderBy>>;
 };
-
 
 export type ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemProposalIdAndQueueIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -4850,7 +4792,6 @@ export type ProposalItemBlocksByProposalVoteProposalIdAndBlockIdManyToManyConnec
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Block` values, with data from `ProposalVote`. */
 export type ProposalItemBlocksByProposalVoteProposalIdAndBlockIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<BlocksGroupBy>;
@@ -4867,7 +4808,6 @@ export type ProposalItemBlocksByProposalVoteProposalIdAndBlockIdManyToManyEdge =
   /** Reads and enables pagination through a set of `ProposalVote`. */
   proposalVotes: ProposalVotesConnection;
 };
-
 
 /** A `Block` edge in the connection, with data from `ProposalVote`. */
 export type ProposalItemBlocksByProposalVoteProposalIdAndBlockIdManyToManyEdgeProposalVotesArgs = {
@@ -4963,7 +4903,6 @@ export type ProposalItemProposersByProposalVoteProposalIdAndVoterIdManyToManyCon
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Proposer` values, with data from `ProposalVote`. */
 export type ProposalItemProposersByProposalVoteProposalIdAndVoterIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposersGroupBy>;
@@ -4980,7 +4919,6 @@ export type ProposalItemProposersByProposalVoteProposalIdAndVoterIdManyToManyEdg
   /** Reads and enables pagination through a set of `ProposalVote`. */
   proposalVotesByVoterId: ProposalVotesConnection;
 };
-
 
 /** A `Proposer` edge in the connection, with data from `ProposalVote`. */
 export type ProposalItemProposersByProposalVoteProposalIdAndVoterIdManyToManyEdgeProposalVotesByVoterIdArgs = {
@@ -5034,12 +4972,12 @@ export type ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemPropo
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `UnsignedProposalsQueue` values, with data from `UnsignedProposalsQueueItem`. */
-export type ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemProposalIdAndQueueIdManyToManyConnectionGroupedAggregatesArgs = {
-  groupBy: Array<UnsignedProposalsQueuesGroupBy>;
-  having?: InputMaybe<UnsignedProposalsQueuesHavingInput>;
-};
+export type ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemProposalIdAndQueueIdManyToManyConnectionGroupedAggregatesArgs =
+  {
+    groupBy: Array<UnsignedProposalsQueuesGroupBy>;
+    having?: InputMaybe<UnsignedProposalsQueuesHavingInput>;
+  };
 
 /** A `UnsignedProposalsQueue` edge in the connection, with data from `UnsignedProposalsQueueItem`. */
 export type ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemProposalIdAndQueueIdManyToManyEdge = {
@@ -5052,17 +4990,17 @@ export type ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemPropo
   unsignedProposalsQueueItemsByQueueId: UnsignedProposalsQueueItemsConnection;
 };
 
-
 /** A `UnsignedProposalsQueue` edge in the connection, with data from `UnsignedProposalsQueueItem`. */
-export type ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemProposalIdAndQueueIdManyToManyEdgeUnsignedProposalsQueueItemsByQueueIdArgs = {
-  after?: InputMaybe<Scalars['Cursor']>;
-  before?: InputMaybe<Scalars['Cursor']>;
-  filter?: InputMaybe<UnsignedProposalsQueueItemFilter>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Array<UnsignedProposalsQueueItemsOrderBy>>;
-};
+export type ProposalItemUnsignedProposalsQueuesByUnsignedProposalsQueueItemProposalIdAndQueueIdManyToManyEdgeUnsignedProposalsQueueItemsByQueueIdArgs =
+  {
+    after?: InputMaybe<Scalars['Cursor']>;
+    before?: InputMaybe<Scalars['Cursor']>;
+    filter?: InputMaybe<UnsignedProposalsQueueItemFilter>;
+    first?: InputMaybe<Scalars['Int']>;
+    last?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    orderBy?: InputMaybe<Array<UnsignedProposalsQueueItemsOrderBy>>;
+  };
 
 export type ProposalItemVariancePopulationAggregates = {
   __typename?: 'ProposalItemVariancePopulationAggregates';
@@ -5097,7 +5035,6 @@ export type ProposalItemsConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `ProposalItem` values. */
 export type ProposalItemsConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposalItemsGroupBy>;
@@ -5122,7 +5059,7 @@ export enum ProposalItemsGroupBy {
   Removed = 'REMOVED',
   Signature = 'SIGNATURE',
   Status = 'STATUS',
-  Type = 'TYPE'
+  Type = 'TYPE',
 }
 
 export type ProposalItemsHavingAverageInput = {
@@ -5501,7 +5438,7 @@ export enum ProposalItemsOrderBy {
   UnsignedProposalsQueueItemsByProposalIdVarianceSampleProposalIdAsc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_PROPOSAL_ID_VARIANCE_SAMPLE_PROPOSAL_ID_ASC',
   UnsignedProposalsQueueItemsByProposalIdVarianceSampleProposalIdDesc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_PROPOSAL_ID_VARIANCE_SAMPLE_PROPOSAL_ID_DESC',
   UnsignedProposalsQueueItemsByProposalIdVarianceSampleQueueIdAsc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_PROPOSAL_ID_VARIANCE_SAMPLE_QUEUE_ID_ASC',
-  UnsignedProposalsQueueItemsByProposalIdVarianceSampleQueueIdDesc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_PROPOSAL_ID_VARIANCE_SAMPLE_QUEUE_ID_DESC'
+  UnsignedProposalsQueueItemsByProposalIdVarianceSampleQueueIdDesc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_PROPOSAL_ID_VARIANCE_SAMPLE_QUEUE_ID_DESC',
 }
 
 export enum ProposalStatus {
@@ -5511,7 +5448,7 @@ export enum ProposalStatus {
   Open = 'Open',
   Rejected = 'Rejected',
   Removed = 'Removed',
-  Signed = 'Signed'
+  Signed = 'Signed',
 }
 
 /** A filter to be used against ProposalStatus fields. All fields are combined with a logical ‘and.’ */
@@ -5680,7 +5617,6 @@ export type ProposalTimelineStatusesConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `ProposalTimelineStatus` values. */
 export type ProposalTimelineStatusesConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposalTimelineStatusesGroupBy>;
@@ -5704,7 +5640,7 @@ export enum ProposalTimelineStatusesGroupBy {
   Timestamp = 'TIMESTAMP',
   TimestampTruncatedToDay = 'TIMESTAMP_TRUNCATED_TO_DAY',
   TimestampTruncatedToHour = 'TIMESTAMP_TRUNCATED_TO_HOUR',
-  TxHash = 'TX_HASH'
+  TxHash = 'TX_HASH',
 }
 
 export type ProposalTimelineStatusesHavingAverageInput = {
@@ -5783,7 +5719,7 @@ export enum ProposalTimelineStatusesOrderBy {
   TimestampAsc = 'TIMESTAMP_ASC',
   TimestampDesc = 'TIMESTAMP_DESC',
   TxHashAsc = 'TX_HASH_ASC',
-  TxHashDesc = 'TX_HASH_DESC'
+  TxHashDesc = 'TX_HASH_DESC',
 }
 
 export enum ProposalType {
@@ -5802,7 +5738,7 @@ export enum ProposalType {
   TokenAddProposal = 'TokenAddProposal',
   TokenRemoveProposal = 'TokenRemoveProposal',
   Unknown = 'Unknown',
-  WrappingFeeUpdateProposal = 'WrappingFeeUpdateProposal'
+  WrappingFeeUpdateProposal = 'WrappingFeeUpdateProposal',
 }
 
 /** A filter to be used against ProposalType fields. All fields are combined with a logical ‘and.’ */
@@ -5975,7 +5911,6 @@ export type ProposalVotesConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `ProposalVote` values. */
 export type ProposalVotesConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposalVotesGroupBy>;
@@ -5997,7 +5932,7 @@ export enum ProposalVotesGroupBy {
   BlockNumber = 'BLOCK_NUMBER',
   For = 'FOR',
   ProposalId = 'PROPOSAL_ID',
-  VoterId = 'VOTER_ID'
+  VoterId = 'VOTER_ID',
 }
 
 export type ProposalVotesHavingAverageInput = {
@@ -6067,7 +6002,7 @@ export enum ProposalVotesOrderBy {
   ProposalIdAsc = 'PROPOSAL_ID_ASC',
   ProposalIdDesc = 'PROPOSAL_ID_DESC',
   VoterIdAsc = 'VOTER_ID_ASC',
-  VoterIdDesc = 'VOTER_ID_DESC'
+  VoterIdDesc = 'VOTER_ID_DESC',
 }
 
 export type Proposer = Node & {
@@ -6090,7 +6025,6 @@ export type Proposer = Node & {
   sessionsBySessionProposerProposerIdAndSessionId: ProposerSessionsBySessionProposerProposerIdAndSessionIdManyToManyConnection;
 };
 
-
 export type ProposerBlocksByProposalVoteVoterIdAndBlockIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -6100,7 +6034,6 @@ export type ProposerBlocksByProposalVoteVoterIdAndBlockIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<BlocksOrderBy>>;
 };
-
 
 export type ProposerProposalItemsByProposalVoteVoterIdAndProposalIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -6112,7 +6045,6 @@ export type ProposerProposalItemsByProposalVoteVoterIdAndProposalIdArgs = {
   orderBy?: InputMaybe<Array<ProposalItemsOrderBy>>;
 };
 
-
 export type ProposerProposalVotesByVoterIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -6123,7 +6055,6 @@ export type ProposerProposalVotesByVoterIdArgs = {
   orderBy?: InputMaybe<Array<ProposalVotesOrderBy>>;
 };
 
-
 export type ProposerSessionProposersArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -6133,7 +6064,6 @@ export type ProposerSessionProposersArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<SessionProposersOrderBy>>;
 };
-
 
 export type ProposerSessionsBySessionProposerProposerIdAndSessionIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -6169,7 +6099,6 @@ export type ProposerBlocksByProposalVoteVoterIdAndBlockIdManyToManyConnection = 
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Block` values, with data from `ProposalVote`. */
 export type ProposerBlocksByProposalVoteVoterIdAndBlockIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<BlocksGroupBy>;
@@ -6186,7 +6115,6 @@ export type ProposerBlocksByProposalVoteVoterIdAndBlockIdManyToManyEdge = {
   /** Reads and enables pagination through a set of `ProposalVote`. */
   proposalVotes: ProposalVotesConnection;
 };
-
 
 /** A `Block` edge in the connection, with data from `ProposalVote`. */
 export type ProposerBlocksByProposalVoteVoterIdAndBlockIdManyToManyEdgeProposalVotesArgs = {
@@ -6238,7 +6166,6 @@ export type ProposerProposalItemsByProposalVoteVoterIdAndProposalIdManyToManyCon
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `ProposalItem` values, with data from `ProposalVote`. */
 export type ProposerProposalItemsByProposalVoteVoterIdAndProposalIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposalItemsGroupBy>;
@@ -6255,7 +6182,6 @@ export type ProposerProposalItemsByProposalVoteVoterIdAndProposalIdManyToManyEdg
   /** Reads and enables pagination through a set of `ProposalVote`. */
   proposalVotesByProposalId: ProposalVotesConnection;
 };
-
 
 /** A `ProposalItem` edge in the connection, with data from `ProposalVote`. */
 export type ProposerProposalItemsByProposalVoteVoterIdAndProposalIdManyToManyEdgeProposalVotesByProposalIdArgs = {
@@ -6285,7 +6211,6 @@ export type ProposerSessionsBySessionProposerProposerIdAndSessionIdManyToManyCon
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Session` values, with data from `SessionProposer`. */
 export type ProposerSessionsBySessionProposerProposerIdAndSessionIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<SessionsGroupBy>;
@@ -6302,7 +6227,6 @@ export type ProposerSessionsBySessionProposerProposerIdAndSessionIdManyToManyEdg
   /** Reads and enables pagination through a set of `SessionProposer`. */
   sessionProposers: SessionProposersConnection;
 };
-
 
 /** A `Session` edge in the connection, with data from `SessionProposer`. */
 export type ProposerSessionsBySessionProposerProposerIdAndSessionIdManyToManyEdgeSessionProposersArgs = {
@@ -6440,7 +6364,6 @@ export type ProposerThresholdsConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `ProposerThreshold` values. */
 export type ProposerThresholdsConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposerThresholdsGroupBy>;
@@ -6459,7 +6382,7 @@ export type ProposerThresholdsEdge = {
 /** Grouping methods for `ProposerThreshold` for usage during aggregation. */
 export enum ProposerThresholdsGroupBy {
   BlockId = 'BLOCK_ID',
-  Value = 'VALUE'
+  Value = 'VALUE',
 }
 
 export type ProposerThresholdsHavingAverageInput = {
@@ -6523,7 +6446,7 @@ export enum ProposerThresholdsOrderBy {
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
   ValueAsc = 'VALUE_ASC',
-  ValueDesc = 'VALUE_DESC'
+  ValueDesc = 'VALUE_DESC',
 }
 
 /** A connection to a list of `Proposer` values. */
@@ -6543,7 +6466,6 @@ export type ProposersConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Proposer` values. */
 export type ProposersConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposersGroupBy>;
@@ -6561,7 +6483,7 @@ export type ProposersEdge = {
 
 /** Grouping methods for `Proposer` for usage during aggregation. */
 export enum ProposersGroupBy {
-  AccountId = 'ACCOUNT_ID'
+  AccountId = 'ACCOUNT_ID',
 }
 
 /** Conditions for `Proposer` aggregates. */
@@ -6744,7 +6666,7 @@ export enum ProposersOrderBy {
   SessionProposersVarianceSampleProposerIdAsc = 'SESSION_PROPOSERS_VARIANCE_SAMPLE_PROPOSER_ID_ASC',
   SessionProposersVarianceSampleProposerIdDesc = 'SESSION_PROPOSERS_VARIANCE_SAMPLE_PROPOSER_ID_DESC',
   SessionProposersVarianceSampleSessionIdAsc = 'SESSION_PROPOSERS_VARIANCE_SAMPLE_SESSION_ID_ASC',
-  SessionProposersVarianceSampleSessionIdDesc = 'SESSION_PROPOSERS_VARIANCE_SAMPLE_SESSION_ID_DESC'
+  SessionProposersVarianceSampleSessionIdDesc = 'SESSION_PROPOSERS_VARIANCE_SAMPLE_SESSION_ID_DESC',
 }
 
 export type PublicKey = Node & {
@@ -6764,7 +6686,6 @@ export type PublicKey = Node & {
   uncompressed?: Maybe<Scalars['String']>;
 };
 
-
 export type PublicKeyBlocksBySessionPublicKeyIdAndBlockIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -6774,7 +6695,6 @@ export type PublicKeyBlocksBySessionPublicKeyIdAndBlockIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<BlocksOrderBy>>;
 };
-
 
 export type PublicKeySessionsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -6810,7 +6730,6 @@ export type PublicKeyBlocksBySessionPublicKeyIdAndBlockIdManyToManyConnection = 
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Block` values, with data from `Session`. */
 export type PublicKeyBlocksBySessionPublicKeyIdAndBlockIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<BlocksGroupBy>;
@@ -6827,7 +6746,6 @@ export type PublicKeyBlocksBySessionPublicKeyIdAndBlockIdManyToManyEdge = {
   /** Reads and enables pagination through a set of `Session`. */
   sessions: SessionsConnection;
 };
-
 
 /** A `Block` edge in the connection, with data from `Session`. */
 export type PublicKeyBlocksBySessionPublicKeyIdAndBlockIdManyToManyEdgeSessionsArgs = {
@@ -6891,7 +6809,6 @@ export type PublicKeysConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `PublicKey` values. */
 export type PublicKeysConnectionGroupedAggregatesArgs = {
   groupBy: Array<PublicKeysGroupBy>;
@@ -6911,7 +6828,7 @@ export type PublicKeysEdge = {
 export enum PublicKeysGroupBy {
   BlockId = 'BLOCK_ID',
   Compressed = 'COMPRESSED',
-  History = 'HISTORY'
+  History = 'HISTORY',
 }
 
 /** Conditions for `PublicKey` aggregates. */
@@ -7062,7 +6979,7 @@ export enum PublicKeysOrderBy {
   SessionsVarianceSampleSignatureThresholdAsc = 'SESSIONS_VARIANCE_SAMPLE_SIGNATURE_THRESHOLD_ASC',
   SessionsVarianceSampleSignatureThresholdDesc = 'SESSIONS_VARIANCE_SAMPLE_SIGNATURE_THRESHOLD_DESC',
   UncompressedAsc = 'UNCOMPRESSED_ASC',
-  UncompressedDesc = 'UNCOMPRESSED_DESC'
+  UncompressedDesc = 'UNCOMPRESSED_DESC',
 }
 
 /** The root query type which gives access points into the data universe. */
@@ -7180,18 +7097,15 @@ export type Query = Node & {
   validators?: Maybe<ValidatorsConnection>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryAccountArgs = {
   id: Scalars['String'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryAccountByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryAccountsArgs = {
@@ -7204,7 +7118,6 @@ export type QueryAccountsArgs = {
   orderBy?: InputMaybe<Array<AccountsOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryAuthoritiesArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -7216,30 +7129,25 @@ export type QueryAuthoritiesArgs = {
   orderBy?: InputMaybe<Array<AuthoritiesOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryAuthorityArgs = {
   id: Scalars['String'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryAuthorityByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryBlockArgs = {
   id: Scalars['String'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryBlockByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryBlocksArgs = {
@@ -7252,18 +7160,15 @@ export type QueryBlocksArgs = {
   orderBy?: InputMaybe<Array<BlocksOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryEventArgs = {
   id: Scalars['String'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryEventByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryEventsArgs = {
@@ -7276,18 +7181,15 @@ export type QueryEventsArgs = {
   orderBy?: InputMaybe<Array<EventsOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryExtrinsicArgs = {
   id: Scalars['String'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryExtrinsicByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryExtrinsicsArgs = {
@@ -7300,18 +7202,15 @@ export type QueryExtrinsicsArgs = {
   orderBy?: InputMaybe<Array<ExtrinsicsOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryKeygenThresholdArgs = {
   id: Scalars['String'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryKeygenThresholdByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryKeygenThresholdsArgs = {
@@ -7324,24 +7223,20 @@ export type QueryKeygenThresholdsArgs = {
   orderBy?: InputMaybe<Array<KeygenThresholdsOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryNodeArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalCounterArgs = {
   id: Scalars['String'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalCounterByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalCountersArgs = {
@@ -7354,18 +7249,15 @@ export type QueryProposalCountersArgs = {
   orderBy?: InputMaybe<Array<ProposalCountersOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalItemArgs = {
   id: Scalars['String'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalItemByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalItemsArgs = {
@@ -7378,18 +7270,15 @@ export type QueryProposalItemsArgs = {
   orderBy?: InputMaybe<Array<ProposalItemsOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalTimelineStatusArgs = {
   id: Scalars['String'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalTimelineStatusByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalTimelineStatusesArgs = {
@@ -7402,18 +7291,15 @@ export type QueryProposalTimelineStatusesArgs = {
   orderBy?: InputMaybe<Array<ProposalTimelineStatusesOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalVoteArgs = {
   id: Scalars['String'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalVoteByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryProposalVotesArgs = {
@@ -7426,30 +7312,25 @@ export type QueryProposalVotesArgs = {
   orderBy?: InputMaybe<Array<ProposalVotesOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryProposerArgs = {
   id: Scalars['String'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryProposerByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryProposerThresholdArgs = {
   id: Scalars['String'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryProposerThresholdByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryProposerThresholdsArgs = {
@@ -7462,7 +7343,6 @@ export type QueryProposerThresholdsArgs = {
   orderBy?: InputMaybe<Array<ProposerThresholdsOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryProposersArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -7474,18 +7354,15 @@ export type QueryProposersArgs = {
   orderBy?: InputMaybe<Array<ProposersOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryPublicKeyArgs = {
   id: Scalars['String'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryPublicKeyByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryPublicKeysArgs = {
@@ -7498,30 +7375,25 @@ export type QueryPublicKeysArgs = {
   orderBy?: InputMaybe<Array<PublicKeysOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionArgs = {
   id: Scalars['String'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionProposerArgs = {
   id: Scalars['String'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionProposerByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionProposersArgs = {
@@ -7534,18 +7406,15 @@ export type QuerySessionProposersArgs = {
   orderBy?: InputMaybe<Array<SessionProposersOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionValidatorArgs = {
   id: Scalars['String'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionValidatorByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionValidatorsArgs = {
@@ -7558,7 +7427,6 @@ export type QuerySessionValidatorsArgs = {
   orderBy?: InputMaybe<Array<SessionValidatorsOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QuerySessionsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -7570,18 +7438,15 @@ export type QuerySessionsArgs = {
   orderBy?: InputMaybe<Array<SessionsOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QuerySignatureThresholdArgs = {
   id: Scalars['String'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QuerySignatureThresholdByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QuerySignatureThresholdsArgs = {
@@ -7594,30 +7459,25 @@ export type QuerySignatureThresholdsArgs = {
   orderBy?: InputMaybe<Array<SignatureThresholdsOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryUnsignedProposalsQueueArgs = {
   id: Scalars['String'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryUnsignedProposalsQueueByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryUnsignedProposalsQueueItemArgs = {
   id: Scalars['String'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryUnsignedProposalsQueueItemByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryUnsignedProposalsQueueItemsArgs = {
@@ -7630,7 +7490,6 @@ export type QueryUnsignedProposalsQueueItemsArgs = {
   orderBy?: InputMaybe<Array<UnsignedProposalsQueueItemsOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryUnsignedProposalsQueuesArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -7642,18 +7501,15 @@ export type QueryUnsignedProposalsQueuesArgs = {
   orderBy?: InputMaybe<Array<UnsignedProposalsQueuesOrderBy>>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryValidatorArgs = {
   id: Scalars['String'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryValidatorByNodeIdArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryValidatorsArgs = {
@@ -7691,7 +7547,6 @@ export type Session = Node & {
   validatorsBySessionValidatorSessionIdAndValidatorId: SessionValidatorsBySessionValidatorSessionIdAndValidatorIdManyToManyConnection;
 };
 
-
 export type SessionProposersBySessionProposerSessionIdAndProposerIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -7701,7 +7556,6 @@ export type SessionProposersBySessionProposerSessionIdAndProposerIdArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ProposersOrderBy>>;
 };
-
 
 export type SessionSessionProposersArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -7713,7 +7567,6 @@ export type SessionSessionProposersArgs = {
   orderBy?: InputMaybe<Array<SessionProposersOrderBy>>;
 };
 
-
 export type SessionSessionValidatorsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -7723,7 +7576,6 @@ export type SessionSessionValidatorsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<SessionValidatorsOrderBy>>;
 };
-
 
 export type SessionValidatorsBySessionValidatorSessionIdAndValidatorIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -7881,7 +7733,6 @@ export type SessionProposersBySessionProposerSessionIdAndProposerIdManyToManyCon
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Proposer` values, with data from `SessionProposer`. */
 export type SessionProposersBySessionProposerSessionIdAndProposerIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<ProposersGroupBy>;
@@ -7898,7 +7749,6 @@ export type SessionProposersBySessionProposerSessionIdAndProposerIdManyToManyEdg
   /** Reads and enables pagination through a set of `SessionProposer`. */
   sessionProposers: SessionProposersConnection;
 };
-
 
 /** A `Proposer` edge in the connection, with data from `SessionProposer`. */
 export type SessionProposersBySessionProposerSessionIdAndProposerIdManyToManyEdgeSessionProposersArgs = {
@@ -7928,7 +7778,6 @@ export type SessionProposersConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `SessionProposer` values. */
 export type SessionProposersConnectionGroupedAggregatesArgs = {
   groupBy: Array<SessionProposersGroupBy>;
@@ -7947,7 +7796,7 @@ export type SessionProposersEdge = {
 /** Grouping methods for `SessionProposer` for usage during aggregation. */
 export enum SessionProposersGroupBy {
   ProposerId = 'PROPOSER_ID',
-  SessionId = 'SESSION_ID'
+  SessionId = 'SESSION_ID',
 }
 
 /** Conditions for `SessionProposer` aggregates. */
@@ -7966,7 +7815,7 @@ export enum SessionProposersOrderBy {
   ProposerIdAsc = 'PROPOSER_ID_ASC',
   ProposerIdDesc = 'PROPOSER_ID_DESC',
   SessionIdAsc = 'SESSION_ID_ASC',
-  SessionIdDesc = 'SESSION_ID_DESC'
+  SessionIdDesc = 'SESSION_ID_DESC',
 }
 
 export type SessionStddevPopulationAggregates = {
@@ -8160,7 +8009,6 @@ export type SessionValidatorsBySessionValidatorSessionIdAndValidatorIdManyToMany
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Validator` values, with data from `SessionValidator`. */
 export type SessionValidatorsBySessionValidatorSessionIdAndValidatorIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<ValidatorsGroupBy>;
@@ -8177,7 +8025,6 @@ export type SessionValidatorsBySessionValidatorSessionIdAndValidatorIdManyToMany
   /** Reads and enables pagination through a set of `SessionValidator`. */
   sessionValidators: SessionValidatorsConnection;
 };
-
 
 /** A `Validator` edge in the connection, with data from `SessionValidator`. */
 export type SessionValidatorsBySessionValidatorSessionIdAndValidatorIdManyToManyEdgeSessionValidatorsArgs = {
@@ -8207,7 +8054,6 @@ export type SessionValidatorsConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `SessionValidator` values. */
 export type SessionValidatorsConnectionGroupedAggregatesArgs = {
   groupBy: Array<SessionValidatorsGroupBy>;
@@ -8232,7 +8078,7 @@ export enum SessionValidatorsGroupBy {
   NextBestOrder = 'NEXT_BEST_ORDER',
   Reputation = 'REPUTATION',
   SessionId = 'SESSION_ID',
-  ValidatorId = 'VALIDATOR_ID'
+  ValidatorId = 'VALIDATOR_ID',
 }
 
 export type SessionValidatorsHavingAverageInput = {
@@ -8317,7 +8163,7 @@ export enum SessionValidatorsOrderBy {
   SessionIdAsc = 'SESSION_ID_ASC',
   SessionIdDesc = 'SESSION_ID_DESC',
   ValidatorIdAsc = 'VALIDATOR_ID_ASC',
-  ValidatorIdDesc = 'VALIDATOR_ID_DESC'
+  ValidatorIdDesc = 'VALIDATOR_ID_DESC',
 }
 
 export type SessionVariancePopulationAggregates = {
@@ -8349,7 +8195,6 @@ export type SessionsConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Session` values. */
 export type SessionsConnectionGroupedAggregatesArgs = {
   groupBy: Array<SessionsGroupBy>;
@@ -8372,7 +8217,7 @@ export enum SessionsGroupBy {
   KeyGenThreshold = 'KEY_GEN_THRESHOLD',
   ProposerThreshold = 'PROPOSER_THRESHOLD',
   PublicKeyId = 'PUBLIC_KEY_ID',
-  SignatureThreshold = 'SIGNATURE_THRESHOLD'
+  SignatureThreshold = 'SIGNATURE_THRESHOLD',
 }
 
 export type SessionsHavingAverageInput = {
@@ -8664,7 +8509,7 @@ export enum SessionsOrderBy {
   SessionValidatorsVarianceSampleValidatorIdAsc = 'SESSION_VALIDATORS_VARIANCE_SAMPLE_VALIDATOR_ID_ASC',
   SessionValidatorsVarianceSampleValidatorIdDesc = 'SESSION_VALIDATORS_VARIANCE_SAMPLE_VALIDATOR_ID_DESC',
   SignatureThresholdAsc = 'SIGNATURE_THRESHOLD_ASC',
-  SignatureThresholdDesc = 'SIGNATURE_THRESHOLD_DESC'
+  SignatureThresholdDesc = 'SIGNATURE_THRESHOLD_DESC',
 }
 
 export type SignatureThreshold = Node & {
@@ -8834,7 +8679,6 @@ export type SignatureThresholdsConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `SignatureThreshold` values. */
 export type SignatureThresholdsConnectionGroupedAggregatesArgs = {
   groupBy: Array<SignatureThresholdsGroupBy>;
@@ -8855,7 +8699,7 @@ export enum SignatureThresholdsGroupBy {
   BlockId = 'BLOCK_ID',
   Current = 'CURRENT',
   Next = 'NEXT',
-  Pending = 'PENDING'
+  Pending = 'PENDING',
 }
 
 export type SignatureThresholdsHavingAverageInput = {
@@ -8941,7 +8785,7 @@ export enum SignatureThresholdsOrderBy {
   PendingAsc = 'PENDING_ASC',
   PendingDesc = 'PENDING_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
 }
 
 /** A filter to be used against String fields. All fields are combined with a logical ‘and.’ */
@@ -9043,7 +8887,6 @@ export type UnsignedProposalsQueue = Node & {
   unsignedProposalsQueueItemsByQueueId: UnsignedProposalsQueueItemsConnection;
 };
 
-
 export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueueIdAndProposalIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -9053,7 +8896,6 @@ export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueue
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ProposalItemsOrderBy>>;
 };
-
 
 export type UnsignedProposalsQueueUnsignedProposalsQueueItemsByQueueIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -9252,7 +9094,6 @@ export type UnsignedProposalsQueueItemsConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `UnsignedProposalsQueueItem` values. */
 export type UnsignedProposalsQueueItemsConnectionGroupedAggregatesArgs = {
   groupBy: Array<UnsignedProposalsQueueItemsGroupBy>;
@@ -9272,7 +9113,7 @@ export type UnsignedProposalsQueueItemsEdge = {
 export enum UnsignedProposalsQueueItemsGroupBy {
   BlockNumber = 'BLOCK_NUMBER',
   ProposalId = 'PROPOSAL_ID',
-  QueueId = 'QUEUE_ID'
+  QueueId = 'QUEUE_ID',
 }
 
 export type UnsignedProposalsQueueItemsHavingAverageInput = {
@@ -9338,7 +9179,7 @@ export enum UnsignedProposalsQueueItemsOrderBy {
   ProposalIdAsc = 'PROPOSAL_ID_ASC',
   ProposalIdDesc = 'PROPOSAL_ID_DESC',
   QueueIdAsc = 'QUEUE_ID_ASC',
-  QueueIdDesc = 'QUEUE_ID_DESC'
+  QueueIdDesc = 'QUEUE_ID_DESC',
 }
 
 export type UnsignedProposalsQueueMaxAggregates = {
@@ -9370,12 +9211,12 @@ export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueue
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `ProposalItem` values, with data from `UnsignedProposalsQueueItem`. */
-export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueueIdAndProposalIdManyToManyConnectionGroupedAggregatesArgs = {
-  groupBy: Array<ProposalItemsGroupBy>;
-  having?: InputMaybe<ProposalItemsHavingInput>;
-};
+export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueueIdAndProposalIdManyToManyConnectionGroupedAggregatesArgs =
+  {
+    groupBy: Array<ProposalItemsGroupBy>;
+    having?: InputMaybe<ProposalItemsHavingInput>;
+  };
 
 /** A `ProposalItem` edge in the connection, with data from `UnsignedProposalsQueueItem`. */
 export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueueIdAndProposalIdManyToManyEdge = {
@@ -9388,17 +9229,17 @@ export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueue
   unsignedProposalsQueueItemsByProposalId: UnsignedProposalsQueueItemsConnection;
 };
 
-
 /** A `ProposalItem` edge in the connection, with data from `UnsignedProposalsQueueItem`. */
-export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueueIdAndProposalIdManyToManyEdgeUnsignedProposalsQueueItemsByProposalIdArgs = {
-  after?: InputMaybe<Scalars['Cursor']>;
-  before?: InputMaybe<Scalars['Cursor']>;
-  filter?: InputMaybe<UnsignedProposalsQueueItemFilter>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Array<UnsignedProposalsQueueItemsOrderBy>>;
-};
+export type UnsignedProposalsQueueProposalItemsByUnsignedProposalsQueueItemQueueIdAndProposalIdManyToManyEdgeUnsignedProposalsQueueItemsByProposalIdArgs =
+  {
+    after?: InputMaybe<Scalars['Cursor']>;
+    before?: InputMaybe<Scalars['Cursor']>;
+    filter?: InputMaybe<UnsignedProposalsQueueItemFilter>;
+    first?: InputMaybe<Scalars['Int']>;
+    last?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    orderBy?: InputMaybe<Array<UnsignedProposalsQueueItemsOrderBy>>;
+  };
 
 export type UnsignedProposalsQueueStddevPopulationAggregates = {
   __typename?: 'UnsignedProposalsQueueStddevPopulationAggregates';
@@ -9447,7 +9288,6 @@ export type UnsignedProposalsQueuesConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `UnsignedProposalsQueue` values. */
 export type UnsignedProposalsQueuesConnectionGroupedAggregatesArgs = {
   groupBy: Array<UnsignedProposalsQueuesGroupBy>;
@@ -9466,7 +9306,7 @@ export type UnsignedProposalsQueuesEdge = {
 /** Grouping methods for `UnsignedProposalsQueue` for usage during aggregation. */
 export enum UnsignedProposalsQueuesGroupBy {
   BlockId = 'BLOCK_ID',
-  BlockNumber = 'BLOCK_NUMBER'
+  BlockNumber = 'BLOCK_NUMBER',
 }
 
 export type UnsignedProposalsQueuesHavingAverageInput = {
@@ -9604,7 +9444,7 @@ export enum UnsignedProposalsQueuesOrderBy {
   UnsignedProposalsQueueItemsByQueueIdVarianceSampleProposalIdAsc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_QUEUE_ID_VARIANCE_SAMPLE_PROPOSAL_ID_ASC',
   UnsignedProposalsQueueItemsByQueueIdVarianceSampleProposalIdDesc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_QUEUE_ID_VARIANCE_SAMPLE_PROPOSAL_ID_DESC',
   UnsignedProposalsQueueItemsByQueueIdVarianceSampleQueueIdAsc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_QUEUE_ID_VARIANCE_SAMPLE_QUEUE_ID_ASC',
-  UnsignedProposalsQueueItemsByQueueIdVarianceSampleQueueIdDesc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_QUEUE_ID_VARIANCE_SAMPLE_QUEUE_ID_DESC'
+  UnsignedProposalsQueueItemsByQueueIdVarianceSampleQueueIdDesc = 'UNSIGNED_PROPOSALS_QUEUE_ITEMS_BY_QUEUE_ID_VARIANCE_SAMPLE_QUEUE_ID_DESC',
 }
 
 export type Validator = Node & {
@@ -9622,7 +9462,6 @@ export type Validator = Node & {
   sessionsBySessionValidatorValidatorIdAndSessionId: ValidatorSessionsBySessionValidatorValidatorIdAndSessionIdManyToManyConnection;
 };
 
-
 export type ValidatorSessionValidatorsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -9632,7 +9471,6 @@ export type ValidatorSessionValidatorsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<SessionValidatorsOrderBy>>;
 };
-
 
 export type ValidatorSessionsBySessionValidatorValidatorIdAndSessionIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -9694,7 +9532,6 @@ export type ValidatorSessionsBySessionValidatorValidatorIdAndSessionIdManyToMany
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Session` values, with data from `SessionValidator`. */
 export type ValidatorSessionsBySessionValidatorValidatorIdAndSessionIdManyToManyConnectionGroupedAggregatesArgs = {
   groupBy: Array<SessionsGroupBy>;
@@ -9711,7 +9548,6 @@ export type ValidatorSessionsBySessionValidatorValidatorIdAndSessionIdManyToMany
   /** Reads and enables pagination through a set of `SessionValidator`. */
   sessionValidators: SessionValidatorsConnection;
 };
-
 
 /** A `Session` edge in the connection, with data from `SessionValidator`. */
 export type ValidatorSessionsBySessionValidatorValidatorIdAndSessionIdManyToManyEdgeSessionValidatorsArgs = {
@@ -9741,7 +9577,6 @@ export type ValidatorsConnection = {
   totalCount: Scalars['Int'];
 };
 
-
 /** A connection to a list of `Validator` values. */
 export type ValidatorsConnectionGroupedAggregatesArgs = {
   groupBy: Array<ValidatorsGroupBy>;
@@ -9759,7 +9594,7 @@ export type ValidatorsEdge = {
 
 /** Grouping methods for `Validator` for usage during aggregation. */
 export enum ValidatorsGroupBy {
-  AccountId = 'ACCOUNT_ID'
+  AccountId = 'ACCOUNT_ID',
 }
 
 /** Conditions for `Validator` aggregates. */
@@ -9942,7 +9777,7 @@ export enum ValidatorsOrderBy {
   SessionValidatorsVarianceSampleSessionIdAsc = 'SESSION_VALIDATORS_VARIANCE_SAMPLE_SESSION_ID_ASC',
   SessionValidatorsVarianceSampleSessionIdDesc = 'SESSION_VALIDATORS_VARIANCE_SAMPLE_SESSION_ID_DESC',
   SessionValidatorsVarianceSampleValidatorIdAsc = 'SESSION_VALIDATORS_VARIANCE_SAMPLE_VALIDATOR_ID_ASC',
-  SessionValidatorsVarianceSampleValidatorIdDesc = 'SESSION_VALIDATORS_VARIANCE_SAMPLE_VALIDATOR_ID_DESC'
+  SessionValidatorsVarianceSampleValidatorIdDesc = 'SESSION_VALIDATORS_VARIANCE_SAMPLE_VALIDATOR_ID_DESC',
 }
 
 export type _Metadata = {
@@ -9966,8 +9801,43 @@ export type ValidatorListingQueryVariables = Exact<{
   offset: Scalars['Int'];
 }>;
 
-
-export type ValidatorListingQuery = { __typename?: 'Query', validators?: { __typename?: 'ValidatorsConnection', totalCount: number, nodes: Array<{ __typename?: 'Validator', authorityId: string, id: string, sessionValidators: { __typename?: 'SessionValidatorsConnection', edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> } } | null>, pageInfo: { __typename?: 'PageInfo', endCursor?: any | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: any | null } } | null };
+export type ValidatorListingQuery = {
+  __typename?: 'Query';
+  validators?: {
+    __typename?: 'ValidatorsConnection';
+    totalCount: number;
+    nodes: Array<{
+      __typename?: 'Validator';
+      authorityId: string;
+      id: string;
+      sessionValidators: {
+        __typename?: 'SessionValidatorsConnection';
+        edges: Array<{
+          __typename?: 'SessionValidatorsEdge';
+          node?: {
+            __typename?: 'SessionValidator';
+            id: string;
+            sessionId: string;
+            reputation: string;
+            isBest: boolean;
+            isNext: boolean;
+            isNextBest: boolean;
+            bestOrder: number;
+            nextBestOrder: number;
+            validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
+          } | null;
+        }>;
+      };
+    } | null>;
+    pageInfo: {
+      __typename?: 'PageInfo';
+      endCursor?: any | null;
+      hasNextPage: boolean;
+      hasPreviousPage: boolean;
+      startCursor?: any | null;
+    };
+  } | null;
+};
 
 export type ValidatorSessionsQueryVariables = Exact<{
   keyGen?: InputMaybe<Scalars['Boolean']>;
@@ -9976,55 +9846,258 @@ export type ValidatorSessionsQueryVariables = Exact<{
   offset: Scalars['Int'];
 }>;
 
-
-export type ValidatorSessionsQuery = { __typename?: 'Query', sessionValidators?: { __typename?: 'SessionValidatorsConnection', totalCount: number, nodes: Array<{ __typename?: 'SessionValidator', validator?: { __typename?: 'Validator', authorityId: string, id: string } | null, session?: { __typename?: 'Session', id: string, publicKey?: { __typename?: 'PublicKey', id: string, compressed?: string | null, uncompressed?: string | null } | null, sessionValidators: { __typename?: 'SessionValidatorsConnection', totalCount: number, edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> } } | null } | null>, pageInfo: { __typename?: 'PageInfo', endCursor?: any | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: any | null } } | null };
+export type ValidatorSessionsQuery = {
+  __typename?: 'Query';
+  sessionValidators?: {
+    __typename?: 'SessionValidatorsConnection';
+    totalCount: number;
+    nodes: Array<{
+      __typename?: 'SessionValidator';
+      validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
+      session?: {
+        __typename?: 'Session';
+        id: string;
+        publicKey?: {
+          __typename?: 'PublicKey';
+          id: string;
+          compressed?: string | null;
+          uncompressed?: string | null;
+        } | null;
+        sessionValidators: {
+          __typename?: 'SessionValidatorsConnection';
+          totalCount: number;
+          edges: Array<{
+            __typename?: 'SessionValidatorsEdge';
+            node?: {
+              __typename?: 'SessionValidator';
+              id: string;
+              sessionId: string;
+              reputation: string;
+              isBest: boolean;
+              isNext: boolean;
+              isNextBest: boolean;
+              bestOrder: number;
+              nextBestOrder: number;
+              validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
+            } | null;
+          }>;
+        };
+      } | null;
+    } | null>;
+    pageInfo: {
+      __typename?: 'PageInfo';
+      endCursor?: any | null;
+      hasNextPage: boolean;
+      hasPreviousPage: boolean;
+      startCursor?: any | null;
+    };
+  } | null;
+};
 
 export type ValidatorOfSessionQueryVariables = Exact<{
   validatorId: Scalars['String'];
   sessionValidatorId: Scalars['String'];
 }>;
 
+export type ValidatorOfSessionQuery = {
+  __typename?: 'Query';
+  sessionValidator?: {
+    __typename?: 'SessionValidator';
+    id: string;
+    sessionId: string;
+    reputation: string;
+    isBest: boolean;
+    isNext: boolean;
+    isNextBest: boolean;
+    bestOrder: number;
+    nextBestOrder: number;
+    session?: { __typename?: 'Session'; keyGenThreshold?: any | null } | null;
+    validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
+  } | null;
+  sessionValidators?: {
+    __typename?: 'SessionValidatorsConnection';
+    aggregates?: {
+      __typename?: 'SessionValidatorAggregates';
+      distinctCount?: { __typename?: 'SessionValidatorDistinctCountAggregates'; id?: any | null } | null;
+    } | null;
+  } | null;
+};
 
-export type ValidatorOfSessionQuery = { __typename?: 'Query', sessionValidator?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, session?: { __typename?: 'Session', keyGenThreshold?: any | null } | null, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null, sessionValidators?: { __typename?: 'SessionValidatorsConnection', aggregates?: { __typename?: 'SessionValidatorAggregates', distinctCount?: { __typename?: 'SessionValidatorDistinctCountAggregates', id?: any | null } | null } | null } | null };
+export type ValidatorMetaFragment = { __typename?: 'Validator'; authorityId: string; id: string };
 
-export type ValidatorMetaFragment = { __typename?: 'Validator', authorityId: string, id: string };
+export type PageInfoMetaFragment = {
+  __typename?: 'PageInfo';
+  endCursor?: any | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor?: any | null;
+};
 
-export type PageInfoMetaFragment = { __typename?: 'PageInfo', endCursor?: any | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: any | null };
+export type SessionAuthValidatorNodeFragment = {
+  __typename?: 'SessionValidator';
+  id: string;
+  sessionId: string;
+  reputation: string;
+  isBest: boolean;
+  isNext: boolean;
+  isNextBest: boolean;
+  bestOrder: number;
+  nextBestOrder: number;
+  validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
+};
 
-export type SessionAuthValidatorNodeFragment = { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null };
+export type SessionAuthValidatorFragment = {
+  __typename?: 'SessionValidatorsConnection';
+  edges: Array<{
+    __typename?: 'SessionValidatorsEdge';
+    node?: {
+      __typename?: 'SessionValidator';
+      id: string;
+      sessionId: string;
+      reputation: string;
+      isBest: boolean;
+      isNext: boolean;
+      isNextBest: boolean;
+      bestOrder: number;
+      nextBestOrder: number;
+      validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
+    } | null;
+  }>;
+};
 
-export type SessionAuthValidatorFragment = { __typename?: 'SessionValidatorsConnection', edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> };
+export type SessionAuthFragment = {
+  __typename?: 'Session';
+  sessionValidators: {
+    __typename?: 'SessionValidatorsConnection';
+    edges: Array<{
+      __typename?: 'SessionValidatorsEdge';
+      node?: {
+        __typename?: 'SessionValidator';
+        id: string;
+        sessionId: string;
+        reputation: string;
+        isBest: boolean;
+        isNext: boolean;
+        isNextBest: boolean;
+        bestOrder: number;
+        nextBestOrder: number;
+        validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
+      } | null;
+    }>;
+  };
+};
 
-export type SessionAuthFragment = { __typename?: 'Session', sessionValidators: { __typename?: 'SessionValidatorsConnection', edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> } };
+export type ProposalListViewFragment = {
+  __typename?: 'ProposalItem';
+  id: string;
+  data: string;
+  signature?: string | null;
+  type: ProposalType;
+  status: string;
+  proposalVotesByProposalId: {
+    __typename?: 'ProposalVotesConnection';
+    totalCount: number;
+    nodes: Array<{
+      __typename?: 'ProposalVote';
+      id: string;
+      voterId: string;
+      voter?: { __typename?: 'Proposer'; id: string } | null;
+    } | null>;
+  };
+  block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
+};
 
-export type ProposalListViewFragment = { __typename?: 'ProposalItem', id: string, data: string, signature?: string | null, type: ProposalType, status: string, proposalVotesByProposalId: { __typename?: 'ProposalVotesConnection', totalCount: number, nodes: Array<{ __typename?: 'ProposalVote', id: string, voterId: string, voter?: { __typename?: 'Proposer', id: string } | null } | null> }, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null };
+export type ProposalsVoteListViewFragment = {
+  __typename?: 'ProposalVote';
+  id: string;
+  voterId: string;
+  for: boolean;
+  txHash: string;
+  block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
+};
 
-export type ProposalsVoteListViewFragment = { __typename?: 'ProposalVote', id: string, voterId: string, for: boolean, txHash: string, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null };
+export type MetaDataQueryVariables = Exact<{ [key: string]: never }>;
 
-export type MetaDataQueryVariables = Exact<{ [key: string]: never; }>;
+export type MetaDataQuery = {
+  __typename?: 'Query';
+  _metadata?: { __typename?: '_Metadata'; targetHeight?: number | null; lastProcessedHeight?: number | null } | null;
+};
 
+export type ProposalCounterQueryVariables = Exact<{ [key: string]: never }>;
 
-export type MetaDataQuery = { __typename?: 'Query', _metadata?: { __typename?: '_Metadata', targetHeight?: number | null, lastProcessedHeight?: number | null } | null };
-
-export type ProposalCounterQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type ProposalCounterQuery = { __typename?: 'Query', proposalCounters?: { __typename?: 'ProposalCountersConnection', nodes: Array<{ __typename?: 'ProposalCounter', id: string, blockNumber: number, unSignedProposalsCount: number, signedProposalsCount: number, statusMap?: any | null, unSignedProposalsMap?: any | null, signedProposalsMap?: any | null } | null> } | null };
+export type ProposalCounterQuery = {
+  __typename?: 'Query';
+  proposalCounters?: {
+    __typename?: 'ProposalCountersConnection';
+    nodes: Array<{
+      __typename?: 'ProposalCounter';
+      id: string;
+      blockNumber: number;
+      unSignedProposalsCount: number;
+      signedProposalsCount: number;
+      statusMap?: any | null;
+      unSignedProposalsMap?: any | null;
+      signedProposalsMap?: any | null;
+    } | null>;
+  } | null;
+};
 
 export type ProposalsQueryVariables = Exact<{
   perPage: Scalars['Int'];
   offset: Scalars['Int'];
 }>;
 
-
-export type ProposalsQuery = { __typename?: 'Query', proposalItems?: { __typename?: 'ProposalItemsConnection', totalCount: number, nodes: Array<{ __typename?: 'ProposalItem', id: string, data: string, signature?: string | null, type: ProposalType, status: string, proposalVotesByProposalId: { __typename?: 'ProposalVotesConnection', totalCount: number, nodes: Array<{ __typename?: 'ProposalVote', id: string, voterId: string, voter?: { __typename?: 'Proposer', id: string } | null } | null> }, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null } | null>, pageInfo: { __typename?: 'PageInfo', endCursor?: any | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: any | null } } | null };
+export type ProposalsQuery = {
+  __typename?: 'Query';
+  proposalItems?: {
+    __typename?: 'ProposalItemsConnection';
+    totalCount: number;
+    nodes: Array<{
+      __typename?: 'ProposalItem';
+      id: string;
+      data: string;
+      signature?: string | null;
+      type: ProposalType;
+      status: string;
+      proposalVotesByProposalId: {
+        __typename?: 'ProposalVotesConnection';
+        totalCount: number;
+        nodes: Array<{
+          __typename?: 'ProposalVote';
+          id: string;
+          voterId: string;
+          voter?: { __typename?: 'Proposer'; id: string } | null;
+        } | null>;
+      };
+      block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
+    } | null>;
+    pageInfo: {
+      __typename?: 'PageInfo';
+      endCursor?: any | null;
+      hasNextPage: boolean;
+      hasPreviousPage: boolean;
+      startCursor?: any | null;
+    };
+  } | null;
+};
 
 export type ProposalsCounterQueryVariables = Exact<{
   id: Scalars['String'];
 }>;
 
-
-export type ProposalsCounterQuery = { __typename?: 'Query', proposalCounter?: { __typename?: 'ProposalCounter', id: string, signedProposalsMap?: any | null, unSignedProposalsMap?: any | null, signedProposalsCount: number, unSignedProposalsCount: number, statusMap?: any | null, block?: { __typename?: 'Block', number: any, timestamp?: any | null } | null } | null };
+export type ProposalsCounterQuery = {
+  __typename?: 'Query';
+  proposalCounter?: {
+    __typename?: 'ProposalCounter';
+    id: string;
+    signedProposalsMap?: any | null;
+    unSignedProposalsMap?: any | null;
+    signedProposalsCount: number;
+    unSignedProposalsCount: number;
+    statusMap?: any | null;
+    block?: { __typename?: 'Block'; number: any; timestamp?: any | null } | null;
+  } | null;
+};
 
 export type ProposalsOverviewQueryVariables = Exact<{
   startRange: BigFloatFilter;
@@ -10032,8 +10105,50 @@ export type ProposalsOverviewQueryVariables = Exact<{
   sessionId: Scalars['String'];
 }>;
 
-
-export type ProposalsOverviewQuery = { __typename?: 'Query', session?: { __typename?: 'Session', id: string, proposerThreshold?: any | null, sessionProposers: { __typename?: 'SessionProposersConnection', totalCount: number }, sessionValidators: { __typename?: 'SessionValidatorsConnection', totalCount: number } } | null, openProposals?: { __typename?: 'ProposalItemsConnection', totalCount: number, nodes: Array<{ __typename?: 'ProposalItem', id: string, data: string, signature?: string | null, type: ProposalType, status: string, proposalVotesByProposalId: { __typename?: 'ProposalVotesConnection', totalCount: number, nodes: Array<{ __typename?: 'ProposalVote', id: string, voterId: string, voter?: { __typename?: 'Proposer', id: string } | null } | null> }, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null } | null>, pageInfo: { __typename?: 'PageInfo', endCursor?: any | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: any | null } } | null, open?: { __typename?: 'ProposalTimelineStatusesConnection', totalCount: number } | null, signed?: { __typename?: 'ProposalTimelineStatusesConnection', totalCount: number } | null, reject?: { __typename?: 'ProposalTimelineStatusesConnection', totalCount: number } | null, accepted?: { __typename?: 'ProposalTimelineStatusesConnection', totalCount: number } | null };
+export type ProposalsOverviewQuery = {
+  __typename?: 'Query';
+  session?: {
+    __typename?: 'Session';
+    id: string;
+    proposerThreshold?: any | null;
+    sessionProposers: { __typename?: 'SessionProposersConnection'; totalCount: number };
+    sessionValidators: { __typename?: 'SessionValidatorsConnection'; totalCount: number };
+  } | null;
+  openProposals?: {
+    __typename?: 'ProposalItemsConnection';
+    totalCount: number;
+    nodes: Array<{
+      __typename?: 'ProposalItem';
+      id: string;
+      data: string;
+      signature?: string | null;
+      type: ProposalType;
+      status: string;
+      proposalVotesByProposalId: {
+        __typename?: 'ProposalVotesConnection';
+        totalCount: number;
+        nodes: Array<{
+          __typename?: 'ProposalVote';
+          id: string;
+          voterId: string;
+          voter?: { __typename?: 'Proposer'; id: string } | null;
+        } | null>;
+      };
+      block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
+    } | null>;
+    pageInfo: {
+      __typename?: 'PageInfo';
+      endCursor?: any | null;
+      hasNextPage: boolean;
+      hasPreviousPage: boolean;
+      startCursor?: any | null;
+    };
+  } | null;
+  open?: { __typename?: 'ProposalTimelineStatusesConnection'; totalCount: number } | null;
+  signed?: { __typename?: 'ProposalTimelineStatusesConnection'; totalCount: number } | null;
+  reject?: { __typename?: 'ProposalTimelineStatusesConnection'; totalCount: number } | null;
+  accepted?: { __typename?: 'ProposalTimelineStatusesConnection'; totalCount: number } | null;
+};
 
 export type ProposalVotesQueryVariables = Exact<{
   perPage: Scalars['Int'];
@@ -10042,171 +10157,436 @@ export type ProposalVotesQueryVariables = Exact<{
   for?: InputMaybe<BooleanFilter>;
 }>;
 
-
-export type ProposalVotesQuery = { __typename?: 'Query', proposalVotes?: { __typename?: 'ProposalVotesConnection', totalCount: number, nodes: Array<{ __typename?: 'ProposalVote', id: string, voterId: string, for: boolean, txHash: string, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null } | null>, pageInfo: { __typename?: 'PageInfo', endCursor?: any | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: any | null } } | null };
+export type ProposalVotesQuery = {
+  __typename?: 'Query';
+  proposalVotes?: {
+    __typename?: 'ProposalVotesConnection';
+    totalCount: number;
+    nodes: Array<{
+      __typename?: 'ProposalVote';
+      id: string;
+      voterId: string;
+      for: boolean;
+      txHash: string;
+      block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
+    } | null>;
+    pageInfo: {
+      __typename?: 'PageInfo';
+      endCursor?: any | null;
+      hasNextPage: boolean;
+      hasPreviousPage: boolean;
+      startCursor?: any | null;
+    };
+  } | null;
+};
 
 export type ProposalDetailsQueryVariables = Exact<{
   id: Scalars['String'];
   targetSessionId: Scalars['String'];
 }>;
 
-
-export type ProposalDetailsQuery = { __typename?: 'Query', session?: { __typename?: 'Session', id: string, sessionProposers: { __typename?: 'SessionProposersConnection', totalCount: number } } | null, proposalItem?: { __typename?: 'ProposalItem', id: string, data: string, signature?: string | null, type: ProposalType, status: string, proposalTimelineStatuses: { __typename?: 'ProposalTimelineStatusesConnection', nodes: Array<{ __typename?: 'ProposalTimelineStatus', id: string, status: ProposalStatus, blockNumber: any, timestamp: any } | null> }, votesFor: { __typename?: 'ProposalVotesConnection', totalCount: number }, totalVotes: { __typename?: 'ProposalVotesConnection', totalCount: number }, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null } | null };
+export type ProposalDetailsQuery = {
+  __typename?: 'Query';
+  session?: {
+    __typename?: 'Session';
+    id: string;
+    sessionProposers: { __typename?: 'SessionProposersConnection'; totalCount: number };
+  } | null;
+  proposalItem?: {
+    __typename?: 'ProposalItem';
+    id: string;
+    data: string;
+    signature?: string | null;
+    type: ProposalType;
+    status: string;
+    proposalTimelineStatuses: {
+      __typename?: 'ProposalTimelineStatusesConnection';
+      nodes: Array<{
+        __typename?: 'ProposalTimelineStatus';
+        id: string;
+        status: ProposalStatus;
+        blockNumber: any;
+        timestamp: any;
+      } | null>;
+    };
+    votesFor: { __typename?: 'ProposalVotesConnection'; totalCount: number };
+    totalVotes: { __typename?: 'ProposalVotesConnection'; totalCount: number };
+    block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
+  } | null;
+};
 
 export type EnsureProposalsQueryVariables = Exact<{
   ids: Array<Scalars['String']> | Scalars['String'];
 }>;
 
-
-export type EnsureProposalsQuery = { __typename?: 'Query', proposalItems?: { __typename?: 'ProposalItemsConnection', nodes: Array<{ __typename?: 'ProposalItem', id: string } | null> } | null };
+export type EnsureProposalsQuery = {
+  __typename?: 'Query';
+  proposalItems?: {
+    __typename?: 'ProposalItemsConnection';
+    nodes: Array<{ __typename?: 'ProposalItem'; id: string } | null>;
+  } | null;
+};
 
 export type PublicKeysQueryVariables = Exact<{
   PerPage?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 }>;
 
-
-export type PublicKeysQuery = { __typename?: 'Query', publicKeys?: { __typename?: 'PublicKeysConnection', totalCount: number, nodes: Array<{ __typename?: 'PublicKey', id: string, compressed?: string | null, uncompressed?: string | null, history: any, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null, sessions: { __typename?: 'SessionsConnection', nodes: Array<{ __typename?: 'Session', id: string, keyGenThreshold?: any | null, signatureThreshold?: any | null, sessionValidators: { __typename?: 'SessionValidatorsConnection', edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> } } | null> } } | null>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: any | null, endCursor?: any | null } } | null };
+export type PublicKeysQuery = {
+  __typename?: 'Query';
+  publicKeys?: {
+    __typename?: 'PublicKeysConnection';
+    totalCount: number;
+    nodes: Array<{
+      __typename?: 'PublicKey';
+      id: string;
+      compressed?: string | null;
+      uncompressed?: string | null;
+      history: any;
+      block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
+      sessions: {
+        __typename?: 'SessionsConnection';
+        nodes: Array<{
+          __typename?: 'Session';
+          id: string;
+          keyGenThreshold?: any | null;
+          signatureThreshold?: any | null;
+          sessionValidators: {
+            __typename?: 'SessionValidatorsConnection';
+            edges: Array<{
+              __typename?: 'SessionValidatorsEdge';
+              node?: {
+                __typename?: 'SessionValidator';
+                id: string;
+                sessionId: string;
+                reputation: string;
+                isBest: boolean;
+                isNext: boolean;
+                isNextBest: boolean;
+                bestOrder: number;
+                nextBestOrder: number;
+                validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
+              } | null;
+            }>;
+          };
+        } | null>;
+      };
+    } | null>;
+    pageInfo: {
+      __typename?: 'PageInfo';
+      hasNextPage: boolean;
+      hasPreviousPage: boolean;
+      startCursor?: any | null;
+      endCursor?: any | null;
+    };
+  } | null;
+};
 
 export type PublicKeyQueryVariables = Exact<{
   id: Scalars['String'];
 }>;
 
-
-export type PublicKeyQuery = { __typename?: 'Query', publicKey?: { __typename?: 'PublicKey', id: string, compressed?: string | null, uncompressed?: string | null, history: any, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null, sessions: { __typename?: 'SessionsConnection', nodes: Array<{ __typename?: 'Session', id: string, keyGenThreshold?: any | null, signatureThreshold?: any | null, sessionValidators: { __typename?: 'SessionValidatorsConnection', edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> } } | null> } } | null };
+export type PublicKeyQuery = {
+  __typename?: 'Query';
+  publicKey?: {
+    __typename?: 'PublicKey';
+    id: string;
+    compressed?: string | null;
+    uncompressed?: string | null;
+    history: any;
+    block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
+    sessions: {
+      __typename?: 'SessionsConnection';
+      nodes: Array<{
+        __typename?: 'Session';
+        id: string;
+        keyGenThreshold?: any | null;
+        signatureThreshold?: any | null;
+        sessionValidators: {
+          __typename?: 'SessionValidatorsConnection';
+          edges: Array<{
+            __typename?: 'SessionValidatorsEdge';
+            node?: {
+              __typename?: 'SessionValidator';
+              id: string;
+              sessionId: string;
+              reputation: string;
+              isBest: boolean;
+              isNext: boolean;
+              isNextBest: boolean;
+              bestOrder: number;
+              nextBestOrder: number;
+              validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
+            } | null;
+          }>;
+        };
+      } | null>;
+    };
+  } | null;
+};
 
 export type SessionKeyIdsQueryVariables = Exact<{
   keys: Array<Scalars['String']> | Scalars['String'];
 }>;
 
+export type SessionKeyIdsQuery = {
+  __typename?: 'Query';
+  sessions?: {
+    __typename?: 'SessionsConnection';
+    nodes: Array<{
+      __typename?: 'Session';
+      id: string;
+      publicKey?: { __typename?: 'PublicKey'; id: string } | null;
+    } | null>;
+  } | null;
+};
 
-export type SessionKeyIdsQuery = { __typename?: 'Query', sessions?: { __typename?: 'SessionsConnection', nodes: Array<{ __typename?: 'Session', id: string, publicKey?: { __typename?: 'PublicKey', id: string } | null } | null> } | null };
+export type CurrentSessionAuthoritiesQueryVariables = Exact<{ [key: string]: never }>;
 
-export type CurrentSessionAuthoritiesQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type CurrentSessionAuthoritiesQuery = { __typename?: 'Query', sessions?: { __typename?: 'SessionsConnection', nodes: Array<{ __typename?: 'Session', id: string, blockId: string, signatureThreshold?: any | null, keyGenThreshold?: any | null, proposerThreshold?: any | null, publicKey?: { __typename?: 'PublicKey', compressed?: string | null } | null, block?: { __typename?: 'Block', id: string, timestamp?: any | null } | null, sessionValidators: { __typename?: 'SessionValidatorsConnection', edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> } } | null> } | null };
+export type CurrentSessionAuthoritiesQuery = {
+  __typename?: 'Query';
+  sessions?: {
+    __typename?: 'SessionsConnection';
+    nodes: Array<{
+      __typename?: 'Session';
+      id: string;
+      blockId: string;
+      signatureThreshold?: any | null;
+      keyGenThreshold?: any | null;
+      proposerThreshold?: any | null;
+      publicKey?: { __typename?: 'PublicKey'; compressed?: string | null } | null;
+      block?: { __typename?: 'Block'; id: string; timestamp?: any | null } | null;
+      sessionValidators: {
+        __typename?: 'SessionValidatorsConnection';
+        edges: Array<{
+          __typename?: 'SessionValidatorsEdge';
+          node?: {
+            __typename?: 'SessionValidator';
+            id: string;
+            sessionId: string;
+            reputation: string;
+            isBest: boolean;
+            isNext: boolean;
+            isNextBest: boolean;
+            bestOrder: number;
+            nextBestOrder: number;
+            validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
+          } | null;
+        }>;
+      };
+    } | null>;
+  } | null;
+};
 
 export type SessionKeysQueryVariables = Exact<{
   SessionId: Array<Scalars['String']> | Scalars['String'];
 }>;
 
-
-export type SessionKeysQuery = { __typename?: 'Query', sessions?: { __typename?: 'SessionsConnection', nodes: Array<{ __typename?: 'Session', id: string, publicKey?: { __typename?: 'PublicKey', id: string, compressed?: string | null, uncompressed?: string | null, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null } | null, sessionValidators: { __typename?: 'SessionValidatorsConnection', edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> } } | null> } | null };
+export type SessionKeysQuery = {
+  __typename?: 'Query';
+  sessions?: {
+    __typename?: 'SessionsConnection';
+    nodes: Array<{
+      __typename?: 'Session';
+      id: string;
+      publicKey?: {
+        __typename?: 'PublicKey';
+        id: string;
+        compressed?: string | null;
+        uncompressed?: string | null;
+        block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
+      } | null;
+      sessionValidators: {
+        __typename?: 'SessionValidatorsConnection';
+        edges: Array<{
+          __typename?: 'SessionValidatorsEdge';
+          node?: {
+            __typename?: 'SessionValidator';
+            id: string;
+            sessionId: string;
+            reputation: string;
+            isBest: boolean;
+            isNext: boolean;
+            isNextBest: boolean;
+            bestOrder: number;
+            nextBestOrder: number;
+            validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
+          } | null;
+        }>;
+      };
+    } | null>;
+  } | null;
+};
 
 export type SessionThresholdHistoryQueryVariables = Exact<{
   offset: Scalars['Int'];
   perPage: Scalars['Int'];
 }>;
 
-
-export type SessionThresholdHistoryQuery = { __typename?: 'Query', sessions?: { __typename?: 'SessionsConnection', totalCount: number, nodes: Array<{ __typename?: 'Session', id: string, signatureThreshold?: any | null, keyGenThreshold?: any | null, block?: { __typename?: 'Block', id: string, timestamp?: any | null } | null } | null>, pageInfo: { __typename?: 'PageInfo', endCursor?: any | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: any | null } } | null };
+export type SessionThresholdHistoryQuery = {
+  __typename?: 'Query';
+  sessions?: {
+    __typename?: 'SessionsConnection';
+    totalCount: number;
+    nodes: Array<{
+      __typename?: 'Session';
+      id: string;
+      signatureThreshold?: any | null;
+      keyGenThreshold?: any | null;
+      block?: { __typename?: 'Block'; id: string; timestamp?: any | null } | null;
+    } | null>;
+    pageInfo: {
+      __typename?: 'PageInfo';
+      endCursor?: any | null;
+      hasNextPage: boolean;
+      hasPreviousPage: boolean;
+      startCursor?: any | null;
+    };
+  } | null;
+};
 
 export type SessionThresholdsQueryVariables = Exact<{
   sessionId: Scalars['String'];
 }>;
 
-
-export type SessionThresholdsQuery = { __typename?: 'Query', session?: { __typename?: 'Session', id: string, signatureThreshold?: any | null, keyGenThreshold?: any | null, proposersCount: { __typename?: 'SessionProposersConnection', totalCount: number }, publicKey?: { __typename?: 'PublicKey', id: string, compressed?: string | null, uncompressed?: string | null, block?: { __typename?: 'Block', timestamp?: any | null, number: any } | null } | null, sessionValidators: { __typename?: 'SessionValidatorsConnection', edges: Array<{ __typename?: 'SessionValidatorsEdge', node?: { __typename?: 'SessionValidator', id: string, sessionId: string, reputation: string, isBest: boolean, isNext: boolean, isNextBest: boolean, bestOrder: number, nextBestOrder: number, validator?: { __typename?: 'Validator', authorityId: string, id: string } | null } | null }> } } | null };
+export type SessionThresholdsQuery = {
+  __typename?: 'Query';
+  session?: {
+    __typename?: 'Session';
+    id: string;
+    signatureThreshold?: any | null;
+    keyGenThreshold?: any | null;
+    proposersCount: { __typename?: 'SessionProposersConnection'; totalCount: number };
+    publicKey?: {
+      __typename?: 'PublicKey';
+      id: string;
+      compressed?: string | null;
+      uncompressed?: string | null;
+      block?: { __typename?: 'Block'; timestamp?: any | null; number: any } | null;
+    } | null;
+    sessionValidators: {
+      __typename?: 'SessionValidatorsConnection';
+      edges: Array<{
+        __typename?: 'SessionValidatorsEdge';
+        node?: {
+          __typename?: 'SessionValidator';
+          id: string;
+          sessionId: string;
+          reputation: string;
+          isBest: boolean;
+          isNext: boolean;
+          isNextBest: boolean;
+          bestOrder: number;
+          nextBestOrder: number;
+          validator?: { __typename?: 'Validator'; authorityId: string; id: string } | null;
+        } | null;
+      }>;
+    };
+  } | null;
+};
 
 export const PageInfoMetaFragmentDoc = gql`
-    fragment PageInfoMeta on PageInfo {
-  endCursor
-  hasNextPage
-  hasPreviousPage
-  startCursor
-}
-    `;
+  fragment PageInfoMeta on PageInfo {
+    endCursor
+    hasNextPage
+    hasPreviousPage
+    startCursor
+  }
+`;
 export const ValidatorMetaFragmentDoc = gql`
-    fragment ValidatorMeta on Validator {
-  authorityId
-  id
-}
-    `;
+  fragment ValidatorMeta on Validator {
+    authorityId
+    id
+  }
+`;
 export const SessionAuthValidatorNodeFragmentDoc = gql`
-    fragment SessionAuthValidatorNode on SessionValidator {
-  id
-  sessionId
-  validator {
-    ...ValidatorMeta
-  }
-  reputation
-  isBest
-  isNext
-  isNextBest
-  bestOrder
-  nextBestOrder
-}
-    ${ValidatorMetaFragmentDoc}`;
-export const SessionAuthValidatorFragmentDoc = gql`
-    fragment SessionAuthValidator on SessionValidatorsConnection {
-  edges {
-    node {
-      ...SessionAuthValidatorNode
-    }
-  }
-}
-    ${SessionAuthValidatorNodeFragmentDoc}`;
-export const SessionAuthFragmentDoc = gql`
-    fragment SessionAuth on Session {
-  sessionValidators {
-    ...SessionAuthValidator
-  }
-}
-    ${SessionAuthValidatorFragmentDoc}`;
-export const ProposalListViewFragmentDoc = gql`
-    fragment ProposalListView on ProposalItem {
-  id
-  data
-  signature
-  type
-  status
-  proposalVotesByProposalId(orderBy: [BLOCK_NUMBER_DESC], first: 3) {
-    nodes {
-      id
-      voterId
-      voter {
-        id
-      }
-    }
-    totalCount
-  }
-  block {
-    timestamp
-    number
-  }
-}
-    `;
-export const ProposalsVoteListViewFragmentDoc = gql`
-    fragment ProposalsVoteListView on ProposalVote {
-  id
-  voterId
-  for
-  txHash: voterId
-  block {
-    timestamp
-    number
-  }
-}
-    `;
-export const ValidatorListingDocument = gql`
-    query ValidatorListing($sessionId: String!, $perPage: Int!, $offset: Int!) {
-  validators(offset: $offset, first: $perPage) {
-    nodes {
+  fragment SessionAuthValidatorNode on SessionValidator {
+    id
+    sessionId
+    validator {
       ...ValidatorMeta
-      sessionValidators(first: 1, filter: {sessionId: {equalTo: $sessionId}}) {
-        ...SessionAuthValidator
+    }
+    reputation
+    isBest
+    isNext
+    isNextBest
+    bestOrder
+    nextBestOrder
+  }
+  ${ValidatorMetaFragmentDoc}
+`;
+export const SessionAuthValidatorFragmentDoc = gql`
+  fragment SessionAuthValidator on SessionValidatorsConnection {
+    edges {
+      node {
+        ...SessionAuthValidatorNode
       }
     }
-    totalCount
-    pageInfo {
-      ...PageInfoMeta
+  }
+  ${SessionAuthValidatorNodeFragmentDoc}
+`;
+export const SessionAuthFragmentDoc = gql`
+  fragment SessionAuth on Session {
+    sessionValidators {
+      ...SessionAuthValidator
     }
   }
-}
-    ${ValidatorMetaFragmentDoc}
-${SessionAuthValidatorFragmentDoc}
-${PageInfoMetaFragmentDoc}`;
+  ${SessionAuthValidatorFragmentDoc}
+`;
+export const ProposalListViewFragmentDoc = gql`
+  fragment ProposalListView on ProposalItem {
+    id
+    data
+    signature
+    type
+    status
+    proposalVotesByProposalId(orderBy: [BLOCK_NUMBER_DESC], first: 3) {
+      nodes {
+        id
+        voterId
+        voter {
+          id
+        }
+      }
+      totalCount
+    }
+    block {
+      timestamp
+      number
+    }
+  }
+`;
+export const ProposalsVoteListViewFragmentDoc = gql`
+  fragment ProposalsVoteListView on ProposalVote {
+    id
+    voterId
+    for
+    txHash: voterId
+    block {
+      timestamp
+      number
+    }
+  }
+`;
+export const ValidatorListingDocument = gql`
+  query ValidatorListing($sessionId: String!, $perPage: Int!, $offset: Int!) {
+    validators(offset: $offset, first: $perPage) {
+      nodes {
+        ...ValidatorMeta
+        sessionValidators(first: 1, filter: { sessionId: { equalTo: $sessionId } }) {
+          ...SessionAuthValidator
+        }
+      }
+      totalCount
+      pageInfo {
+        ...PageInfoMeta
+      }
+    }
+  }
+  ${ValidatorMetaFragmentDoc}
+  ${SessionAuthValidatorFragmentDoc}
+  ${PageInfoMetaFragmentDoc}
+`;
 
 /**
  * __useValidatorListingQuery__
@@ -10226,50 +10606,55 @@ ${PageInfoMetaFragmentDoc}`;
  *   },
  * });
  */
-export function useValidatorListingQuery(baseOptions: Apollo.QueryHookOptions<ValidatorListingQuery, ValidatorListingQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<ValidatorListingQuery, ValidatorListingQueryVariables>(ValidatorListingDocument, options);
-      }
-export function useValidatorListingLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ValidatorListingQuery, ValidatorListingQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<ValidatorListingQuery, ValidatorListingQueryVariables>(ValidatorListingDocument, options);
-        }
+export function useValidatorListingQuery(
+  baseOptions: Apollo.QueryHookOptions<ValidatorListingQuery, ValidatorListingQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<ValidatorListingQuery, ValidatorListingQueryVariables>(ValidatorListingDocument, options);
+}
+export function useValidatorListingLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<ValidatorListingQuery, ValidatorListingQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<ValidatorListingQuery, ValidatorListingQueryVariables>(ValidatorListingDocument, options);
+}
 export type ValidatorListingQueryHookResult = ReturnType<typeof useValidatorListingQuery>;
 export type ValidatorListingLazyQueryHookResult = ReturnType<typeof useValidatorListingLazyQuery>;
 export type ValidatorListingQueryResult = Apollo.QueryResult<ValidatorListingQuery, ValidatorListingQueryVariables>;
 export const ValidatorSessionsDocument = gql`
-    query ValidatorSessions($keyGen: Boolean, $validatorId: String!, $perPage: Int!, $offset: Int!) {
-  sessionValidators(
-    filter: {isBest: {equalTo: $keyGen}, validatorId: {equalTo: $validatorId}}
-    offset: $offset
-    first: $perPage
-  ) {
-    nodes {
-      validator {
-        ...ValidatorMeta
-      }
-      session {
-        id
-        publicKey {
+  query ValidatorSessions($keyGen: Boolean, $validatorId: String!, $perPage: Int!, $offset: Int!) {
+    sessionValidators(
+      filter: { isBest: { equalTo: $keyGen }, validatorId: { equalTo: $validatorId } }
+      offset: $offset
+      first: $perPage
+    ) {
+      nodes {
+        validator {
+          ...ValidatorMeta
+        }
+        session {
           id
-          compressed
-          uncompressed
-        }
-        sessionValidators(first: 3) {
-          ...SessionAuthValidator
-          totalCount
+          publicKey {
+            id
+            compressed
+            uncompressed
+          }
+          sessionValidators(first: 3) {
+            ...SessionAuthValidator
+            totalCount
+          }
         }
       }
-    }
-    totalCount
-    pageInfo {
-      ...PageInfoMeta
+      totalCount
+      pageInfo {
+        ...PageInfoMeta
+      }
     }
   }
-}
-    ${ValidatorMetaFragmentDoc}
-${SessionAuthValidatorFragmentDoc}
-${PageInfoMetaFragmentDoc}`;
+  ${ValidatorMetaFragmentDoc}
+  ${SessionAuthValidatorFragmentDoc}
+  ${PageInfoMetaFragmentDoc}
+`;
 
 /**
  * __useValidatorSessionsQuery__
@@ -10290,36 +10675,42 @@ ${PageInfoMetaFragmentDoc}`;
  *   },
  * });
  */
-export function useValidatorSessionsQuery(baseOptions: Apollo.QueryHookOptions<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>(ValidatorSessionsDocument, options);
-      }
-export function useValidatorSessionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>(ValidatorSessionsDocument, options);
-        }
+export function useValidatorSessionsQuery(
+  baseOptions: Apollo.QueryHookOptions<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>(ValidatorSessionsDocument, options);
+}
+export function useValidatorSessionsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>(
+    ValidatorSessionsDocument,
+    options
+  );
+}
 export type ValidatorSessionsQueryHookResult = ReturnType<typeof useValidatorSessionsQuery>;
 export type ValidatorSessionsLazyQueryHookResult = ReturnType<typeof useValidatorSessionsLazyQuery>;
 export type ValidatorSessionsQueryResult = Apollo.QueryResult<ValidatorSessionsQuery, ValidatorSessionsQueryVariables>;
 export const ValidatorOfSessionDocument = gql`
-    query ValidatorOfSession($validatorId: String!, $sessionValidatorId: String!) {
-  sessionValidator(id: $sessionValidatorId) {
-    ...SessionAuthValidatorNode
-    session {
-      keyGenThreshold
+  query ValidatorOfSession($validatorId: String!, $sessionValidatorId: String!) {
+    sessionValidator(id: $sessionValidatorId) {
+      ...SessionAuthValidatorNode
+      session {
+        keyGenThreshold
+      }
     }
-  }
-  sessionValidators(
-    filter: {validatorId: {equalTo: $validatorId}, isBest: {equalTo: true}}
-  ) {
-    aggregates {
-      distinctCount {
-        id
+    sessionValidators(filter: { validatorId: { equalTo: $validatorId }, isBest: { equalTo: true } }) {
+      aggregates {
+        distinctCount {
+          id
+        }
       }
     }
   }
-}
-    ${SessionAuthValidatorNodeFragmentDoc}`;
+  ${SessionAuthValidatorNodeFragmentDoc}
+`;
 
 /**
  * __useValidatorOfSessionQuery__
@@ -10338,25 +10729,38 @@ export const ValidatorOfSessionDocument = gql`
  *   },
  * });
  */
-export function useValidatorOfSessionQuery(baseOptions: Apollo.QueryHookOptions<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>(ValidatorOfSessionDocument, options);
-      }
-export function useValidatorOfSessionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>(ValidatorOfSessionDocument, options);
-        }
+export function useValidatorOfSessionQuery(
+  baseOptions: Apollo.QueryHookOptions<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>(
+    ValidatorOfSessionDocument,
+    options
+  );
+}
+export function useValidatorOfSessionLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>(
+    ValidatorOfSessionDocument,
+    options
+  );
+}
 export type ValidatorOfSessionQueryHookResult = ReturnType<typeof useValidatorOfSessionQuery>;
 export type ValidatorOfSessionLazyQueryHookResult = ReturnType<typeof useValidatorOfSessionLazyQuery>;
-export type ValidatorOfSessionQueryResult = Apollo.QueryResult<ValidatorOfSessionQuery, ValidatorOfSessionQueryVariables>;
+export type ValidatorOfSessionQueryResult = Apollo.QueryResult<
+  ValidatorOfSessionQuery,
+  ValidatorOfSessionQueryVariables
+>;
 export const MetaDataDocument = gql`
-    query MetaData {
-  _metadata {
-    targetHeight
-    lastProcessedHeight
+  query MetaData {
+    _metadata {
+      targetHeight
+      lastProcessedHeight
+    }
   }
-}
-    `;
+`;
 
 /**
  * __useMetaDataQuery__
@@ -10374,31 +10778,31 @@ export const MetaDataDocument = gql`
  * });
  */
 export function useMetaDataQuery(baseOptions?: Apollo.QueryHookOptions<MetaDataQuery, MetaDataQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<MetaDataQuery, MetaDataQueryVariables>(MetaDataDocument, options);
-      }
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<MetaDataQuery, MetaDataQueryVariables>(MetaDataDocument, options);
+}
 export function useMetaDataLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MetaDataQuery, MetaDataQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<MetaDataQuery, MetaDataQueryVariables>(MetaDataDocument, options);
-        }
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<MetaDataQuery, MetaDataQueryVariables>(MetaDataDocument, options);
+}
 export type MetaDataQueryHookResult = ReturnType<typeof useMetaDataQuery>;
 export type MetaDataLazyQueryHookResult = ReturnType<typeof useMetaDataLazyQuery>;
 export type MetaDataQueryResult = Apollo.QueryResult<MetaDataQuery, MetaDataQueryVariables>;
 export const ProposalCounterDocument = gql`
-    query ProposalCounter {
-  proposalCounters(first: 2, offset: 1, orderBy: [BLOCK_NUMBER_DESC]) {
-    nodes {
-      id
-      blockNumber
-      unSignedProposalsCount
-      signedProposalsCount
-      statusMap
-      unSignedProposalsMap
-      signedProposalsMap
+  query ProposalCounter {
+    proposalCounters(first: 2, offset: 1, orderBy: [BLOCK_NUMBER_DESC]) {
+      nodes {
+        id
+        blockNumber
+        unSignedProposalsCount
+        signedProposalsCount
+        statusMap
+        unSignedProposalsMap
+        signedProposalsMap
+      }
     }
   }
-}
-    `;
+`;
 
 /**
  * __useProposalCounterQuery__
@@ -10415,31 +10819,36 @@ export const ProposalCounterDocument = gql`
  *   },
  * });
  */
-export function useProposalCounterQuery(baseOptions?: Apollo.QueryHookOptions<ProposalCounterQuery, ProposalCounterQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<ProposalCounterQuery, ProposalCounterQueryVariables>(ProposalCounterDocument, options);
-      }
-export function useProposalCounterLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProposalCounterQuery, ProposalCounterQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<ProposalCounterQuery, ProposalCounterQueryVariables>(ProposalCounterDocument, options);
-        }
+export function useProposalCounterQuery(
+  baseOptions?: Apollo.QueryHookOptions<ProposalCounterQuery, ProposalCounterQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<ProposalCounterQuery, ProposalCounterQueryVariables>(ProposalCounterDocument, options);
+}
+export function useProposalCounterLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<ProposalCounterQuery, ProposalCounterQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<ProposalCounterQuery, ProposalCounterQueryVariables>(ProposalCounterDocument, options);
+}
 export type ProposalCounterQueryHookResult = ReturnType<typeof useProposalCounterQuery>;
 export type ProposalCounterLazyQueryHookResult = ReturnType<typeof useProposalCounterLazyQuery>;
 export type ProposalCounterQueryResult = Apollo.QueryResult<ProposalCounterQuery, ProposalCounterQueryVariables>;
 export const ProposalsDocument = gql`
-    query Proposals($perPage: Int!, $offset: Int!) {
-  proposalItems(first: $perPage, offset: $offset) {
-    nodes {
-      ...ProposalListView
-    }
-    totalCount
-    pageInfo {
-      ...PageInfoMeta
+  query Proposals($perPage: Int!, $offset: Int!) {
+    proposalItems(first: $perPage, offset: $offset) {
+      nodes {
+        ...ProposalListView
+      }
+      totalCount
+      pageInfo {
+        ...PageInfoMeta
+      }
     }
   }
-}
-    ${ProposalListViewFragmentDoc}
-${PageInfoMetaFragmentDoc}`;
+  ${ProposalListViewFragmentDoc}
+  ${PageInfoMetaFragmentDoc}
+`;
 
 /**
  * __useProposalsQuery__
@@ -10459,32 +10868,34 @@ ${PageInfoMetaFragmentDoc}`;
  * });
  */
 export function useProposalsQuery(baseOptions: Apollo.QueryHookOptions<ProposalsQuery, ProposalsQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<ProposalsQuery, ProposalsQueryVariables>(ProposalsDocument, options);
-      }
-export function useProposalsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProposalsQuery, ProposalsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<ProposalsQuery, ProposalsQueryVariables>(ProposalsDocument, options);
-        }
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<ProposalsQuery, ProposalsQueryVariables>(ProposalsDocument, options);
+}
+export function useProposalsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<ProposalsQuery, ProposalsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<ProposalsQuery, ProposalsQueryVariables>(ProposalsDocument, options);
+}
 export type ProposalsQueryHookResult = ReturnType<typeof useProposalsQuery>;
 export type ProposalsLazyQueryHookResult = ReturnType<typeof useProposalsLazyQuery>;
 export type ProposalsQueryResult = Apollo.QueryResult<ProposalsQuery, ProposalsQueryVariables>;
 export const ProposalsCounterDocument = gql`
-    query ProposalsCounter($id: String!) {
-  proposalCounter(id: $id) {
-    id
-    signedProposalsMap
-    unSignedProposalsMap
-    signedProposalsCount
-    unSignedProposalsCount
-    statusMap
-    block {
-      number
-      timestamp
+  query ProposalsCounter($id: String!) {
+    proposalCounter(id: $id) {
+      id
+      signedProposalsMap
+      unSignedProposalsMap
+      signedProposalsCount
+      unSignedProposalsCount
+      statusMap
+      block {
+        number
+        timestamp
+      }
     }
   }
-}
-    `;
+`;
 
 /**
  * __useProposalsCounterQuery__
@@ -10502,65 +10913,66 @@ export const ProposalsCounterDocument = gql`
  *   },
  * });
  */
-export function useProposalsCounterQuery(baseOptions: Apollo.QueryHookOptions<ProposalsCounterQuery, ProposalsCounterQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<ProposalsCounterQuery, ProposalsCounterQueryVariables>(ProposalsCounterDocument, options);
-      }
-export function useProposalsCounterLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProposalsCounterQuery, ProposalsCounterQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<ProposalsCounterQuery, ProposalsCounterQueryVariables>(ProposalsCounterDocument, options);
-        }
+export function useProposalsCounterQuery(
+  baseOptions: Apollo.QueryHookOptions<ProposalsCounterQuery, ProposalsCounterQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<ProposalsCounterQuery, ProposalsCounterQueryVariables>(ProposalsCounterDocument, options);
+}
+export function useProposalsCounterLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<ProposalsCounterQuery, ProposalsCounterQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<ProposalsCounterQuery, ProposalsCounterQueryVariables>(ProposalsCounterDocument, options);
+}
 export type ProposalsCounterQueryHookResult = ReturnType<typeof useProposalsCounterQuery>;
 export type ProposalsCounterLazyQueryHookResult = ReturnType<typeof useProposalsCounterLazyQuery>;
 export type ProposalsCounterQueryResult = Apollo.QueryResult<ProposalsCounterQuery, ProposalsCounterQueryVariables>;
 export const ProposalsOverviewDocument = gql`
-    query ProposalsOverview($startRange: BigFloatFilter!, $endRange: BigFloatFilter!, $sessionId: String!) {
-  session(id: $sessionId) {
-    id
-    proposerThreshold
-    sessionProposers {
+  query ProposalsOverview($startRange: BigFloatFilter!, $endRange: BigFloatFilter!, $sessionId: String!) {
+    session(id: $sessionId) {
+      id
+      proposerThreshold
+      sessionProposers {
+        totalCount
+      }
+      sessionValidators {
+        totalCount
+      }
+    }
+    openProposals: proposalItems(filter: { status: { equalTo: "Open" } }, orderBy: [BLOCK_NUMBER_DESC], first: 10) {
+      nodes {
+        ...ProposalListView
+      }
+      pageInfo {
+        ...PageInfoMeta
+      }
       totalCount
     }
-    sessionValidators {
+    open: proposalTimelineStatuses(
+      filter: { status: { equalTo: Open }, and: [{ blockNumber: $startRange }, { blockNumber: $endRange }] }
+    ) {
+      totalCount
+    }
+    signed: proposalTimelineStatuses(
+      filter: { status: { equalTo: Signed }, and: [{ blockNumber: $startRange }, { blockNumber: $endRange }] }
+    ) {
+      totalCount
+    }
+    reject: proposalTimelineStatuses(
+      filter: { status: { equalTo: Rejected }, and: [{ blockNumber: $startRange }, { blockNumber: $endRange }] }
+    ) {
+      totalCount
+    }
+    accepted: proposalTimelineStatuses(
+      filter: { status: { equalTo: Accepted }, and: [{ blockNumber: $startRange }, { blockNumber: $endRange }] }
+    ) {
       totalCount
     }
   }
-  openProposals: proposalItems(
-    filter: {status: {equalTo: "Open"}}
-    orderBy: [BLOCK_NUMBER_DESC]
-    first: 10
-  ) {
-    nodes {
-      ...ProposalListView
-    }
-    pageInfo {
-      ...PageInfoMeta
-    }
-    totalCount
-  }
-  open: proposalTimelineStatuses(
-    filter: {status: {equalTo: Open}, and: [{blockNumber: $startRange}, {blockNumber: $endRange}]}
-  ) {
-    totalCount
-  }
-  signed: proposalTimelineStatuses(
-    filter: {status: {equalTo: Signed}, and: [{blockNumber: $startRange}, {blockNumber: $endRange}]}
-  ) {
-    totalCount
-  }
-  reject: proposalTimelineStatuses(
-    filter: {status: {equalTo: Rejected}, and: [{blockNumber: $startRange}, {blockNumber: $endRange}]}
-  ) {
-    totalCount
-  }
-  accepted: proposalTimelineStatuses(
-    filter: {status: {equalTo: Accepted}, and: [{blockNumber: $startRange}, {blockNumber: $endRange}]}
-  ) {
-    totalCount
-  }
-}
-    ${ProposalListViewFragmentDoc}
-${PageInfoMetaFragmentDoc}`;
+  ${ProposalListViewFragmentDoc}
+  ${PageInfoMetaFragmentDoc}
+`;
 
 /**
  * __useProposalsOverviewQuery__
@@ -10580,36 +10992,44 @@ ${PageInfoMetaFragmentDoc}`;
  *   },
  * });
  */
-export function useProposalsOverviewQuery(baseOptions: Apollo.QueryHookOptions<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>(ProposalsOverviewDocument, options);
-      }
-export function useProposalsOverviewLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>(ProposalsOverviewDocument, options);
-        }
+export function useProposalsOverviewQuery(
+  baseOptions: Apollo.QueryHookOptions<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>(ProposalsOverviewDocument, options);
+}
+export function useProposalsOverviewLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>(
+    ProposalsOverviewDocument,
+    options
+  );
+}
 export type ProposalsOverviewQueryHookResult = ReturnType<typeof useProposalsOverviewQuery>;
 export type ProposalsOverviewLazyQueryHookResult = ReturnType<typeof useProposalsOverviewLazyQuery>;
 export type ProposalsOverviewQueryResult = Apollo.QueryResult<ProposalsOverviewQuery, ProposalsOverviewQueryVariables>;
 export const ProposalVotesDocument = gql`
-    query ProposalVotes($perPage: Int!, $offset: Int!, $proposalId: String!, $for: BooleanFilter) {
-  proposalVotes(
-    filter: {proposalId: {equalTo: $proposalId}, for: $for}
-    orderBy: [BLOCK_NUMBER_DESC]
-    first: $perPage
-    offset: $offset
-  ) {
-    nodes {
-      ...ProposalsVoteListView
-    }
-    totalCount
-    pageInfo {
-      ...PageInfoMeta
+  query ProposalVotes($perPage: Int!, $offset: Int!, $proposalId: String!, $for: BooleanFilter) {
+    proposalVotes(
+      filter: { proposalId: { equalTo: $proposalId }, for: $for }
+      orderBy: [BLOCK_NUMBER_DESC]
+      first: $perPage
+      offset: $offset
+    ) {
+      nodes {
+        ...ProposalsVoteListView
+      }
+      totalCount
+      pageInfo {
+        ...PageInfoMeta
+      }
     }
   }
-}
-    ${ProposalsVoteListViewFragmentDoc}
-${PageInfoMetaFragmentDoc}`;
+  ${ProposalsVoteListViewFragmentDoc}
+  ${PageInfoMetaFragmentDoc}
+`;
 
 /**
  * __useProposalVotesQuery__
@@ -10630,52 +11050,56 @@ ${PageInfoMetaFragmentDoc}`;
  *   },
  * });
  */
-export function useProposalVotesQuery(baseOptions: Apollo.QueryHookOptions<ProposalVotesQuery, ProposalVotesQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<ProposalVotesQuery, ProposalVotesQueryVariables>(ProposalVotesDocument, options);
-      }
-export function useProposalVotesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProposalVotesQuery, ProposalVotesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<ProposalVotesQuery, ProposalVotesQueryVariables>(ProposalVotesDocument, options);
-        }
+export function useProposalVotesQuery(
+  baseOptions: Apollo.QueryHookOptions<ProposalVotesQuery, ProposalVotesQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<ProposalVotesQuery, ProposalVotesQueryVariables>(ProposalVotesDocument, options);
+}
+export function useProposalVotesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<ProposalVotesQuery, ProposalVotesQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<ProposalVotesQuery, ProposalVotesQueryVariables>(ProposalVotesDocument, options);
+}
 export type ProposalVotesQueryHookResult = ReturnType<typeof useProposalVotesQuery>;
 export type ProposalVotesLazyQueryHookResult = ReturnType<typeof useProposalVotesLazyQuery>;
 export type ProposalVotesQueryResult = Apollo.QueryResult<ProposalVotesQuery, ProposalVotesQueryVariables>;
 export const ProposalDetailsDocument = gql`
-    query ProposalDetails($id: String!, $targetSessionId: String!) {
-  session(id: $targetSessionId) {
-    id
-    sessionProposers {
-      totalCount
-    }
-  }
-  proposalItem(id: $id) {
-    id
-    data
-    signature
-    type
-    status
-    proposalTimelineStatuses {
-      nodes {
-        id
-        status
-        blockNumber
-        timestamp
+  query ProposalDetails($id: String!, $targetSessionId: String!) {
+    session(id: $targetSessionId) {
+      id
+      sessionProposers {
+        totalCount
       }
     }
-    votesFor: proposalVotesByProposalId(filter: {for: {equalTo: true}}) {
-      totalCount
-    }
-    totalVotes: proposalVotesByProposalId {
-      totalCount
-    }
-    block {
-      timestamp
-      number
+    proposalItem(id: $id) {
+      id
+      data
+      signature
+      type
+      status
+      proposalTimelineStatuses {
+        nodes {
+          id
+          status
+          blockNumber
+          timestamp
+        }
+      }
+      votesFor: proposalVotesByProposalId(filter: { for: { equalTo: true } }) {
+        totalCount
+      }
+      totalVotes: proposalVotesByProposalId {
+        totalCount
+      }
+      block {
+        timestamp
+        number
+      }
     }
   }
-}
-    `;
+`;
 
 /**
  * __useProposalDetailsQuery__
@@ -10694,26 +11118,30 @@ export const ProposalDetailsDocument = gql`
  *   },
  * });
  */
-export function useProposalDetailsQuery(baseOptions: Apollo.QueryHookOptions<ProposalDetailsQuery, ProposalDetailsQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<ProposalDetailsQuery, ProposalDetailsQueryVariables>(ProposalDetailsDocument, options);
-      }
-export function useProposalDetailsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProposalDetailsQuery, ProposalDetailsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<ProposalDetailsQuery, ProposalDetailsQueryVariables>(ProposalDetailsDocument, options);
-        }
+export function useProposalDetailsQuery(
+  baseOptions: Apollo.QueryHookOptions<ProposalDetailsQuery, ProposalDetailsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<ProposalDetailsQuery, ProposalDetailsQueryVariables>(ProposalDetailsDocument, options);
+}
+export function useProposalDetailsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<ProposalDetailsQuery, ProposalDetailsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<ProposalDetailsQuery, ProposalDetailsQueryVariables>(ProposalDetailsDocument, options);
+}
 export type ProposalDetailsQueryHookResult = ReturnType<typeof useProposalDetailsQuery>;
 export type ProposalDetailsLazyQueryHookResult = ReturnType<typeof useProposalDetailsLazyQuery>;
 export type ProposalDetailsQueryResult = Apollo.QueryResult<ProposalDetailsQuery, ProposalDetailsQueryVariables>;
 export const EnsureProposalsDocument = gql`
-    query ensureProposals($ids: [String!]!) {
-  proposalItems(filter: {id: {in: $ids}}) {
-    nodes {
-      id
+  query ensureProposals($ids: [String!]!) {
+    proposalItems(filter: { id: { in: $ids } }) {
+      nodes {
+        id
+      }
     }
   }
-}
-    `;
+`;
 
 /**
  * __useEnsureProposalsQuery__
@@ -10731,52 +11159,53 @@ export const EnsureProposalsDocument = gql`
  *   },
  * });
  */
-export function useEnsureProposalsQuery(baseOptions: Apollo.QueryHookOptions<EnsureProposalsQuery, EnsureProposalsQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<EnsureProposalsQuery, EnsureProposalsQueryVariables>(EnsureProposalsDocument, options);
-      }
-export function useEnsureProposalsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EnsureProposalsQuery, EnsureProposalsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<EnsureProposalsQuery, EnsureProposalsQueryVariables>(EnsureProposalsDocument, options);
-        }
+export function useEnsureProposalsQuery(
+  baseOptions: Apollo.QueryHookOptions<EnsureProposalsQuery, EnsureProposalsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<EnsureProposalsQuery, EnsureProposalsQueryVariables>(EnsureProposalsDocument, options);
+}
+export function useEnsureProposalsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<EnsureProposalsQuery, EnsureProposalsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<EnsureProposalsQuery, EnsureProposalsQueryVariables>(EnsureProposalsDocument, options);
+}
 export type EnsureProposalsQueryHookResult = ReturnType<typeof useEnsureProposalsQuery>;
 export type EnsureProposalsLazyQueryHookResult = ReturnType<typeof useEnsureProposalsLazyQuery>;
 export type EnsureProposalsQueryResult = Apollo.QueryResult<EnsureProposalsQuery, EnsureProposalsQueryVariables>;
 export const PublicKeysDocument = gql`
-    query PublicKeys($PerPage: Int, $offset: Int) {
-  publicKeys(
-    first: $PerPage
-    offset: $offset
-    orderBy: [SESSIONS_SUM_BLOCK_NUMBER_ASC]
-  ) {
-    nodes {
-      id
-      compressed
-      uncompressed
-      history
-      block {
-        timestamp
-        number
-      }
-      sessions(first: 1) {
-        nodes {
-          id
-          ...SessionAuth
-          keyGenThreshold
-          signatureThreshold
+  query PublicKeys($PerPage: Int, $offset: Int) {
+    publicKeys(first: $PerPage, offset: $offset, orderBy: [SESSIONS_SUM_BLOCK_NUMBER_ASC]) {
+      nodes {
+        id
+        compressed
+        uncompressed
+        history
+        block {
+          timestamp
+          number
+        }
+        sessions(first: 1) {
+          nodes {
+            id
+            ...SessionAuth
+            keyGenThreshold
+            signatureThreshold
+          }
         }
       }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
     }
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
-      startCursor
-      endCursor
-    }
-    totalCount
   }
-}
-    ${SessionAuthFragmentDoc}`;
+  ${SessionAuthFragmentDoc}
+`;
 
 /**
  * __usePublicKeysQuery__
@@ -10796,38 +11225,41 @@ export const PublicKeysDocument = gql`
  * });
  */
 export function usePublicKeysQuery(baseOptions?: Apollo.QueryHookOptions<PublicKeysQuery, PublicKeysQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<PublicKeysQuery, PublicKeysQueryVariables>(PublicKeysDocument, options);
-      }
-export function usePublicKeysLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PublicKeysQuery, PublicKeysQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<PublicKeysQuery, PublicKeysQueryVariables>(PublicKeysDocument, options);
-        }
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<PublicKeysQuery, PublicKeysQueryVariables>(PublicKeysDocument, options);
+}
+export function usePublicKeysLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<PublicKeysQuery, PublicKeysQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<PublicKeysQuery, PublicKeysQueryVariables>(PublicKeysDocument, options);
+}
 export type PublicKeysQueryHookResult = ReturnType<typeof usePublicKeysQuery>;
 export type PublicKeysLazyQueryHookResult = ReturnType<typeof usePublicKeysLazyQuery>;
 export type PublicKeysQueryResult = Apollo.QueryResult<PublicKeysQuery, PublicKeysQueryVariables>;
 export const PublicKeyDocument = gql`
-    query PublicKey($id: String!) {
-  publicKey(id: $id) {
-    id
-    compressed
-    uncompressed
-    history
-    block {
-      timestamp
-      number
-    }
-    sessions(first: 1) {
-      nodes {
-        id
-        ...SessionAuth
-        keyGenThreshold
-        signatureThreshold
+  query PublicKey($id: String!) {
+    publicKey(id: $id) {
+      id
+      compressed
+      uncompressed
+      history
+      block {
+        timestamp
+        number
+      }
+      sessions(first: 1) {
+        nodes {
+          id
+          ...SessionAuth
+          keyGenThreshold
+          signatureThreshold
+        }
       }
     }
   }
-}
-    ${SessionAuthFragmentDoc}`;
+  ${SessionAuthFragmentDoc}
+`;
 
 /**
  * __usePublicKeyQuery__
@@ -10846,28 +11278,30 @@ export const PublicKeyDocument = gql`
  * });
  */
 export function usePublicKeyQuery(baseOptions: Apollo.QueryHookOptions<PublicKeyQuery, PublicKeyQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<PublicKeyQuery, PublicKeyQueryVariables>(PublicKeyDocument, options);
-      }
-export function usePublicKeyLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PublicKeyQuery, PublicKeyQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<PublicKeyQuery, PublicKeyQueryVariables>(PublicKeyDocument, options);
-        }
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<PublicKeyQuery, PublicKeyQueryVariables>(PublicKeyDocument, options);
+}
+export function usePublicKeyLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<PublicKeyQuery, PublicKeyQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<PublicKeyQuery, PublicKeyQueryVariables>(PublicKeyDocument, options);
+}
 export type PublicKeyQueryHookResult = ReturnType<typeof usePublicKeyQuery>;
 export type PublicKeyLazyQueryHookResult = ReturnType<typeof usePublicKeyLazyQuery>;
 export type PublicKeyQueryResult = Apollo.QueryResult<PublicKeyQuery, PublicKeyQueryVariables>;
 export const SessionKeyIdsDocument = gql`
-    query SessionKeyIds($keys: [String!]!) {
-  sessions(filter: {id: {in: $keys}}) {
-    nodes {
-      id
-      publicKey {
+  query SessionKeyIds($keys: [String!]!) {
+    sessions(filter: { id: { in: $keys } }) {
+      nodes {
         id
+        publicKey {
+          id
+        }
       }
     }
   }
-}
-    `;
+`;
 
 /**
  * __useSessionKeyIdsQuery__
@@ -10885,38 +11319,43 @@ export const SessionKeyIdsDocument = gql`
  *   },
  * });
  */
-export function useSessionKeyIdsQuery(baseOptions: Apollo.QueryHookOptions<SessionKeyIdsQuery, SessionKeyIdsQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<SessionKeyIdsQuery, SessionKeyIdsQueryVariables>(SessionKeyIdsDocument, options);
-      }
-export function useSessionKeyIdsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SessionKeyIdsQuery, SessionKeyIdsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<SessionKeyIdsQuery, SessionKeyIdsQueryVariables>(SessionKeyIdsDocument, options);
-        }
+export function useSessionKeyIdsQuery(
+  baseOptions: Apollo.QueryHookOptions<SessionKeyIdsQuery, SessionKeyIdsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<SessionKeyIdsQuery, SessionKeyIdsQueryVariables>(SessionKeyIdsDocument, options);
+}
+export function useSessionKeyIdsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<SessionKeyIdsQuery, SessionKeyIdsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<SessionKeyIdsQuery, SessionKeyIdsQueryVariables>(SessionKeyIdsDocument, options);
+}
 export type SessionKeyIdsQueryHookResult = ReturnType<typeof useSessionKeyIdsQuery>;
 export type SessionKeyIdsLazyQueryHookResult = ReturnType<typeof useSessionKeyIdsLazyQuery>;
 export type SessionKeyIdsQueryResult = Apollo.QueryResult<SessionKeyIdsQuery, SessionKeyIdsQueryVariables>;
 export const CurrentSessionAuthoritiesDocument = gql`
-    query CurrentSessionAuthorities {
-  sessions(last: 1, orderBy: [BLOCK_NUMBER_DESC]) {
-    nodes {
-      id
-      blockId
-      ...SessionAuth
-      publicKey {
-        compressed
-      }
-      signatureThreshold
-      keyGenThreshold
-      proposerThreshold
-      block {
+  query CurrentSessionAuthorities {
+    sessions(last: 1, orderBy: [BLOCK_NUMBER_DESC]) {
+      nodes {
         id
-        timestamp
+        blockId
+        ...SessionAuth
+        publicKey {
+          compressed
+        }
+        signatureThreshold
+        keyGenThreshold
+        proposerThreshold
+        block {
+          id
+          timestamp
+        }
       }
     }
   }
-}
-    ${SessionAuthFragmentDoc}`;
+  ${SessionAuthFragmentDoc}
+`;
 
 /**
  * __useCurrentSessionAuthoritiesQuery__
@@ -10933,36 +11372,50 @@ export const CurrentSessionAuthoritiesDocument = gql`
  *   },
  * });
  */
-export function useCurrentSessionAuthoritiesQuery(baseOptions?: Apollo.QueryHookOptions<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>(CurrentSessionAuthoritiesDocument, options);
-      }
-export function useCurrentSessionAuthoritiesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>(CurrentSessionAuthoritiesDocument, options);
-        }
+export function useCurrentSessionAuthoritiesQuery(
+  baseOptions?: Apollo.QueryHookOptions<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>(
+    CurrentSessionAuthoritiesDocument,
+    options
+  );
+}
+export function useCurrentSessionAuthoritiesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>(
+    CurrentSessionAuthoritiesDocument,
+    options
+  );
+}
 export type CurrentSessionAuthoritiesQueryHookResult = ReturnType<typeof useCurrentSessionAuthoritiesQuery>;
 export type CurrentSessionAuthoritiesLazyQueryHookResult = ReturnType<typeof useCurrentSessionAuthoritiesLazyQuery>;
-export type CurrentSessionAuthoritiesQueryResult = Apollo.QueryResult<CurrentSessionAuthoritiesQuery, CurrentSessionAuthoritiesQueryVariables>;
+export type CurrentSessionAuthoritiesQueryResult = Apollo.QueryResult<
+  CurrentSessionAuthoritiesQuery,
+  CurrentSessionAuthoritiesQueryVariables
+>;
 export const SessionKeysDocument = gql`
-    query SessionKeys($SessionId: [String!]!) {
-  sessions(filter: {id: {in: $SessionId}}) {
-    nodes {
-      id
-      ...SessionAuth
-      publicKey {
+  query SessionKeys($SessionId: [String!]!) {
+    sessions(filter: { id: { in: $SessionId } }) {
+      nodes {
         id
-        compressed
-        uncompressed
-        block {
-          timestamp
-          number
+        ...SessionAuth
+        publicKey {
+          id
+          compressed
+          uncompressed
+          block {
+            timestamp
+            number
+          }
         }
       }
     }
   }
-}
-    ${SessionAuthFragmentDoc}`;
+  ${SessionAuthFragmentDoc}
+`;
 
 /**
  * __useSessionKeysQuery__
@@ -10981,35 +11434,38 @@ export const SessionKeysDocument = gql`
  * });
  */
 export function useSessionKeysQuery(baseOptions: Apollo.QueryHookOptions<SessionKeysQuery, SessionKeysQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<SessionKeysQuery, SessionKeysQueryVariables>(SessionKeysDocument, options);
-      }
-export function useSessionKeysLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SessionKeysQuery, SessionKeysQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<SessionKeysQuery, SessionKeysQueryVariables>(SessionKeysDocument, options);
-        }
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<SessionKeysQuery, SessionKeysQueryVariables>(SessionKeysDocument, options);
+}
+export function useSessionKeysLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<SessionKeysQuery, SessionKeysQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<SessionKeysQuery, SessionKeysQueryVariables>(SessionKeysDocument, options);
+}
 export type SessionKeysQueryHookResult = ReturnType<typeof useSessionKeysQuery>;
 export type SessionKeysLazyQueryHookResult = ReturnType<typeof useSessionKeysLazyQuery>;
 export type SessionKeysQueryResult = Apollo.QueryResult<SessionKeysQuery, SessionKeysQueryVariables>;
 export const SessionThresholdHistoryDocument = gql`
-    query SessionThresholdHistory($offset: Int!, $perPage: Int!) {
-  sessions(first: $perPage, offset: $offset, orderBy: [BLOCK_NUMBER_DESC]) {
-    nodes {
-      id
-      signatureThreshold
-      keyGenThreshold
-      block {
+  query SessionThresholdHistory($offset: Int!, $perPage: Int!) {
+    sessions(first: $perPage, offset: $offset, orderBy: [BLOCK_NUMBER_DESC]) {
+      nodes {
         id
-        timestamp
+        signatureThreshold
+        keyGenThreshold
+        block {
+          id
+          timestamp
+        }
       }
+      pageInfo {
+        ...PageInfoMeta
+      }
+      totalCount
     }
-    pageInfo {
-      ...PageInfoMeta
-    }
-    totalCount
   }
-}
-    ${PageInfoMetaFragmentDoc}`;
+  ${PageInfoMetaFragmentDoc}
+`;
 
 /**
  * __useSessionThresholdHistoryQuery__
@@ -11028,39 +11484,53 @@ export const SessionThresholdHistoryDocument = gql`
  *   },
  * });
  */
-export function useSessionThresholdHistoryQuery(baseOptions: Apollo.QueryHookOptions<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>(SessionThresholdHistoryDocument, options);
-      }
-export function useSessionThresholdHistoryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>(SessionThresholdHistoryDocument, options);
-        }
+export function useSessionThresholdHistoryQuery(
+  baseOptions: Apollo.QueryHookOptions<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>(
+    SessionThresholdHistoryDocument,
+    options
+  );
+}
+export function useSessionThresholdHistoryLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>(
+    SessionThresholdHistoryDocument,
+    options
+  );
+}
 export type SessionThresholdHistoryQueryHookResult = ReturnType<typeof useSessionThresholdHistoryQuery>;
 export type SessionThresholdHistoryLazyQueryHookResult = ReturnType<typeof useSessionThresholdHistoryLazyQuery>;
-export type SessionThresholdHistoryQueryResult = Apollo.QueryResult<SessionThresholdHistoryQuery, SessionThresholdHistoryQueryVariables>;
+export type SessionThresholdHistoryQueryResult = Apollo.QueryResult<
+  SessionThresholdHistoryQuery,
+  SessionThresholdHistoryQueryVariables
+>;
 export const SessionThresholdsDocument = gql`
-    query SessionThresholds($sessionId: String!) {
-  session(id: $sessionId) {
-    id
-    signatureThreshold
-    keyGenThreshold
-    proposersCount: sessionProposers {
-      totalCount
-    }
-    ...SessionAuth
-    publicKey {
+  query SessionThresholds($sessionId: String!) {
+    session(id: $sessionId) {
       id
-      compressed
-      uncompressed
-      block {
-        timestamp
-        number
+      signatureThreshold
+      keyGenThreshold
+      proposersCount: sessionProposers {
+        totalCount
+      }
+      ...SessionAuth
+      publicKey {
+        id
+        compressed
+        uncompressed
+        block {
+          timestamp
+          number
+        }
       }
     }
   }
-}
-    ${SessionAuthFragmentDoc}`;
+  ${SessionAuthFragmentDoc}
+`;
 
 /**
  * __useSessionThresholdsQuery__
@@ -11078,14 +11548,21 @@ export const SessionThresholdsDocument = gql`
  *   },
  * });
  */
-export function useSessionThresholdsQuery(baseOptions: Apollo.QueryHookOptions<SessionThresholdsQuery, SessionThresholdsQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<SessionThresholdsQuery, SessionThresholdsQueryVariables>(SessionThresholdsDocument, options);
-      }
-export function useSessionThresholdsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SessionThresholdsQuery, SessionThresholdsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<SessionThresholdsQuery, SessionThresholdsQueryVariables>(SessionThresholdsDocument, options);
-        }
+export function useSessionThresholdsQuery(
+  baseOptions: Apollo.QueryHookOptions<SessionThresholdsQuery, SessionThresholdsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<SessionThresholdsQuery, SessionThresholdsQueryVariables>(SessionThresholdsDocument, options);
+}
+export function useSessionThresholdsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<SessionThresholdsQuery, SessionThresholdsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<SessionThresholdsQuery, SessionThresholdsQueryVariables>(
+    SessionThresholdsDocument,
+    options
+  );
+}
 export type SessionThresholdsQueryHookResult = ReturnType<typeof useSessionThresholdsQuery>;
 export type SessionThresholdsLazyQueryHookResult = ReturnType<typeof useSessionThresholdsLazyQuery>;
 export type SessionThresholdsQueryResult = Apollo.QueryResult<SessionThresholdsQuery, SessionThresholdsQueryVariables>;

--- a/packages/page-statistics/src/gql/proposals.graphql
+++ b/packages/page-statistics/src/gql/proposals.graphql
@@ -1,164 +1,173 @@
 # Proposals listing query
 query Proposals(
-  # The number of proposals to return
-  $perPage: Int!
-  # The number of proposals to skip
-  $offset: Int!
+    # The number of proposals to return
+    $perPage: Int!
+    # The number of proposals to skip
+    $offset: Int!
 ) {
-  # Listing proposals items
-  proposalItems(first: $perPage, offset: $offset) {
-    nodes {
-      ...ProposalListView
+    # Listing proposals items
+    proposalItems(first: $perPage, offset: $offset) {
+        nodes {
+            ...ProposalListView
+        }
+        totalCount
+        pageInfo {
+            ...PageInfoMeta
+        }
     }
-    totalCount
-    pageInfo {
-      ...PageInfoMeta
-    }
-  }
 }
 
 query ProposalsCounter(
-  #  Proposal counter id
-  $id: String!
+    #  Proposal counter id
+    $id: String!
 ) {
-  proposalCounter(id: $id) {
-    id
-    signedProposalsMap
-    unSignedProposalsMap
+    proposalCounter(id: $id) {
+        id
+        signedProposalsMap
+        unSignedProposalsMap
 
-    signedProposalsCount
-    unSignedProposalsCount
+        signedProposalsCount
+        unSignedProposalsCount
 
-    statusMap
+        statusMap
 
-    block {
-      number
-      timestamp
+        block {
+            number
+            timestamp
+        }
     }
-  }
 }
 
 # Proposals over view query
 query ProposalsOverview(
-  # Starting block number value for the stats start
-  $startRange: BigFloatFilter!
-  # Ending block number value for the stats start
-  $endRange: BigFloatFilter!
-  # Session id for threshold and proposers stats
-  $sessionId: String!
+    # Starting block number value for the stats start
+    $startRange: BigFloatFilter!
+    # Ending block number value for the stats start
+    $endRange: BigFloatFilter!
+    # Session id for threshold and proposers stats
+    $sessionId: String!
 ) {
-  session(id: $sessionId) {
-    id
-    proposerThreshold
+    session(id: $sessionId) {
+        id
+        proposerThreshold
 
-    sessionProposers {
-      totalCount
+        sessionProposers {
+            totalCount
+        }
+        sessionValidators {
+            totalCount
+        }
     }
-    sessionValidators {
-      totalCount
+    # Opn Proposals fetching only the recent 10 elements
+    openProposals: proposalItems(filter: { status: { equalTo: "Open" } }, orderBy: [BLOCK_NUMBER_DESC], first: 10) {
+        nodes {
+            ...ProposalListView
+        }
+        pageInfo {
+            ...PageInfoMeta
+        }
+        totalCount
     }
-  }
-  # Opn Proposals fetching only the recent 10 elements
-  openProposals: proposalItems(filter: { status: { equalTo: "Open" } }, orderBy: [BLOCK_NUMBER_DESC], first: 10) {
-    nodes {
-      ...ProposalListView
+    # Open proposals count for a range for block numbers
+    open: proposalTimelineStatuses(
+        filter: { status: { equalTo: Open }, and: [{ blockNumber: $startRange }, { blockNumber: $endRange }] }
+    ) {
+        totalCount
     }
-    pageInfo {
-      ...PageInfoMeta
+    # Signed proposals count for a range for block numbers
+    signed: proposalTimelineStatuses(
+        filter: { status: { equalTo: Signed }, and: [{ blockNumber: $startRange }, { blockNumber: $endRange }] }
+    ) {
+        totalCount
     }
-    totalCount
-  }
-  # Open proposals count for a range for block numbers
-  open: proposalTimelineStatuses(
-    filter: { status: { equalTo: Open }, and: [{ blockNumber: $startRange }, { blockNumber: $endRange }] }
-  ) {
-    totalCount
-  }
-  # Signed proposals count for a range for block numbers
-  signed: proposalTimelineStatuses(
-    filter: { status: { equalTo: Signed }, and: [{ blockNumber: $startRange }, { blockNumber: $endRange }] }
-  ) {
-    totalCount
-  }
-  # Rejected proposals count for a range for block numbers
-  reject: proposalTimelineStatuses(
-    filter: { status: { equalTo: Rejected }, and: [{ blockNumber: $startRange }, { blockNumber: $endRange }] }
-  ) {
-    totalCount
-  }
-  # Accepted proposals count for a range for block numbers
-  accepted: proposalTimelineStatuses(
-    filter: { status: { equalTo: Accepted }, and: [{ blockNumber: $startRange }, { blockNumber: $endRange }] }
-  ) {
-    totalCount
-  }
+    # Rejected proposals count for a range for block numbers
+    reject: proposalTimelineStatuses(
+        filter: { status: { equalTo: Rejected }, and: [{ blockNumber: $startRange }, { blockNumber: $endRange }] }
+    ) {
+        totalCount
+    }
+    # Accepted proposals count for a range for block numbers
+    accepted: proposalTimelineStatuses(
+        filter: { status: { equalTo: Accepted }, and: [{ blockNumber: $startRange }, { blockNumber: $endRange }] }
+    ) {
+        totalCount
+    }
 }
 
 # Query votes for a prooser
 query ProposalVotes(
-  # The number of votes to return
-  $perPage: Int!
-  # The number of votes to skip
-  $offset: Int!
-  # The proposal id
-  $proposalId: String!
-  $for: BooleanFilter
+    # The number of votes to return
+    $perPage: Int!
+    # The number of votes to skip
+    $offset: Int!
+    # The proposal id
+    $proposalId: String!
+    $for: BooleanFilter
 ) {
-  proposalVotes(
-    filter: { proposalId: { equalTo: $proposalId }, for: $for }
-    orderBy: [BLOCK_NUMBER_DESC]
-    first: $perPage
-    offset: $offset
-  ) {
-    nodes {
-      ...ProposalsVoteListView
+    proposalVotes(
+        filter: { proposalId: { equalTo: $proposalId }, for: $for }
+        orderBy: [BLOCK_NUMBER_DESC]
+        first: $perPage
+        offset: $offset
+    ) {
+        nodes {
+            ...ProposalsVoteListView
+        }
+        totalCount
+        pageInfo {
+            ...PageInfoMeta
+        }
     }
-    totalCount
-    pageInfo {
-      ...PageInfoMeta
-    }
-  }
 }
 # Proposals details query
 query ProposalDetails(
-  # Proposal id
-  $id: String!
-  # Session for votes status
-  $targetSessionId: String!
+    # Proposal id
+    $id: String!
+    # Session for votes status
+    $targetSessionId: String!
 ) {
-  session(id: $targetSessionId) {
-    id
-    sessionProposers {
-      totalCount
-    }
-  }
-
-  proposalItem(id: $id) {
-    id
-    data
-    signature
-    type
-    status
-    proposalTimelineStatuses {
-      nodes {
+    session(id: $targetSessionId) {
         id
+        sessionProposers {
+            totalCount
+        }
+    }
+
+    proposalItem(id: $id) {
+        id
+        data
+        signature
+        type
         status
-        blockNumber
-        timestamp
-      }
-    }
+        proposalTimelineStatuses {
+            nodes {
+                id
+                status
+                blockNumber
+                timestamp
+            }
+        }
 
-    votesFor: proposalVotesByProposalId(filter: { for: { equalTo: true } }) {
-      totalCount
-    }
+        votesFor: proposalVotesByProposalId(filter: { for: { equalTo: true } }) {
+            totalCount
+        }
 
-    totalVotes: proposalVotesByProposalId {
-      totalCount
-    }
+        totalVotes: proposalVotesByProposalId {
+            totalCount
+        }
 
-    block {
-      timestamp
-      number
+        block {
+            timestamp
+            number
+        }
     }
-  }
+}
+
+
+query ensureProposals($ids:[String!]!){
+    proposalItems (filter: {id: {in: $ids}}) {
+        nodes {
+            id
+        }
+    }
 }

--- a/packages/page-statistics/src/gql/public-keys.graphql
+++ b/packages/page-statistics/src/gql/public-keys.graphql
@@ -47,3 +47,14 @@ query PublicKey($id: String!) {
     }
   }
 }
+
+query SessionKeyIds($keys: [String!]!) {
+  sessions(filter: { id: { in: $keys } }) {
+    nodes {
+      id
+      publicKey {
+        id
+      }
+    }
+  }
+}

--- a/packages/page-statistics/src/provider/hooks/useKeys.ts
+++ b/packages/page-statistics/src/provider/hooks/useKeys.ts
@@ -369,6 +369,7 @@ export function useKey(id: string): Loadable<PublicKeyDetails> {
       });
     return () => subscription.unsubscribe();
   }, [callSessionKeys, query]);
+
   useEffect(() => {
     const subscription = sessionKeysQuery.observable
       .filter((res) => Boolean(res.data && res.data.sessions))

--- a/packages/page-statistics/src/provider/hooks/useKeys.ts
+++ b/packages/page-statistics/src/provider/hooks/useKeys.ts
@@ -125,6 +125,19 @@ type PublicKeyDetailsPage = {
 /**
  * List keys for table view
  *
+ * @example
+ * An example of using previous and next values
+ * ```jsx
+ *  const KeyDetailsPage = ({key}:{key:string}) => {
+ *    const proposalDetailsPage = useKey(key);
+ *    const nextAndPrevStatus = proposalDetailsPage.nextAndPrevStatus
+ *    const hasNext = useMemo( () => prevAndNextKey.val?.nextKeyId !== null, [nextAndPrevStatus])
+ *    const hasPrev = useMemo( () => prevAndNextKey.val?.previousKeyId !== null, [nextAndPrevStatus])
+ *    return <div>
+ *      <button  disabled={!hasPrev}>Next</button> <button disabled={!hasNext}>Prev</button>
+ *    </div>
+ *  }
+ * ```
  * */
 export function useKeys(reqQuery: PageInfoQuery): Loadable<Page<PublicKeyListView>> {
   const [call, query] = usePublicKeysLazyQuery();

--- a/packages/page-statistics/src/provider/hooks/useKeys.ts
+++ b/packages/page-statistics/src/provider/hooks/useKeys.ts
@@ -15,8 +15,8 @@ import { Loadable, Page, PageInfoQuery, SessionKeyHistory, SessionKeyStatus, Thr
  *  @param id - public key id
  *  @param uncompressed - Uncompressed public key value
  *  @param compressed - Compressed public key value
- *  @params start - The time when the public key started taking effect and be the active key
- *  @params end - The time when the public key stopped taking effect and be the active key
+ *  @param start - The time when the public key started taking effect and be the active key
+ *  @param end - The time when the public key stopped taking effect and be the active key
  *  @param session - The session id for that key (Life time of the key)
  * */
 type PublicKeyContent = {

--- a/packages/page-statistics/src/provider/hooks/useProposal.ts
+++ b/packages/page-statistics/src/provider/hooks/useProposal.ts
@@ -1,5 +1,6 @@
 import {
   ProposalType,
+  useEnsureProposalsLazyQuery,
   useProposalDetailsLazyQuery,
   useProposalsLazyQuery,
   useProposalsOverviewLazyQuery,
@@ -159,6 +160,7 @@ type ProposalDetails = {
   timeline: ProposalTimeLine[];
   data: ProposalData;
 };
+
 /**
  * Proposals overview
  * @return ProposalsOverview - Proposal overview data
@@ -240,6 +242,7 @@ export function useProposalsOverview(
   }, [query]);
   return proposalsOverview;
 }
+
 /**
  * Listing query for proposals
  * */
@@ -298,10 +301,16 @@ export function useProposals(reqQuery: PageInfoQuery): ProposalsPage {
   return proposalsPage;
 }
 
+type NextAndPrevStatus = {
+  nextProposalId: string | null;
+  previousProposalId: string | null;
+};
 type ProposalDetailsPage = {
   proposal: Loadable<ProposalDetails>;
   votes: VotesPage;
+  nextAndPrevStatus: Loadable<NextAndPrevStatus>;
 };
+
 /**
  * Load a proposal with paginated votes and status at a given session
  * */
@@ -311,10 +320,33 @@ export function useProposal(targetSessionId: string, votesReqQuery: VotesQuery):
     val: null,
     isFailed: false,
   });
+
+  const [nextAndPrevStatus, setNextAndPrevStatus] = useState<Loadable<NextAndPrevStatus>>({
+    isLoading: false,
+    val: null,
+    isFailed: false,
+  });
+  const [ensureProposals, ensureProposalsQuery] = useEnsureProposalsLazyQuery();
+
   const [call, query] = useProposalDetailsLazyQuery();
   const { offset, perPage } = votesReqQuery;
   const proposalId = votesReqQuery.filter.proposalId;
   const votes = useVotes(votesReqQuery);
+
+  useEffect(() => {
+    ensureProposals({
+      variables: {
+        ids: [Number(proposalId) - 1, Number(proposalId) + 1].map((i) => String(i)),
+      },
+    }).catch((e) => {
+      setNextAndPrevStatus({
+        val: null,
+        error: e.message,
+        isLoading: false,
+        isFailed: true,
+      });
+    });
+  }, [proposalId, ensureProposals]);
 
   useEffect(() => {
     call({
@@ -331,7 +363,32 @@ export function useProposal(targetSessionId: string, votesReqQuery: VotesQuery):
       });
     });
   }, [proposalId, offset, perPage, targetSessionId, call]);
-
+  useEffect(() => {
+    const subscription = ensureProposalsQuery.observable
+      .map((res): Loadable<NextAndPrevStatus> => {
+        if (res.data && res.data.proposalItems) {
+          const proposals = res.data.proposalItems.nodes.filter((p) => p !== null);
+          const nextProposalId = proposals.find((p) => Number(p!.id) === Number(proposalId) + 1)?.id ?? null;
+          const previousProposalId = proposals.find((p) => Number(p!.id) === Number(proposalId) - 1)?.id ?? null;
+          return {
+            val: {
+              nextProposalId,
+              previousProposalId,
+            },
+            isFailed: false,
+            isLoading: false,
+          };
+        }
+        return {
+          isLoading: res.loading,
+          isFailed: Boolean(res.error),
+          error: res.error?.message ?? undefined,
+          val: null,
+        };
+      })
+      .subscribe(setNextAndPrevStatus);
+    return () => subscription.unsubscribe();
+  }, [ensureProposalsQuery, setNextAndPrevStatus, proposalId]);
   useEffect(() => {
     const subscription = query.observable
       .map((res): Loadable<ProposalDetails> => {
@@ -380,8 +437,9 @@ export function useProposal(targetSessionId: string, votesReqQuery: VotesQuery):
     () => ({
       proposal: proposalDetails,
       votes,
+      nextAndPrevStatus,
     }),
-    [proposalDetails, votes]
+    [nextAndPrevStatus, proposalDetails, votes]
   );
 }
 

--- a/packages/page-statistics/src/provider/hooks/useProposal.ts
+++ b/packages/page-statistics/src/provider/hooks/useProposal.ts
@@ -327,6 +327,9 @@ type ProposalDetailsPage = {
  *    const nextAndPrevStatus = proposalDetailsPage.nextAndPrevStatus
  *    const hasNext = useMemo( () => nextAndPrevStatus.val?.nextProposalId !== null, [nextAndPrevStatus])
  *    const hasPrev = useMemo( () => nextAndPrevStatus.val?.previousProposalId !== null, [nextAndPrevStatus])
+ *    return <div>
+ *      <button  disabled={!hasPrev}>Next</button> <button disabled={!hasNext}>Prev</button>
+ *    </div>
  *  }
  * ```
  *

--- a/packages/page-statistics/src/provider/hooks/useProposal.ts
+++ b/packages/page-statistics/src/provider/hooks/useProposal.ts
@@ -313,6 +313,23 @@ type ProposalDetailsPage = {
 
 /**
  * Load a proposal with paginated votes and status at a given session
+ * @example
+ * An example of using previous and next values
+ * ```jsx
+ *  const ProposalDetailsPage = ({id,targetSessionId}:{id:string ,targetSessionId:string}) => {
+ *    const proposalDetailsPage = useProposal(targetSessionId , {
+ *      offset: 0,
+ *      perPage: 10,
+ *      filter:{
+ *        proposalId:id
+ *      }
+ *    });
+ *    const nextAndPrevStatus = proposalDetailsPage.nextAndPrevStatus
+ *    const hasNext = useMemo( () => nextAndPrevStatus.val?.nextProposalId !== null, [nextAndPrevStatus])
+ *    const hasPrev = useMemo( () => nextAndPrevStatus.val?.previousProposalId !== null, [nextAndPrevStatus])
+ *  }
+ * ```
+ *
  * */
 export function useProposal(targetSessionId: string, votesReqQuery: VotesQuery): ProposalDetailsPage {
   const [proposalDetails, setProposalDetails] = useState<Loadable<ProposalDetails>>({


### PR DESCRIPTION
## Summary of changes
- For Proposals and keys there is a new `next` `prev` ids to fetch the next item if any
- The `next` `prev` can be null which means there is no previous or next entry


### Reference issue to close (if applicable)
- Closes #600 

-----
### Code Checklist 

- [x] Tested
- [x] Documented
