### PR TITLE
fix(ThemeSwitcher): input visibility

### DIFF
--- a/packages/react-components/src/AppBar/ThemeSwitcher.tsx
+++ b/packages/react-components/src/AppBar/ThemeSwitcher.tsx
@@ -20,6 +20,7 @@ const ThemeSwitcherWrapper = styled.label`
     width: 0;
     height: 0;
     padding: 0;
+    visibility: hidden;
   }
 
   .theme-entry {


### PR DESCRIPTION
## Summary of changes
- hide input from `ThemeSwitcher` component since a small square was visible (on firefox)


### Reference issue to close (if applicable)
- None

-----
### Code Checklist 

- [ ] Tested
- [ ] Documented

### Screenshot

**before**
![Screenshot 2022-10-19 at 14-25-04 Webb Network](https://user-images.githubusercontent.com/9987732/196690813-6db19304-1934-4820-b45a-e627e22082cc.png)

**after**
![Screenshot 2022-10-19 at 14-26-31 Webb Network](https://user-images.githubusercontent.com/9987732/196690846-afcdc5c7-26d2-4c6d-86d5-33a4aaeeb206.png)
