### PR TITLE
Adding tooltips and dropdown for the note account table

### DIFF
--- a/apps/bridge-dapp/package.json
+++ b/apps/bridge-dapp/package.json
@@ -48,7 +48,7 @@
     "sass": "^1.52.3",
     "sass-loader": "^13.0.0",
     "style-loader": "^3.3.1",
-    "tailwindcss": "^3.1.3",
+    "tailwindcss": "^3.2.4",
     "tailwindcss-radix": "^2.5.0",
     "terser-webpack-plugin": "^5.3.3",
     "typescript": "^4.8.3",

--- a/apps/bridge-dapp/src/containers/ShieldedAssetsTableContainer/ShieldedAssetsTableContainer.tsx
+++ b/apps/bridge-dapp/src/containers/ShieldedAssetsTableContainer/ShieldedAssetsTableContainer.tsx
@@ -16,6 +16,7 @@ import {
 import {
   Button,
   fuzzyFilter,
+  IconWithTooltip,
   Table,
   TokenPairIcons,
   Tooltip,
@@ -37,16 +38,10 @@ const columns: ColumnDef<ShieldedAssetDataType, any>[] = [
     header: 'Chain',
     cell: (props) => (
       <div className="flex items-center">
-        <Tooltip>
-          <TooltipTrigger className="cursor-auto">
-            <ChainIcon size="lg" name={props.getValue<string>()} />
-          </TooltipTrigger>
-          <TooltipBody>
-            <Typography className="capitalize" variant="body1">
-              {props.getValue<string>()}
-            </Typography>
-          </TooltipBody>
-        </Tooltip>
+        <IconWithTooltip
+          icon={<ChainIcon size="lg" name={props.getValue<string>()} />}
+          content={props.getValue<string>()}
+        />
       </div>
     ),
   }),

--- a/apps/bridge-dapp/src/containers/ShieldedAssetsTableContainer/ShieldedAssetsTableContainer.tsx
+++ b/apps/bridge-dapp/src/containers/ShieldedAssetsTableContainer/ShieldedAssetsTableContainer.tsx
@@ -74,17 +74,20 @@ const columns: ColumnDef<ShieldedAssetDataType, any>[] = [
         return null;
       }
 
-      const firstTwoTokens = composition.slice(0, 2);
+      const [firstToken, secondToken] = composition.slice(0, 2);
       const numOfHiddenTokens = composition.length - 2;
 
       return (
         <div className="flex items-center space-x-1">
-          {firstTwoTokens.length === 1 ? (
-            <TokenIcon name={firstTwoTokens[0]} />
+          {!secondToken ? (
+            <IconWithTooltip
+              icon={<TokenIcon name={firstToken} />}
+              content={firstToken}
+            />
           ) : (
             <TokenPairIcons
-              token1Symbol={firstTwoTokens[0]}
-              token2Symbol={firstTwoTokens[1]}
+              token1Symbol={firstToken}
+              token2Symbol={secondToken}
             />
           )}
 

--- a/apps/bridge-dapp/src/containers/ShieldedAssetsTableContainer/ShieldedAssetsTableContainer.tsx
+++ b/apps/bridge-dapp/src/containers/ShieldedAssetsTableContainer/ShieldedAssetsTableContainer.tsx
@@ -18,6 +18,9 @@ import {
   fuzzyFilter,
   Table,
   TokenPairIcons,
+  Tooltip,
+  TooltipBody,
+  TooltipTrigger,
   Typography,
 } from '@webb-tools/webb-ui-components';
 import { FC } from 'react';
@@ -32,7 +35,20 @@ const columnHelper = createColumnHelper<ShieldedAssetDataType>();
 const columns: ColumnDef<ShieldedAssetDataType, any>[] = [
   columnHelper.accessor('chain', {
     header: 'Chain',
-    cell: (props) => <ChainIcon size="lg" name={props.getValue<string>()} />,
+    cell: (props) => (
+      <div className="flex items-center">
+        <Tooltip>
+          <TooltipTrigger className="cursor-auto">
+            <ChainIcon size="lg" name={props.getValue<string>()} />
+          </TooltipTrigger>
+          <TooltipBody>
+            <Typography className="capitalize" variant="body1">
+              {props.getValue<string>()}
+            </Typography>
+          </TooltipBody>
+        </Tooltip>
+      </div>
+    ),
   }),
 
   columnHelper.accessor('governedTokenSymbol', {

--- a/apps/bridge-dapp/src/containers/ShieldedAssetsTableContainer/ShieldedAssetsTableContainer.tsx
+++ b/apps/bridge-dapp/src/containers/ShieldedAssetsTableContainer/ShieldedAssetsTableContainer.tsx
@@ -24,7 +24,7 @@ import {
   TooltipTrigger,
   Typography,
 } from '@webb-tools/webb-ui-components';
-import { FC } from 'react';
+import { FC, PropsWithChildren, useCallback, useMemo } from 'react';
 import { EmptyTable } from '../../components/tables';
 import {
   ShieldedAssetDataType,
@@ -33,7 +33,7 @@ import {
 
 const columnHelper = createColumnHelper<ShieldedAssetDataType>();
 
-const columns: ColumnDef<ShieldedAssetDataType, any>[] = [
+const staticColumns: ColumnDef<ShieldedAssetDataType, any>[] = [
   columnHelper.accessor('chain', {
     header: 'Chain',
     cell: (props) => (
@@ -122,32 +122,72 @@ const columns: ColumnDef<ShieldedAssetDataType, any>[] = [
       </Typography>
     ),
   }),
-
-  columnHelper.accessor('assetsUrl', {
-    header: 'Action',
-    cell: () => {
-      return (
-        <div className="flex items-center space-x-1">
-          <Button variant="utility" size="sm" className="p-2">
-            <AddBoxLineIcon className="!fill-current" />
-          </Button>
-
-          <Button variant="utility" size="sm" className="p-2">
-            <SendPlanLineIcon className="!fill-current" />
-          </Button>
-
-          <Button variant="utility" size="sm" className="p-2">
-            <WalletLineIcon className="!fill-current" />
-          </Button>
-        </div>
-      );
-    },
-  }),
 ];
 
 export const ShieldedAssetsTableContainer: FC<
   ShieldedAssetsTableContainerProps
 > = ({ data = [], onUploadSpendNote }) => {
+  const onTransfer = useCallback(() => {
+    console.warn('Transfer is not implemented yet');
+  }, []);
+
+  const onDeposit = useCallback(() => {
+    console.warn('Deposit is not implemented yet');
+  }, []);
+
+  const onWithdraw = useCallback(() => {
+    console.warn('Withdraw is not implemented yet');
+  }, []);
+
+  const columns = useMemo<Array<ColumnDef<ShieldedAssetDataType, any>>>(
+    () => [
+      ...staticColumns,
+
+      columnHelper.accessor('assetsUrl', {
+        header: 'Action',
+        cell: () => {
+          return (
+            <div className="flex items-center space-x-1">
+              <ActionWithTooltip content="Deposit">
+                <Button
+                  variant="utility"
+                  size="sm"
+                  className="p-2"
+                  onClick={onDeposit}
+                >
+                  <AddBoxLineIcon className="!fill-current" />
+                </Button>
+              </ActionWithTooltip>
+
+              <ActionWithTooltip content="Transfer">
+                <Button
+                  variant="utility"
+                  size="sm"
+                  className="p-2"
+                  onClick={onTransfer}
+                >
+                  <SendPlanLineIcon className="!fill-current" />
+                </Button>
+              </ActionWithTooltip>
+
+              <ActionWithTooltip content="Withdraw">
+                <Button
+                  variant="utility"
+                  size="sm"
+                  className="p-2"
+                  onClick={onWithdraw}
+                >
+                  <WalletLineIcon className="!fill-current" />
+                </Button>
+              </ActionWithTooltip>
+            </div>
+          );
+        },
+      }),
+    ],
+    [onDeposit, onTransfer, onWithdraw]
+  );
+
   const table = useReactTable({
     data,
     columns,
@@ -177,5 +217,23 @@ export const ShieldedAssetsTableContainer: FC<
         totalRecords={data.length}
       />
     </div>
+  );
+};
+
+/***********************
+ * Internal components *
+ ***********************/
+
+const ActionWithTooltip: FC<PropsWithChildren<{ content: string }>> = ({
+  content,
+  children,
+}) => {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipBody>
+        <Typography variant="body3">{content}</Typography>
+      </TooltipBody>
+    </Tooltip>
   );
 };

--- a/apps/bridge-dapp/src/containers/SpendNotesTableContainer/SpendNotesTableContainer.tsx
+++ b/apps/bridge-dapp/src/containers/SpendNotesTableContainer/SpendNotesTableContainer.tsx
@@ -13,24 +13,25 @@ import {
 } from '@webb-tools/icons';
 import {
   Button,
+  Dropdown,
+  DropdownBasicButton,
+  DropdownBody,
   fuzzyFilter,
   IconWithTooltip,
   KeyValueWithButton,
+  MenuItem,
   shortenString,
   Table,
   TokenPairIcons,
-  Tooltip,
-  TooltipBody,
-  TooltipTrigger,
   Typography,
 } from '@webb-tools/webb-ui-components';
-import { FC } from 'react';
+import { FC, useCallback, useMemo } from 'react';
 import { EmptyTable } from '../../components/tables';
 import { SpendNoteDataType, SpendNotesTableContainerProps } from './types';
 
 const columnHelper = createColumnHelper<SpendNoteDataType>();
 
-const columns: ColumnDef<SpendNoteDataType, any>[] = [
+const staticColumns: ColumnDef<SpendNoteDataType, any>[] = [
   columnHelper.accessor('chain', {
     header: 'Chain',
     cell: (props) => (
@@ -124,23 +125,27 @@ const columns: ColumnDef<SpendNoteDataType, any>[] = [
       />
     ),
   }),
-
-  columnHelper.accessor('assetsUrl', {
-    header: '',
-    cell: () => {
-      return (
-        <Button variant="utility" size="sm" className="p-2">
-          <ChevronDown className="!fill-current" />
-        </Button>
-      );
-    },
-  }),
 ];
 
 export const SpendNotesTableContainer: FC<SpendNotesTableContainerProps> = ({
   data = [],
   onUploadSpendNote,
 }) => {
+  const columns = useMemo<Array<ColumnDef<SpendNoteDataType, any>>>(() => {
+    return [
+      ...staticColumns,
+
+      columnHelper.accessor('assetsUrl', {
+        header: '',
+        cell: (props) => {
+          const note = props.row.original.note;
+
+          return <ActionDropdownButton note={note} />;
+        },
+      }),
+    ];
+  }, []);
+
   const table = useReactTable({
     data,
     columns,
@@ -171,5 +176,32 @@ export const SpendNotesTableContainer: FC<SpendNotesTableContainerProps> = ({
         totalRecords={data.length}
       />
     </div>
+  );
+};
+
+const ActionDropdownButton: FC<{ note: string }> = ({ note }) => {
+  const onQuickTransfer = useCallback(() => {
+    console.log('Trying to quick transfer with note: ', note);
+    console.warn('Quick transfer haven"t implemented yet ');
+  }, [note]);
+
+  const onQuickWithdraw = useCallback(() => {
+    console.log('Trying to quick withdraw with note: ', note);
+    console.warn('Quick withdraw haven"t implemented yet ');
+  }, [note]);
+
+  return (
+    <Dropdown>
+      <DropdownBasicButton>
+        <Button as="span" variant="utility" size="sm" className="p-2">
+          <ChevronDown className="!fill-current" />
+        </Button>
+      </DropdownBasicButton>
+
+      <DropdownBody className="min-w-[200px]" size="sm">
+        <MenuItem onClick={onQuickTransfer}>Quick Transfer</MenuItem>
+        <MenuItem onClick={onQuickWithdraw}>Quick Withdraw</MenuItem>
+      </DropdownBody>
+    </Dropdown>
   );
 };

--- a/apps/bridge-dapp/src/containers/SpendNotesTableContainer/SpendNotesTableContainer.tsx
+++ b/apps/bridge-dapp/src/containers/SpendNotesTableContainer/SpendNotesTableContainer.tsx
@@ -14,6 +14,7 @@ import {
 import {
   Button,
   fuzzyFilter,
+  IconWithTooltip,
   KeyValueWithButton,
   shortenString,
   Table,
@@ -33,16 +34,12 @@ const columns: ColumnDef<SpendNoteDataType, any>[] = [
   columnHelper.accessor('chain', {
     header: 'Chain',
     cell: (props) => (
-      <Tooltip>
-        <TooltipTrigger className="cursor-auto">
-          <ChainIcon size="lg" name={props.getValue<string>()} />
-        </TooltipTrigger>
-        <TooltipBody>
-          <Typography className="capitalize" variant="body1">
-            {props.getValue<string>()}
-          </Typography>
-        </TooltipBody>
-      </Tooltip>
+      <div className="flex items-center">
+        <IconWithTooltip
+          icon={<ChainIcon size="lg" name={props.getValue<string>()} />}
+          content={props.getValue<string>()}
+        />
+      </div>
     ),
   }),
 

--- a/apps/bridge-dapp/src/containers/SpendNotesTableContainer/SpendNotesTableContainer.tsx
+++ b/apps/bridge-dapp/src/containers/SpendNotesTableContainer/SpendNotesTableContainer.tsx
@@ -18,10 +18,11 @@ import {
   shortenString,
   Table,
   TokenPairIcons,
-  TokenWithAmount,
+  Tooltip,
+  TooltipBody,
+  TooltipTrigger,
   Typography,
 } from '@webb-tools/webb-ui-components';
-import { formatDistanceToNow } from 'date-fns';
 import { FC } from 'react';
 import { EmptyTable } from '../../components/tables';
 import { SpendNoteDataType, SpendNotesTableContainerProps } from './types';
@@ -31,7 +32,18 @@ const columnHelper = createColumnHelper<SpendNoteDataType>();
 const columns: ColumnDef<SpendNoteDataType, any>[] = [
   columnHelper.accessor('chain', {
     header: 'Chain',
-    cell: (props) => <ChainIcon size="lg" name={props.getValue<string>()} />,
+    cell: (props) => (
+      <Tooltip>
+        <TooltipTrigger className="cursor-auto">
+          <ChainIcon size="lg" name={props.getValue<string>()} />
+        </TooltipTrigger>
+        <TooltipBody>
+          <Typography className="capitalize" variant="body1">
+            {props.getValue<string>()}
+          </Typography>
+        </TooltipBody>
+      </Tooltip>
+    ),
   }),
 
   columnHelper.accessor('governedTokenSymbol', {
@@ -78,7 +90,7 @@ const columns: ColumnDef<SpendNoteDataType, any>[] = [
 
           {numOfHiddenTokens > 0 && (
             <Typography className="inline-block" variant="body3">
-              +3 others
+              +{numOfHiddenTokens} others
             </Typography>
           )}
         </div>

--- a/apps/stats-dapp/package.json
+++ b/apps/stats-dapp/package.json
@@ -47,7 +47,7 @@
     "sass": "^1.52.3",
     "sass-loader": "^13.0.0",
     "style-loader": "^3.3.1",
-    "tailwindcss": "^3.1.3",
+    "tailwindcss": "^3.2.4",
     "tailwindcss-radix": "^2.5.0",
     "terser-webpack-plugin": "^5.3.3",
     "typescript": "^4.8.3",

--- a/libs/tailwind-preset/package.json
+++ b/libs/tailwind-preset/package.json
@@ -7,6 +7,6 @@
     "@tailwindcss/forms": "0.5.3",
     "tailwindcss-radix": "^2.5.0",
     "tailwind-scrollbar": "^2.0.1",
-    "tailwindcss": "3.1.8"
+    "tailwindcss": "3.2.4"
   }
 }

--- a/libs/webb-ui-components/src/components/IconWithTooltip/IconWithTooltip.tsx
+++ b/libs/webb-ui-components/src/components/IconWithTooltip/IconWithTooltip.tsx
@@ -1,16 +1,23 @@
 import { FC } from 'react';
+import { twMerge } from 'tailwind-merge';
 
 import { Typography } from '../../typography/Typography';
 import { Tooltip, TooltipBody, TooltipTrigger } from '../Tooltip/Tooltip';
 import { IconWithTooltipProp } from './types';
 
-export const IconWithTooltip: FC<IconWithTooltipProp> = ({ content, icon }) => {
+export const IconWithTooltip: FC<IconWithTooltipProp> = ({
+  content,
+  btnClassName,
+  icon,
+}) => {
   return (
     <Tooltip>
-      <TooltipTrigger className="cursor-auto">{icon}</TooltipTrigger>
+      <TooltipTrigger className={twMerge('cursor-auto', btnClassName)}>
+        {icon}
+      </TooltipTrigger>
       <TooltipBody>
         {typeof content === 'string' || typeof content === 'number' ? (
-          <Typography className="capitalize" variant="body1">
+          <Typography className="capitalize" variant="body3">
             {content}
           </Typography>
         ) : (

--- a/libs/webb-ui-components/src/components/IconWithTooltip/IconWithTooltip.tsx
+++ b/libs/webb-ui-components/src/components/IconWithTooltip/IconWithTooltip.tsx
@@ -1,0 +1,22 @@
+import { FC } from 'react';
+
+import { Typography } from '../../typography/Typography';
+import { Tooltip, TooltipBody, TooltipTrigger } from '../Tooltip/Tooltip';
+import { IconWithTooltipProp } from './types';
+
+export const IconWithTooltip: FC<IconWithTooltipProp> = ({ content, icon }) => {
+  return (
+    <Tooltip>
+      <TooltipTrigger className="cursor-auto">{icon}</TooltipTrigger>
+      <TooltipBody>
+        {typeof content === 'string' || typeof content === 'number' ? (
+          <Typography className="capitalize" variant="body1">
+            {content}
+          </Typography>
+        ) : (
+          content
+        )}
+      </TooltipBody>
+    </Tooltip>
+  );
+};

--- a/libs/webb-ui-components/src/components/IconWithTooltip/index.ts
+++ b/libs/webb-ui-components/src/components/IconWithTooltip/index.ts
@@ -1,0 +1,1 @@
+export * from './IconWithTooltip';

--- a/libs/webb-ui-components/src/components/IconWithTooltip/types.d.ts
+++ b/libs/webb-ui-components/src/components/IconWithTooltip/types.d.ts
@@ -8,4 +8,9 @@ export interface IconWithTooltipProp {
    * The tooltip content
    */
   content: React.ReactNode;
+
+  /**
+   * The tooltip trigger className for tailwind styling
+   */
+  btnClassName?: string;
 }

--- a/libs/webb-ui-components/src/components/IconWithTooltip/types.d.ts
+++ b/libs/webb-ui-components/src/components/IconWithTooltip/types.d.ts
@@ -1,0 +1,11 @@
+export interface IconWithTooltipProp {
+  /**
+   * The icon to display
+   */
+  icon: React.ReactNode;
+
+  /**
+   * The tooltip content
+   */
+  content: React.ReactNode;
+}

--- a/libs/webb-ui-components/src/components/Table/TData.tsx
+++ b/libs/webb-ui-components/src/components/Table/TData.tsx
@@ -7,23 +7,25 @@ import { TDataProps } from './types';
 /**
  * The styler wrapper of `<td></td>` tag, use inside `<tbody></tbody>` tab for table
  */
-export const TData = forwardRef<HTMLTableCellElement, TDataProps>(({ children, className, ...props }, ref) => {
-  return (
-    <td
-      {...props}
-      className={twMerge(
-        cx(
-          'px-2 py-4 text-left border-t first:pl-6 last:pr-6 body1',
-          'border-mono-40 dark:border-mono-140',
-          'text-mono-140 dark:text-mono-60',
-          'bg-mono-0 dark:bg-mono-180',
-          'group-hover:bg-blue-0 dark:group-hover:bg-mono-160'
-        ),
-        className
-      )}
-      ref={ref}
-    >
-      {children}
-    </td>
-  );
-});
+export const TData = forwardRef<HTMLTableCellElement, TDataProps>(
+  ({ children, className, ...props }, ref) => {
+    return (
+      <td
+        {...props}
+        className={twMerge(
+          cx(
+            'px-2 py-4 text-left border-t first:pl-6 last:pr-6 body1',
+            'border-mono-40 dark:border-mono-140',
+            'text-mono-140 dark:text-mono-60',
+            'bg-mono-0 dark:bg-mono-180',
+            'group-hover/tr:bg-blue-0 dark:group-hover/tr:bg-mono-160'
+          ),
+          className
+        )}
+        ref={ref}
+      >
+        {children}
+      </td>
+    );
+  }
+);

--- a/libs/webb-ui-components/src/components/Table/Table.tsx
+++ b/libs/webb-ui-components/src/components/Table/Table.tsx
@@ -39,7 +39,7 @@ const TableComp = <T extends RowData>(
         </thead>
         <tbody>
           {table.getRowModel().rows.map((row) => (
-            <tr key={row.id} className="group">
+            <tr key={row.id} className="group/tr">
               {row.getVisibleCells().map((cell) => (
                 <TData className={tdClassName} key={cell.id}>
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/libs/webb-ui-components/src/components/TokenPairIcons/TokenPairIcons.tsx
+++ b/libs/webb-ui-components/src/components/TokenPairIcons/TokenPairIcons.tsx
@@ -10,7 +10,7 @@ export const TokenPairIcons = forwardRef<HTMLDivElement, TokenPairIconsProps>(
       <div
         {...props}
         className={twMerge(
-          'flex items-center relative group',
+          'flex items-center group/token relative',
           chainName ? 'mr-1' : '',
           className
         )}
@@ -21,7 +21,7 @@ export const TokenPairIcons = forwardRef<HTMLDivElement, TokenPairIconsProps>(
           content={token1Symbol.toUpperCase()}
         />
         <IconWithTooltip
-          btnClassName="-ml-2 transition-all group-hover:ml-1"
+          btnClassName="-ml-2 transition-all group-hover/token:ml-1"
           icon={<TokenIcon size="lg" name={token2Symbol.toLowerCase()} />}
           content={token2Symbol.toUpperCase()}
         />

--- a/libs/webb-ui-components/src/components/TokenPairIcons/TokenPairIcons.tsx
+++ b/libs/webb-ui-components/src/components/TokenPairIcons/TokenPairIcons.tsx
@@ -1,6 +1,7 @@
 import { ChainIcon, TokenIcon } from '@webb-tools/icons';
 import { forwardRef } from 'react';
 import { twMerge } from 'tailwind-merge';
+import { IconWithTooltip } from '../IconWithTooltip';
 import { TokenPairIconsProps } from './types';
 
 export const TokenPairIcons = forwardRef<HTMLDivElement, TokenPairIconsProps>(
@@ -9,14 +10,21 @@ export const TokenPairIcons = forwardRef<HTMLDivElement, TokenPairIconsProps>(
       <div
         {...props}
         className={twMerge(
-          'flex items-center -space-x-2 relative',
+          'flex items-center relative group',
           chainName ? 'mr-1' : '',
           className
         )}
         ref={ref}
       >
-        <TokenIcon size="lg" name={token1Symbol.toLowerCase()} />
-        <TokenIcon size="lg" name={token2Symbol.toLowerCase()} />
+        <IconWithTooltip
+          icon={<TokenIcon size="lg" name={token1Symbol.toLowerCase()} />}
+          content={token1Symbol.toUpperCase()}
+        />
+        <IconWithTooltip
+          btnClassName="-ml-2 transition-all group-hover:ml-1"
+          icon={<TokenIcon size="lg" name={token2Symbol.toLowerCase()} />}
+          content={token2Symbol.toUpperCase()}
+        />
 
         {chainName && (
           <ChainIcon

--- a/libs/webb-ui-components/src/components/index.ts
+++ b/libs/webb-ui-components/src/components/index.ts
@@ -20,6 +20,7 @@ export * from './DropdownMenu';
 export * from './FileUploads';
 export * from './Filter';
 export * from './Footer';
+export * from './IconWithTooltip';
 export * from './Input';
 export * from './KeyCard';
 export * from './KeyValueWithButton';

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "style-loader": "^3.3.1",
     "tailwind-merge": "^1.6.0",
     "tailwind-scrollbar": "^2.0.1",
-    "tailwindcss": "3.1.8",
+    "tailwindcss": "3.2.4",
     "tailwindcss-radix": "^2.5.0",
     "thread-loader": "^3.0.4",
     "tinycolor2": "^1.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13805,7 +13805,7 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.0.3, fast-glob@^3.2.11, fast-glob@^3.2.12, fast-glob@^3.2.5, fast-glob@^3.2.7, fast-glob@^3.2.9:
+fast-glob@^3.0.3, fast-glob@^3.2.12, fast-glob@^3.2.5, fast-glob@^3.2.7, fast-glob@^3.2.9:
   version "3.2.12"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
   integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
@@ -20515,13 +20515,6 @@ postcss-modules@^4.0.0:
     postcss-modules-values "^4.0.0"
     string-hash "^1.1.1"
 
-postcss-nested@5.0.6:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-5.0.6.tgz#466343f7fc8d3d46af3e7dba3fcd47d052a945bc"
-  integrity sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==
-  dependencies:
-    postcss-selector-parser "^6.0.6"
-
 postcss-nested@6.0.0, postcss-nested@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-6.0.0.tgz#1572f1984736578f360cffc7eb7dca69e30d1735"
@@ -20615,7 +20608,7 @@ postcss-reduce-transforms@^5.1.0:
   dependencies:
     postcss-value-parser "^4.2.0"
 
-postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4, postcss-selector-parser@^6.0.5, postcss-selector-parser@^6.0.6, postcss-selector-parser@^6.0.9:
+postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4, postcss-selector-parser@^6.0.5, postcss-selector-parser@^6.0.9:
   version "6.0.10"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
   integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
@@ -23496,38 +23489,10 @@ tailwindcss-radix@^2.5.0:
   resolved "https://registry.yarnpkg.com/tailwindcss-radix/-/tailwindcss-radix-2.6.1.tgz#793d72e7185fc4f5c9e2b1d1cfc9470ade41b897"
   integrity sha512-ejh4BHkn/3g349l+JiEW6I4//uclU4nllEqnOK3/8zpORscIk9WbjLyYR2UzqwVRjjzgd72I/hMDJZm3+XO48w==
 
-tailwindcss@3.1.8:
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.1.8.tgz#4f8520550d67a835d32f2f4021580f9fddb7b741"
-  integrity sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==
-  dependencies:
-    arg "^5.0.2"
-    chokidar "^3.5.3"
-    color-name "^1.1.4"
-    detective "^5.2.1"
-    didyoumean "^1.2.2"
-    dlv "^1.1.3"
-    fast-glob "^3.2.11"
-    glob-parent "^6.0.2"
-    is-glob "^4.0.3"
-    lilconfig "^2.0.6"
-    normalize-path "^3.0.0"
-    object-hash "^3.0.0"
-    picocolors "^1.0.0"
-    postcss "^8.4.14"
-    postcss-import "^14.1.0"
-    postcss-js "^4.0.0"
-    postcss-load-config "^3.1.4"
-    postcss-nested "5.0.6"
-    postcss-selector-parser "^6.0.10"
-    postcss-value-parser "^4.2.0"
-    quick-lru "^5.1.1"
-    resolve "^1.22.1"
-
-tailwindcss@^3.1.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.2.3.tgz#c5ee3cb95dae7a80592d43a460d277915c7b2938"
-  integrity sha512-Xt9D4PK4zuuQCEB8bwK9JUCKmTgUwyac/6b0/42Vqhgl6YJkep+Wf5wq+5uXYfmrupdAD0YY2NY1hyZp1HjRrg==
+tailwindcss@3.2.4, tailwindcss@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.2.4.tgz#afe3477e7a19f3ceafb48e4b083e292ce0dc0250"
+  integrity sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==
   dependencies:
     arg "^5.0.2"
     chokidar "^3.5.3"


### PR DESCRIPTION
## Summary of changes
- Adding _tooltips_ for the **chain column** on the **shielded assets** table and **spend note** table
- Adding _tooltips_ for the **composition column** on the **shielded asset** table and **spend note** table
- Adding _tooltips_ for the **action column** on the **shielded asset** table
- Adding _dropdown menu_ for the **action column** on the **spend note** table
- Upgrade to Tailwind v3.2.4 (latest version) to support nested group class names.

### Reference issue to close (if applicable)
- Closes https://github.com/webb-tools/webb-dapp/issues/724
- Closes https://github.com/webb-tools/webb-dapp/issues/733
- Closes https://github.com/webb-tools/webb-dapp/issues/729

-----
### Code Checklist 

- [x] Tested
- [x] Documented

### Screen Recording

https://user-images.githubusercontent.com/60747384/204585359-2274974e-fc0c-4e69-b8bb-926b1552bec1.mp4


