### PR TITLE
Fix max balance and amount input error message

### DIFF
--- a/apps/bridge-dapp/src/containers/DepositContainer/DepositContainer.tsx
+++ b/apps/bridge-dapp/src/containers/DepositContainer/DepositContainer.tsx
@@ -307,8 +307,9 @@ export const DepositContainer = forwardRef<
   }, [chains, selectedSourceChain, setMainComponent, sourceChains]);
 
   const onMaxBtnClick = useCallback(() => {
-    setAmount(selectedTokenBalance ?? 0);
-  }, [selectedTokenBalance]);
+    const balance = selectedToken?.balance ?? '0';
+    setAmount(Number(balance));
+  }, [selectedToken]);
 
   // Main action on click
   const actionOnClick = useCallback(async () => {
@@ -383,7 +384,7 @@ export const DepositContainer = forwardRef<
     selectedSourceChain,
     destChainInputValue,
     wrappableCurrency,
-    governedCurrency
+    governedCurrency,
   ]);
 
   // Only disable button when the wallet is connected and exists a note account

--- a/apps/bridge-dapp/src/containers/DepositContainer/DepositContainer.tsx
+++ b/apps/bridge-dapp/src/containers/DepositContainer/DepositContainer.tsx
@@ -223,23 +223,21 @@ export const DepositContainer = forwardRef<
     [brideGovernedCurrency, bridgeWrappableCurrency]
   );
   const isDisabledDepositButton = useMemo(() => {
+    const selectedTokenBalance = selectedToken?.balance
+      ? Number(selectedToken.balance)
+      : 0;
     return [
       selectedSourceChain,
       selectedToken,
       destChainInputValue,
       amount,
-      typeof selectedTokenBalance === 'number'
-        ? isWrapFlow
-          ? true
-          : amount <= selectedTokenBalance
-        : true,
+      selectedTokenBalance >= amount,
     ].some((val) => Boolean(val) === false);
   }, [
     amount,
     destChainInputValue,
     selectedSourceChain,
     selectedToken,
-    selectedTokenBalance,
     isWrapFlow,
   ]);
 
@@ -494,7 +492,14 @@ export const DepositContainer = forwardRef<
   useEffect(() => {
     setDestChain(defaultDestinationChain);
   }, [defaultDestinationChain]);
-
+  const amountErrorMessage = useMemo(() => {
+    if (!selectedToken?.balance) {
+      return undefined;
+    }
+    return Number(selectedToken.balance) >= amount
+      ? undefined
+      : 'Insufficient balance';
+  }, [amount, selectedToken]);
   return (
     <>
       <div {...props} ref={ref}>
@@ -550,6 +555,7 @@ export const DepositContainer = forwardRef<
             amount: amount ? amount.toString() : undefined,
             onAmountChange,
             onMaxBtnClick,
+            errorMessage: amountErrorMessage,
           }}
           buttonProps={{
             onClick: actionOnClick,

--- a/libs/evm-contracts/src/webb-vanchor.ts
+++ b/libs/evm-contracts/src/webb-vanchor.ts
@@ -703,6 +703,7 @@ export class VAnchorContract {
 
     const levels = await this.inner.levels();
     const provingManager = new CircomProvingManager(wasmBuffer, levels, worker);
+    console.log('provingManager: ', provingManager);
     const proof = (await provingManager.prove(
       'vanchor',
       proofInput

--- a/libs/evm-contracts/src/webb-vanchor.ts
+++ b/libs/evm-contracts/src/webb-vanchor.ts
@@ -703,7 +703,6 @@ export class VAnchorContract {
 
     const levels = await this.inner.levels();
     const provingManager = new CircomProvingManager(wasmBuffer, levels, worker);
-    console.log('provingManager: ', provingManager);
     const proof = (await provingManager.prove(
       'vanchor',
       proofInput


### PR DESCRIPTION
## Summary of changes
- Make the max button handler set the balance for the selected token (Wrappable asset for wrap & deposit,Governed asset for deposit)
- Added error message for the amount input
- disable the `Wrap and Deposit` or `Wrap` buttons for insufficient balances


### Reference issue to close (if applicable)
- Closes #774 

https://user-images.githubusercontent.com/35463181/205900558-96b3e2a6-9871-40db-98f3-d296d5a81259.mp4


-----
### Code Checklist 

- [ ] Tested
- [ ] Documented
