### PR TITLE
Dynamic block explorer link, RESET bug fix and best/finalized block chips updates on custom endpoint input

### DIFF
--- a/apps/stats-dapp/src/components/Header/Header.tsx
+++ b/apps/stats-dapp/src/components/Header/Header.tsx
@@ -36,7 +36,7 @@ export const Header: FC<HeaderProps> = ({
   connectedEndpoint,
   setConnectedEndpoint,
 }) => {
-  const { webbApiConfig, webbAppConfig } = constants;
+  const { webbApiConfig, webbAppConfig, SubqueryNodes } = constants;
 
   // This state variable tracks the user input of the 'Custom Data Source'
   const [endpointUserInput, setEndpointUserInput] = useState(connectedEndpoint);
@@ -113,11 +113,22 @@ export const Header: FC<HeaderProps> = ({
                   className="px-4 py-3.5 pt-4 border-b border-mono-40 dark:border-mono-140"
                   icon={<ExternalLinkLine size="lg" />}
                   onClick={() => {
-                    window.open(webbApiConfig.href, '_blank');
+                    window.open(
+                      endpointUserInput === SubqueryNodes.parachain
+                        ? webbApiConfig.parachain.href
+                        : endpointUserInput === SubqueryNodes.standalone
+                        ? webbApiConfig.standalone.href
+                        : '',
+                      '_blank'
+                    );
                   }}
                 >
                   <Typography variant="label" fw="bold">
-                    {webbApiConfig.name}
+                    {endpointUserInput === SubqueryNodes.parachain
+                      ? webbApiConfig.parachain.name
+                      : endpointUserInput === SubqueryNodes.standalone
+                      ? webbApiConfig.standalone.name
+                      : ''}
                   </Typography>
                 </MenuItem>
 

--- a/apps/stats-dapp/src/components/Header/Header.tsx
+++ b/apps/stats-dapp/src/components/Header/Header.tsx
@@ -36,7 +36,7 @@ export const Header: FC<HeaderProps> = ({
   connectedEndpoint,
   setConnectedEndpoint,
 }) => {
-  const { webbApiConfig, webbAppConfig, SubqueryNodes } = constants;
+  const { webbApiConfig, webbAppConfig, subqueryNodes } = constants;
 
   // This state variable tracks the user input of the 'Custom Data Source'
   const [endpointUserInput, setEndpointUserInput] = useState(connectedEndpoint);
@@ -114,9 +114,9 @@ export const Header: FC<HeaderProps> = ({
                   icon={<ExternalLinkLine size="lg" />}
                   onClick={() => {
                     window.open(
-                      endpointUserInput === SubqueryNodes.parachain
+                      endpointUserInput === subqueryNodes.parachain
                         ? webbApiConfig.parachain.href
-                        : endpointUserInput === SubqueryNodes.standalone
+                        : endpointUserInput === subqueryNodes.standalone
                         ? webbApiConfig.standalone.href
                         : '',
                       '_blank'
@@ -124,9 +124,9 @@ export const Header: FC<HeaderProps> = ({
                   }}
                 >
                   <Typography variant="label" fw="bold">
-                    {endpointUserInput === SubqueryNodes.parachain
+                    {endpointUserInput === subqueryNodes.parachain
                       ? webbApiConfig.parachain.name
-                      : endpointUserInput === SubqueryNodes.standalone
+                      : endpointUserInput === subqueryNodes.standalone
                       ? webbApiConfig.standalone.name
                       : ''}
                   </Typography>
@@ -156,7 +156,7 @@ export const Header: FC<HeaderProps> = ({
                       size="sm"
                       variant="link"
                       onClick={() => {
-                        setEndpointUserInput(connectedEndpoint);
+                        setEndpointUserInput(subqueryNodes.parachain);
                       }}
                     >
                       Reset

--- a/apps/stats-dapp/src/components/Header/Header.tsx
+++ b/apps/stats-dapp/src/components/Header/Header.tsx
@@ -36,7 +36,7 @@ export const Header: FC<HeaderProps> = ({
   connectedEndpoint,
   setConnectedEndpoint,
 }) => {
-  const { webbApiConfig, webbAppConfig, subqueryNodes } = constants;
+  const { webbApiConfig, webbAppConfig, webbNodes } = constants;
 
   // This state variable tracks the user input of the 'Custom Data Source'
   const [endpointUserInput, setEndpointUserInput] = useState(connectedEndpoint);
@@ -114,9 +114,10 @@ export const Header: FC<HeaderProps> = ({
                   icon={<ExternalLinkLine size="lg" />}
                   onClick={() => {
                     window.open(
-                      endpointUserInput === subqueryNodes.parachain
+                      endpointUserInput === webbNodes.parachain.subqueryEndpoint
                         ? webbApiConfig.parachain.href
-                        : endpointUserInput === subqueryNodes.standalone
+                        : endpointUserInput ===
+                          webbNodes.standalone.subqueryEndpoint
                         ? webbApiConfig.standalone.href
                         : '',
                       '_blank'
@@ -124,9 +125,10 @@ export const Header: FC<HeaderProps> = ({
                   }}
                 >
                   <Typography variant="label" fw="bold">
-                    {endpointUserInput === subqueryNodes.parachain
+                    {endpointUserInput === webbNodes.parachain.subqueryEndpoint
                       ? webbApiConfig.parachain.name
-                      : endpointUserInput === subqueryNodes.standalone
+                      : endpointUserInput ===
+                        webbNodes.standalone.subqueryEndpoint
                       ? webbApiConfig.standalone.name
                       : ''}
                   </Typography>
@@ -156,7 +158,9 @@ export const Header: FC<HeaderProps> = ({
                       size="sm"
                       variant="link"
                       onClick={() => {
-                        setEndpointUserInput(subqueryNodes.parachain);
+                        setEndpointUserInput(
+                          webbNodes.parachain.subqueryEndpoint
+                        );
                       }}
                     >
                       Reset

--- a/apps/stats-dapp/src/containers/Layout/Layout.tsx
+++ b/apps/stats-dapp/src/containers/Layout/Layout.tsx
@@ -82,7 +82,11 @@ export const Layout: FC<PropsWithChildren> = ({ children }) => {
       />
 
       <ApolloProvider client={apolloClient}>
-        <StatsProvider blockTime={6} sessionHeight={600}>
+        <StatsProvider
+          blockTime={6}
+          sessionHeight={600}
+          connectedEndpoint={connectedEndpoint}
+        >
           <NavBoxInfoContainer />
           <main className="max-w-[1160px] mx-auto">{children}</main>
         </StatsProvider>

--- a/apps/stats-dapp/src/provider/hooks/useKeys.ts
+++ b/apps/stats-dapp/src/provider/hooks/useKeys.ts
@@ -361,7 +361,7 @@ export function useActiveKeys(): Loadable<[PublicKey, PublicKey]> {
               activeKey,
               {
                 ...nextKey,
-                start: activeKey.end,
+                start: activeKey?.end,
               },
             ],
             isFailed: false,

--- a/apps/stats-dapp/src/provider/stats-provider.tsx
+++ b/apps/stats-dapp/src/provider/stats-provider.tsx
@@ -1,3 +1,4 @@
+import * as constants from '@webb-tools/webb-ui-components/constants';
 import { useLastBlockQuery, useMetaDataQuery } from '../generated/graphql';
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { ApiPromise, WsProvider } from '@polkadot/api';
@@ -53,6 +54,8 @@ type StatsProvidervalue = {
   isReady: boolean;
   // polkadot api
   api?: ApiPromise;
+  // connected subquery endpoint
+  connectedEndpoint?: string;
 };
 
 /**
@@ -100,6 +103,7 @@ const statsContext: React.Context<StatsProvidervalue> =
       activeSessionBlock: 0,
     },
     isReady: false,
+    connectedEndpoint: '',
   });
 export function useStatsContext() {
   return useContext(statsContext);
@@ -149,6 +153,8 @@ export const StatsProvider: React.FC<
   const [isReady, setIsReady] = useState(false);
   const [api, setApi] = useState<ApiPromise | undefined>();
 
+  const { webbNodes } = constants;
+
   const value = useMemo<StatsProvidervalue>(() => {
     return {
       time,
@@ -165,13 +171,19 @@ export const StatsProvider: React.FC<
 
   useEffect(() => {
     const getPromiseApi = async (): Promise<void> => {
-      const wsProvider = new WsProvider(polkadotProviderEndpoint);
+      const providerEndpoint =
+        props.connectedEndpoint === webbNodes.parachain.subqueryEndpoint
+          ? webbNodes.parachain.providerEndpoint
+          : props.connectedEndpoint === webbNodes.standalone.subqueryEndpoint
+          ? webbNodes.standalone.providerEndpoint
+          : '';
+      const wsProvider = new WsProvider(providerEndpoint);
       const apiPromise = await ApiPromise.create({ provider: wsProvider });
       setApi(apiPromise);
     };
 
     getPromiseApi();
-  }, []);
+  }, [props.connectedEndpoint]);
 
   useEffect(() => {
     const subscription = query.observable

--- a/libs/webb-ui-components/src/constants/index.ts
+++ b/libs/webb-ui-components/src/constants/index.ts
@@ -22,10 +22,32 @@ export const logoConfig: Link = {
   path: '/',
 };
 
-export const webbApiConfig: ExternalLink = {
-  name: 'Arana Alpha',
-  href: 'https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Farana-alpha-1.webb.tools#/explorer',
-  ...commonExternalProps,
+type SubqueryNodeInfo = {
+  parachain: string;
+  standalone: string;
+};
+
+export const SubqueryNodes: SubqueryNodeInfo = {
+  parachain: 'https://tangle-subquery.webb.tools/graphql',
+  standalone: 'https://subquery-dev.webb.tools/graphql',
+};
+
+type webbApiConfigType = {
+  parachain: ExternalLink;
+  standalone: ExternalLink;
+};
+
+export const webbApiConfig: webbApiConfigType = {
+  parachain: {
+    name: 'Tangle Network',
+    href: 'https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ftangle1.webb.tools#/explorer',
+    ...commonExternalProps,
+  },
+  standalone: {
+    name: 'Arana Alpha',
+    href: 'https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Farana-alpha-1.webb.tools#/explorer',
+    ...commonExternalProps,
+  },
 };
 
 export const webbAppConfig: ExternalLink = {

--- a/libs/webb-ui-components/src/constants/index.ts
+++ b/libs/webb-ui-components/src/constants/index.ts
@@ -22,14 +22,26 @@ export const logoConfig: Link = {
   path: '/',
 };
 
-type SubqueryNodeInfo = {
-  parachain: string;
-  standalone: string;
+type WebbNodeInfo = {
+  parachain: {
+    subqueryEndpoint: string;
+    providerEndpoint: string;
+  };
+  standalone: {
+    subqueryEndpoint: string;
+    providerEndpoint: string;
+  };
 };
 
-export const subqueryNodes: SubqueryNodeInfo = {
-  parachain: 'https://tangle-subquery.webb.tools/graphql',
-  standalone: 'https://subquery-dev.webb.tools/graphql',
+export const webbNodes: WebbNodeInfo = {
+  parachain: {
+    subqueryEndpoint: 'https://tangle-subquery.webb.tools/graphql',
+    providerEndpoint: 'wss://tangle-archive.webb.tools/',
+  },
+  standalone: {
+    subqueryEndpoint: 'https://subquery-dev.webb.tools/graphql',
+    providerEndpoint: 'wss://arana-alpha-1.webb.tools/',
+  },
 };
 
 type webbApiConfigType = {

--- a/libs/webb-ui-components/src/constants/index.ts
+++ b/libs/webb-ui-components/src/constants/index.ts
@@ -27,7 +27,7 @@ type SubqueryNodeInfo = {
   standalone: string;
 };
 
-export const SubqueryNodes: SubqueryNodeInfo = {
+export const subqueryNodes: SubqueryNodeInfo = {
   parachain: 'https://tangle-subquery.webb.tools/graphql',
   standalone: 'https://subquery-dev.webb.tools/graphql',
 };


### PR DESCRIPTION
## Summary of changes
- Block explorer links changes based on custom data source endpoint and default endpoint.
- Bug fix: `RESET` in custom data source now resets the app's endpoint to it's default endpoint.
- Bug fix: `best` and `finalized` block chips now updates on custom data source endpoint but only works for `parachain` and `standalone` nodes.


### Reference issue to close (if applicable)
- Closes #820 
- Closes #803 
- Closes #798 