### PR TITLE
Updates useDarkMode hook

### DIFF
--- a/apps/stats-dapp/src/containers/StackedAreaChartContainer/StackedAreaChartContainer.tsx
+++ b/apps/stats-dapp/src/containers/StackedAreaChartContainer/StackedAreaChartContainer.tsx
@@ -22,8 +22,7 @@ import {
   useProposalsOvertimeTotalCount,
   TimeRange,
 } from '../../provider/hooks';
-import { useDarkMode } from '@webb-tools/webb-ui-components';
-
+import { useStatsContext } from '../../provider/stats-provider';
 import { WebbColorsType } from '@webb-tools/webb-ui-components/types';
 import resolveConfig from 'tailwindcss/resolveConfig';
 import tailwindConfig from /* preval */ '../../../tailwind.config.js';
@@ -102,7 +101,7 @@ const allProposals = [
 ];
 
 export const StackedAreaChartContainer = () => {
-  const [isDarkMode, _] = useDarkMode();
+  const { isDarkMode } = useStatsContext();
 
   const [timeRange, setTimeRange] = useState<TimeRange>('three-months');
 

--- a/apps/stats-dapp/src/containers/StackedAreaChartContainer/StackedAreaChartContainer.tsx
+++ b/apps/stats-dapp/src/containers/StackedAreaChartContainer/StackedAreaChartContainer.tsx
@@ -142,11 +142,11 @@ export const StackedAreaChartContainer = () => {
         legend: {
           position: 'right',
           labels: {
-            padding: 12,
+            padding: 13,
             usePointStyle: true,
             pointStyle: 'rectRounded',
             pointStyleWidth: 16,
-            color: webbColors.mono['100'],
+            color: isDarkMode ? webbColors.mono['40'] : webbColors.mono['160'],
           },
           align: 'start',
           onHover: (_, legendItem, legend) => {
@@ -203,11 +203,6 @@ export const StackedAreaChartContainer = () => {
           grid: {
             display: false,
           },
-          title: {
-            display: true,
-            text: 'Months',
-            color: webbColors.mono['100'],
-          },
           ticks: {
             color: webbColors.mono['100'],
           },
@@ -215,7 +210,7 @@ export const StackedAreaChartContainer = () => {
         y: {
           stacked: true,
           grid: {
-            color: webbColors.mono['80'],
+            color: webbColors.mono['100'],
             borderDash: [4, 4],
           },
           ticks: {
@@ -229,7 +224,7 @@ export const StackedAreaChartContainer = () => {
         intersect: false,
       },
     };
-  }, []);
+  }, [isDarkMode]);
 
   return (
     <Card className="flex flex-col space-y-4 max-w-full">
@@ -283,14 +278,32 @@ export const StackedAreaChartContainer = () => {
         </div>
       </div>
 
+      <div className="flex items-center justify-between px-12 pt-4 pb-2">
+        <TitleWithInfo
+          title="Proposal #"
+          variant="body2"
+          titleClassName="text-mono-200 dark:text-mono-0"
+        />
+      </div>
+
       <div className="px-12 max-w-full">
         <div>
           {isLoading ? (
             <Spinner className="block mx-auto" size="xl" />
           ) : (
-            <Line options={chartOptions} data={chartData} className="h-96" />
+            <div>
+              <Line options={chartOptions} data={chartData} className="h-96" />
+            </div>
           )}
         </div>
+      </div>
+
+      <div className="flex items-center pl-[438px]">
+        <TitleWithInfo
+          title="Month"
+          variant="body2"
+          titleClassName="text-mono-200 dark:text-mono-0"
+        />
       </div>
     </Card>
   );

--- a/apps/stats-dapp/src/provider/stats-provider.tsx
+++ b/apps/stats-dapp/src/provider/stats-provider.tsx
@@ -56,8 +56,7 @@ type StatsProvidervalue = {
   // connected subquery endpoint
   connectedEndpoint?: string;
   // is dark mode
-  isDarkMode: boolean;
-  // toggle dark mode
+  isDarkMode?: boolean;
 };
 
 /**
@@ -106,7 +105,6 @@ const statsContext: React.Context<StatsProvidervalue> =
     },
     isReady: false,
     connectedEndpoint: '',
-    isDarkMode: false,
   });
 export function useStatsContext() {
   return useContext(statsContext);
@@ -168,6 +166,8 @@ export const StatsProvider: React.FC<
         setIsDarkMode(false);
       }
     }
+
+    getCurrentTheme();
 
     window.addEventListener('storage', getCurrentTheme);
 

--- a/apps/stats-dapp/src/provider/stats-provider.tsx
+++ b/apps/stats-dapp/src/provider/stats-provider.tsx
@@ -2,7 +2,6 @@ import * as constants from '@webb-tools/webb-ui-components/constants';
 import { useLastBlockQuery, useMetaDataQuery } from '../generated/graphql';
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import { polkadotProviderEndpoint } from '../constants';
 
 /**
  * Chain metadata
@@ -56,6 +55,9 @@ type StatsProvidervalue = {
   api?: ApiPromise;
   // connected subquery endpoint
   connectedEndpoint?: string;
+  // is dark mode
+  isDarkMode: boolean;
+  // toggle dark mode
 };
 
 /**
@@ -104,6 +106,7 @@ const statsContext: React.Context<StatsProvidervalue> =
     },
     isReady: false,
     connectedEndpoint: '',
+    isDarkMode: false,
   });
 export function useStatsContext() {
   return useContext(statsContext);
@@ -155,6 +158,22 @@ export const StatsProvider: React.FC<
 
   const { webbNodes } = constants;
 
+  const [isDarkMode, setIsDarkMode] = useState(false);
+
+  useEffect(() => {
+    function getCurrentTheme() {
+      if (localStorage.getItem('theme') === 'dark') {
+        setIsDarkMode(true);
+      } else if (localStorage.getItem('theme') === 'light') {
+        setIsDarkMode(false);
+      }
+    }
+
+    window.addEventListener('storage', getCurrentTheme);
+
+    return () => window.removeEventListener('storage', getCurrentTheme);
+  }, []);
+
   const value = useMemo<StatsProvidervalue>(() => {
     return {
       time,
@@ -165,8 +184,9 @@ export const StatsProvider: React.FC<
       isReady,
       metaData,
       api,
+      isDarkMode,
     };
-  }, [staticConfig, metaData, isReady, time, api]);
+  }, [staticConfig, metaData, isReady, time, api, isDarkMode]);
   const query = useLastBlockQuery();
 
   useEffect(() => {

--- a/libs/webb-ui-components/src/hooks/useDarkMode.ts
+++ b/libs/webb-ui-components/src/hooks/useDarkMode.ts
@@ -3,19 +3,24 @@ import { useCallback, useEffect, useState } from 'react';
 /**
  * Function to toggle or change the theme mode (possible value: `light`, `dark`, `undefined`)
  */
-export type ToggleThemeModeFunc = (nextThemeMode?: 'light' | 'dark' | undefined) => void;
+export type ToggleThemeModeFunc = (
+  nextThemeMode?: 'light' | 'dark' | undefined
+) => void;
 
 /**
  * Hook to get the current theme mode and a function to toggle the theme mode
  * @returns `[isDarkMode, toggleThemeMode]`
  */
 export function useDarkMode(): [boolean, ToggleThemeModeFunc] {
-  const [preferredTheme, setPreferredTheme] = useState<null | 'dark' | 'light'>(null);
+  const [preferredTheme, setPreferredTheme] = useState<null | 'dark' | 'light'>(
+    null
+  );
 
   useEffect(() => {
     if (
       localStorage.getItem('theme') === 'dark' ||
-      (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
+      (!('theme' in localStorage) &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches)
     ) {
       document.documentElement.classList.add('dark');
       setPreferredTheme('dark');
@@ -39,6 +44,7 @@ export function useDarkMode(): [boolean, ToggleThemeModeFunc] {
           if (localStorage.getItem('theme') !== _nextThemeMode) {
             document.documentElement.classList.add(_nextThemeMode);
             localStorage.setItem('theme', _nextThemeMode);
+            window.dispatchEvent(new Event('storage'));
           }
           break;
         }
@@ -47,6 +53,7 @@ export function useDarkMode(): [boolean, ToggleThemeModeFunc] {
           if (localStorage.getItem('theme') !== _nextThemeMode) {
             document.documentElement.classList.remove('dark');
             localStorage.setItem('theme', _nextThemeMode);
+            window.dispatchEvent(new Event('storage'));
           }
           break;
         }

--- a/libs/webb-ui-components/src/hooks/useDarkMode.ts
+++ b/libs/webb-ui-components/src/hooks/useDarkMode.ts
@@ -17,6 +17,12 @@ export function useDarkMode(): [boolean, ToggleThemeModeFunc] {
   );
 
   useEffect(() => {
+    if (localStorage.getItem('theme') === null) {
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+      window.dispatchEvent(new Event('storage'));
+    }
+
     if (
       localStorage.getItem('theme') === 'dark' ||
       (!('theme' in localStorage) &&


### PR DESCRIPTION
## Summary of changes
- Updates `useDarkMode` hook to emit `localstorage` changes event such that we can listen to the event to get the current selected theme.
- Adds `isDarkMode` state to `statsContext` such that we can use `const { isDarkMode } = useStatsContext()` in any component to get the current selected theme.
- Updates `text`, `labels` and few `elements` colors of `Stacked Area Chart` to match the design with `light` and `dark` mode accordingly.

### Reference issue to close (if applicable)
- Closes #618 
