### PR TITLE
Fixes withdraw asset token balance zero

### DIFF
--- a/apps/bridge-dapp/src/containers/WithdrawContainer/WithdrawContainer.tsx
+++ b/apps/bridge-dapp/src/containers/WithdrawContainer/WithdrawContainer.tsx
@@ -132,9 +132,13 @@ export const WithdrawContainer = forwardRef<
       return {
         name: currency.view.name,
         symbol: currency.view.symbol,
+        balance:
+          selectedFungibleToken?.symbol === currency.view.symbol
+            ? availableAmount
+            : 0,
       };
     });
-  }, [fungibleCurrencies]);
+  }, [fungibleCurrencies, availableAmount, selectedFungibleToken]);
 
   const selectedUnwrapToken = useMemo<AssetType | undefined>(() => {
     if (!wrappableCurrency) {


### PR DESCRIPTION
## Summary of changes
- Deposited asset balance is not shown as zero in token selection component while withdrawing.

## Changes overview

https://user-images.githubusercontent.com/53374218/213958825-480524e0-7099-4f03-bc09-712705bf682c.mov




### Reference issue to close (if applicable)
- Closes #889 
