### PR TITLE
Updates metamask deprecated methods usage

### DIFF
--- a/libs/web3-api-provider/src/ext-provider/web3-provider.ts
+++ b/libs/web3-api-provider/src/ext-provider/web3-provider.ts
@@ -85,9 +85,7 @@ export class Web3Provider<T = unknown> {
       // @ts-ignore
       const provider = Web3Provider.currentProvider;
 
-      // Enable the api
-      await provider.enable();
-      await provider.send('eth_requestAccounts', []);
+      await provider.request({ method: 'eth_requestAccounts' });
       const web3Provider = new Web3Provider(new Web3(provider), {
         description: 'MetaMask',
         icons: [],


### PR DESCRIPTION
## Summary of changes
- Removes `provider.enable()` and `provider.send()` methods while connecting to `Metamask` and replaces them with recommended method: `provider.request({ method: 'eth_requestAccounts' })`.

### No warnings when connecting to metamask

https://user-images.githubusercontent.com/53374218/215171646-014e4e8f-87f1-4f98-87b1-8064788719cf.mov

### Reference issue to close (if applicable)
- Closes #747 
