### PR TITLE
Updates failed transaction message and transaction progress card font sizes

### DIFF
--- a/libs/webb-ui-components/src/containers/TransactionProgressCard/TransactionCardFooter.tsx
+++ b/libs/webb-ui-components/src/containers/TransactionProgressCard/TransactionCardFooter.tsx
@@ -62,7 +62,7 @@ export const TransactionCardFooter: FC<
   }, [showDetails]);
   return (
     <div
-      className={cx('my-0 flex items-center p-4 py-2', {
+      className={cx('my-0 flex items-center px-4 py-3', {
         'bg-yellow-10 border-t-2 border-yellow-90 dark:bg-yellow-120':
           hasWarning,
       })}
@@ -76,8 +76,8 @@ export const TransactionCardFooter: FC<
 
         {message && !link && (
           <Typography
-            variant={'body3'}
-            fw={'bold'}
+            variant={'body1'}
+            fw={'normal'}
             className={twMerge(textClass, 'flex items-center')}
           >
             {message}
@@ -86,16 +86,12 @@ export const TransactionCardFooter: FC<
         {link && (
           <a rel="noopener noreferrer" href={link.uri} target="_blank">
             <Typography
-              variant={'body3'}
-              fw={'bold'}
+              variant={'body1'}
+              fw={'normal'}
               className={twMerge(textClass, 'flex items-center')}
             >
               {link.text}
-              <ExternalLinkIcon
-                width={12}
-                height={12}
-                className="!fill-current inline whitespace-nowrap ml-1"
-              />
+              <ExternalLinkIcon className="!fill-current inline whitespace-nowrap ml-1" />
             </Typography>
           </a>
         )}
@@ -104,7 +100,7 @@ export const TransactionCardFooter: FC<
         <Button
           onClick={buttonHandler}
           variant={'link'}
-          size={'sm'}
+          size={'md'}
           className={hasWarning ? textClass : undefined}
         >
           {showDetails ? 'DETAILS' : 'DISMISS'}

--- a/libs/webb-ui-components/src/containers/TransactionProgressCard/TransactionProgressCard.tsx
+++ b/libs/webb-ui-components/src/containers/TransactionProgressCard/TransactionProgressCard.tsx
@@ -225,41 +225,43 @@ export const TransactionProgressCard = forwardRef<
           </div>
           {/*Card Content*/}
           <div className={twMerge('my-0 flex items-center', sectionPadding)}>
-            <div className={'h-full self-start'}>
-              <div className={'h-full self-start w-8 '}>{tokens}</div>
-            </div>
-            <div className={'px-3'}>
-              <Typography
-                variant={'h4'}
-                fw={'bold'}
-                className={'py-0 text-mono-200'}
-              >
-                {label.amount}
-              </Typography>
-              {labelVariant === 'native' ? (
+            <div className="flex items-start">
+              <div className={'h-full pt-1.5'}>
+                <div className={'h-full w-8'}>{tokens}</div>
+              </div>
+              <div className={'px-3'}>
                 <Typography
-                  variant={'h5'}
+                  variant={'h4'}
                   fw={'bold'}
-                  className={'py-0 text-mono-100'}
+                  className={'py-0 text-mono-200'}
                 >
-                  {(label as NativeLabel).nativeValue} USD
+                  {label.amount}
                 </Typography>
-              ) : (
-                <a
-                  rel="noopener noreferrer"
-                  href={(label as BridgeLabel).tokenURI}
-                  target="_blank"
-                >
+                {labelVariant === 'native' ? (
                   <Typography
-                    variant={'body1'}
+                    variant={'h5'}
                     fw={'bold'}
-                    className="flex items-center py-0 uppercase text-mono-200"
+                    className={'py-0 text-mono-100'}
                   >
-                    {(label as BridgeLabel).token}
-                    <ExternalLinkLine className="!fill-current inline whitespace-nowrap ml-1" />
+                    {(label as NativeLabel).nativeValue} USD
                   </Typography>
-                </a>
-              )}
+                ) : (
+                  <a
+                    rel="noopener noreferrer"
+                    href={(label as BridgeLabel).tokenURI}
+                    target="_blank"
+                  >
+                    <Typography
+                      variant={'body1'}
+                      fw={'bold'}
+                      className="flex items-center py-0 uppercase text-mono-200"
+                    >
+                      {(label as BridgeLabel).token}
+                      <ExternalLinkLine className="!fill-current inline whitespace-nowrap ml-1" />
+                    </Typography>
+                  </a>
+                )}
+              </div>
             </div>
             <div className={'h-full self-start items-end grow flex flex-col'}>
               {hasSyncNote && (

--- a/libs/webb-ui-components/src/containers/TransactionProgressCard/TransactionProgressCard.tsx
+++ b/libs/webb-ui-components/src/containers/TransactionProgressCard/TransactionProgressCard.tsx
@@ -216,9 +216,9 @@ export const TransactionProgressCard = forwardRef<
               <Chip color={chipColor}>{method}</Chip>
             </div>
             <Typography
-              fw={'bold'}
-              variant={'body2'}
-              className={'whitespace-nowrap'}
+              fw={'semibold'}
+              variant={'body1'}
+              className={'whitespace-nowrap uppercase'}
             >
               {timeLabel}
             </Typography>
@@ -238,7 +238,7 @@ export const TransactionProgressCard = forwardRef<
               </Typography>
               {labelVariant === 'native' ? (
                 <Typography
-                  variant={'body1'}
+                  variant={'h5'}
                   fw={'bold'}
                   className={'py-0 text-mono-100'}
                 >
@@ -256,11 +256,7 @@ export const TransactionProgressCard = forwardRef<
                     className="flex items-center py-0 uppercase text-mono-200"
                   >
                     {(label as BridgeLabel).token}
-                    <ExternalLinkLine
-                      width={12}
-                      height={12}
-                      className="!fill-current inline whitespace-nowrap ml-1"
-                    />
+                    <ExternalLinkLine className="!fill-current inline whitespace-nowrap ml-1" />
                   </Typography>
                 </a>
               )}

--- a/libs/webb-ui-components/src/containers/TransactionProgressCard/TransactionQueueCard.tsx
+++ b/libs/webb-ui-components/src/containers/TransactionProgressCard/TransactionQueueCard.tsx
@@ -51,23 +51,15 @@ const CompletedFooter: FC<{ method: TransactionItemVariant }> = ({
   );
 };
 
-const FailedFooter: FC<{ method: TransactionItemVariant }> = ({ method }) => {
-  const message = useMemo(() => {
-    switch (method) {
-      case 'Transfer':
-        return 'Failed to  transfer!';
-      case 'Deposit':
-        return 'Failed to deposit';
-      case 'Withdraw':
-        return 'Failed to withdraw';
-    }
-  }, [method]);
+const FailedFooter = () => {
   return (
     <>
       <span className={'inline-block pr-2'}>
         <AlertFill maxWidth={16} />
       </span>
-      <span className={'text-inherit dark:text-inherit'}>{message} &nbsp;</span>
+      <span className={'text-inherit dark:text-inherit'}>
+        Transaction failed &nbsp;
+      </span>
     </>
   );
 };
@@ -155,14 +147,12 @@ export const TransactionQueueCard = forwardRef<
               hasWarning: isErrored,
               link: isCompleted
                 ? { uri: txURI, text: <CompletedFooter method={tx.method} /> }
+                : isErrored
+                ? { uri: txURI, text: <FailedFooter /> }
                 : tx.txStatus.message
                 ? undefined
                 : { uri: recipientURI, text: recipientFooter },
-              message: isErrored ? (
-                <FailedFooter method={tx.method} />
-              ) : (
-                tx.txStatus.message
-              ),
+              message: isErrored ? <FailedFooter /> : tx.txStatus.message,
             },
             label: {
               amount: tx.amount,
@@ -267,7 +257,7 @@ export const TransactionQueueCard = forwardRef<
 
           <div className={'grow'}>
             <Typography
-              variant={'body1'}
+              variant={'h5'}
               fw={'bold'}
               className={' text-mono-180 dark:text-mono'}
             >
@@ -279,7 +269,7 @@ export const TransactionQueueCard = forwardRef<
                   : 'Transaction Processing')}
             </Typography>
             <Typography
-              variant={'body2'}
+              variant={'body1'}
               className={'text-mono-120 dark:text-mono-80 pr-1'}
             >
               {transactionSummeryText}


### PR DESCRIPTION
## Summary of changes
- All failed transaction footer message nows shows `Transaction failed`.
- `Transaction failed` is now an external link to the explorer page.
- Updates transaction progress card text font sizes to match with the design.

### Transaction failed link video

https://user-images.githubusercontent.com/53374218/215603808-2b75b15f-3944-4704-950b-fc25fbdb6a36.mov

### Update font size
<img width="326" alt="Screenshot 2023-01-30 at 1 43 56 PM" src="https://user-images.githubusercontent.com/53374218/215604079-5e8ab3b6-f699-4069-bc6d-fee81d41c3da.png">
<img width="316" alt="Screenshot 2023-01-30 at 1 55 21 PM" src="https://user-images.githubusercontent.com/53374218/215604128-302619b8-85db-4ecf-bb81-e7415ac89e48.png">



### Reference issue to close (if applicable)
- Closes #932 
