### PR TITLE
Replaces action dropdown and removes deposit button in table

### DIFF
--- a/apps/bridge-dapp/src/containers/ShieldedAssetsTableContainer/ShieldedAssetsTableContainer.tsx
+++ b/apps/bridge-dapp/src/containers/ShieldedAssetsTableContainer/ShieldedAssetsTableContainer.tsx
@@ -155,25 +155,6 @@ export const ShieldedAssetsTableContainer: FC<
     ]
   );
 
-  const onDeposit = useCallback(
-    (shieldedAsset: ShieldedAssetDataType) => {
-      onActiveTabChange?.('Deposit');
-
-      const { rawChain, rawFungibleCurrency } = shieldedAsset;
-
-      onDefaultDestinationChainChange?.(rawChain);
-
-      if (rawFungibleCurrency) {
-        ondefaultFungibleCurrencyChange?.(rawFungibleCurrency);
-      }
-    },
-    [
-      onActiveTabChange,
-      onDefaultDestinationChainChange,
-      ondefaultFungibleCurrencyChange,
-    ]
-  );
-
   const onWithdraw = useCallback(
     (shieldedAsset: ShieldedAssetDataType) => {
       onActiveTabChange?.('Withdraw');
@@ -204,17 +185,6 @@ export const ShieldedAssetsTableContainer: FC<
 
           return (
             <div className="flex items-center space-x-1">
-              <ActionWithTooltip content="Deposit">
-                <Button
-                  variant="utility"
-                  size="sm"
-                  className="p-2"
-                  onClick={() => onDeposit(shieldedAsset)}
-                >
-                  <AddBoxLineIcon className="!fill-current" />
-                </Button>
-              </ActionWithTooltip>
-
               <ActionWithTooltip content="Transfer">
                 <Button
                   variant="utility"
@@ -241,7 +211,7 @@ export const ShieldedAssetsTableContainer: FC<
         },
       }),
     ],
-    [onDeposit, onTransfer, onWithdraw]
+    [onTransfer, onWithdraw]
   );
 
   const table = useReactTable({

--- a/apps/bridge-dapp/src/containers/SpendNotesTableContainer/SpendNotesTableContainer.tsx
+++ b/apps/bridge-dapp/src/containers/SpendNotesTableContainer/SpendNotesTableContainer.tsx
@@ -9,24 +9,25 @@ import {
   ChainIcon,
   ChevronDown,
   ExternalLinkLine,
+  SendPlanLineIcon,
+  WalletLineIcon,
   TokenIcon,
 } from '@webb-tools/icons';
 import { useNoteAccount } from '@webb-tools/react-hooks';
 import {
   Button,
-  Dropdown,
-  DropdownBasicButton,
-  DropdownBody,
   fuzzyFilter,
   IconWithTooltip,
   KeyValueWithButton,
-  MenuItem,
   shortenString,
   Table,
   TokenPairIcons,
   Typography,
+  Tooltip,
+  TooltipBody,
+  TooltipTrigger,
 } from '@webb-tools/webb-ui-components';
-import { FC, useCallback, useMemo } from 'react';
+import { FC, PropsWithChildren, useCallback, useMemo } from 'react';
 import { EmptyTable, LoadingTable } from '../../components/tables';
 import { SpendNoteDataType, SpendNotesTableContainerProps } from './types';
 
@@ -249,17 +250,46 @@ const ActionDropdownButton: FC<
   ]);
 
   return (
-    <Dropdown>
-      <DropdownBasicButton>
-        <Button as="span" variant="utility" size="sm" className="p-2">
-          <ChevronDown className="!fill-current" />
+    <div className="flex items-center space-x-1">
+      <ActionWithTooltip content="Transfer">
+        <Button
+          variant="utility"
+          size="sm"
+          className="p-2"
+          onClick={onQuickTransfer}
+        >
+          <SendPlanLineIcon className="!fill-current" />
         </Button>
-      </DropdownBasicButton>
+      </ActionWithTooltip>
 
-      <DropdownBody className="min-w-[200px]" size="sm">
-        <MenuItem onClick={onQuickTransfer}>Quick Transfer</MenuItem>
-        <MenuItem onClick={onQuickWithdraw}>Quick Withdraw</MenuItem>
-      </DropdownBody>
-    </Dropdown>
+      <ActionWithTooltip content="Withdraw">
+        <Button
+          variant="utility"
+          size="sm"
+          className="p-2"
+          onClick={onQuickWithdraw}
+        >
+          <WalletLineIcon className="!fill-current" />
+        </Button>
+      </ActionWithTooltip>
+    </div>
+  );
+};
+
+/***********************
+ * Internal components *
+ ***********************/
+
+const ActionWithTooltip: FC<PropsWithChildren<{ content: string }>> = ({
+  content,
+  children,
+}) => {
+  return (
+    <Tooltip delayDuration={200}>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipBody>
+        <Typography variant="body3">{content}</Typography>
+      </TooltipBody>
+    </Tooltip>
   );
 };


### PR DESCRIPTION
## Summary of changes

- Replaces action dropdown in available spend notes table with transfer button and withdraw button.
- Removes deposit button in shielded assets table.

### Proposed area of change

- [x] `apps/bridge-dapp`
- [ ] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

- Closes #946 
- Closes #950 

### Screen Recording


https://user-images.githubusercontent.com/53374218/215881729-f8c894c0-00c7-42ec-ba02-f5026fe40c57.mov

-----
### Code Checklist 
_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
