### PR TITLE
Updates spend notes table column header

### DIFF
--- a/apps/bridge-dapp/src/containers/SpendNotesTableContainer/SpendNotesTableContainer.tsx
+++ b/apps/bridge-dapp/src/containers/SpendNotesTableContainer/SpendNotesTableContainer.tsx
@@ -26,6 +26,7 @@ import {
   Tooltip,
   TooltipBody,
   TooltipTrigger,
+  TitleWithInfo,
 } from '@webb-tools/webb-ui-components';
 import { FC, PropsWithChildren, useCallback, useMemo } from 'react';
 import { EmptyTable, LoadingTable } from '../../components/tables';
@@ -120,7 +121,9 @@ const staticColumns: ColumnDef<SpendNoteDataType, any>[] = [
   }),
 
   columnHelper.accessor('note', {
-    header: 'Note',
+    header: () => (
+      <TitleWithInfo title="Spend Note" info="Spend note" variant="body1" className='justify-center' />
+    ),
     cell: (props) => (
       <div className="flex items-center justify-center">
         <KeyValueWithButton

--- a/apps/bridge-dapp/src/containers/SpendNotesTableContainer/SpendNotesTableContainer.tsx
+++ b/apps/bridge-dapp/src/containers/SpendNotesTableContainer/SpendNotesTableContainer.tsx
@@ -122,7 +122,12 @@ const staticColumns: ColumnDef<SpendNoteDataType, any>[] = [
 
   columnHelper.accessor('note', {
     header: () => (
-      <TitleWithInfo title="Spend Note" info="Spend note" variant="body1" className='justify-center' />
+      <TitleWithInfo
+        title="Spend Note"
+        info="Spend note"
+        variant="body1"
+        className="justify-center"
+      />
     ),
     cell: (props) => (
       <div className="flex items-center justify-center">


### PR DESCRIPTION
## Summary of changes

- Updates `Note` to `Spend Note` with a title info in the spend available note table.

### Proposed area of change

- [x] `apps/bridge-dapp`
- [ ] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

- Closes #944 (Only the last UI discrepancy is addressed in this PR, rest of them are addressed here: PR #963 )

### Screen Recording
<img width="249" alt="Screenshot 2023-02-01 at 12 09 38 PM" src="https://user-images.githubusercontent.com/53374218/216152254-1d211de6-e3f0-40e4-bcce-dd87e58e560a.png">



-----
### Code Checklist 
_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
