### PR TITLE
32-bytes Fixing for Leaves and Roots

### DIFF
--- a/apps/bridge-dapp/src/containers/TransferContainer/TransferConfirmContainer.tsx
+++ b/apps/bridge-dapp/src/containers/TransferContainer/TransferConfirmContainer.tsx
@@ -25,20 +25,23 @@ export const TransferConfirmContainer = forwardRef<
   HTMLDivElement,
   TransferConfirmContainerProps
 >(
-  ({
-    amount,
-    changeAmount,
-    currency,
-    destChain,
-    recipient,
-    relayer,
-    note: changeNote,
-    changeUtxo,
-    transferUtxo,
-    inputNotes,
-    onResetState,
-    ...props
-  }) => {
+  (
+    {
+      amount,
+      changeAmount,
+      currency,
+      destChain,
+      recipient,
+      relayer,
+      note: changeNote,
+      changeUtxo,
+      transferUtxo,
+      inputNotes,
+      onResetState,
+      ...props
+    },
+    ref
+  ) => {
     // State for tracking the status of the change note checkbox
     const [isChecked, setIsChecked] = useState(false);
 
@@ -210,6 +213,7 @@ export const TransferConfirmContainer = forwardRef<
     return (
       <TransferConfirm
         {...props}
+        ref={ref}
         title={isTransfering ? 'Transfer in Progress' : undefined}
         activeChains={activeChains}
         amount={amount}

--- a/libs/web3-api-provider/src/webb-provider.ts
+++ b/libs/web3-api-provider/src/webb-provider.ts
@@ -170,10 +170,11 @@ export class WebbWeb3Provider
       return null;
     }
 
-    const typedChainId = calculateTypedChainId(ChainType.EVM, this.chainId);
+    const chainId = await this.getChainId();
+    const typedChainId = calculateTypedChainId(ChainType.EVM, chainId);
     const address = vanchors[0].neighbours[typedChainId];
 
-    return new ResourceId(address.toString(), ChainType.EVM, this.chainId);
+    return new ResourceId(address.toString(), ChainType.EVM, chainId);
   }
 
   getProvider(): Web3Provider {
@@ -323,6 +324,9 @@ export class WebbWeb3Provider
       console.log('Leaves from chain: ', leavesFromChain);
 
       leaves = [...storedContractInfo.leaves, ...leavesFromChain.newLeaves];
+
+      // Fixed all the leaves to be 32 bytes
+      leaves = leaves.map((leaf) => toFixedHex(leaf));
 
       // Cached the new leaves
       await storage.set('lastQueriedBlock', leavesFromChain.lastQueriedBlock);

--- a/libs/web3-api-provider/src/webb-provider/relayer-manager.ts
+++ b/libs/web3-api-provider/src/webb-provider/relayer-manager.ts
@@ -18,6 +18,7 @@ import {
   MerkleTree,
   Note,
   parseTypedChainId,
+  toFixedHex,
 } from '@webb-tools/sdk-core';
 import { ethers } from 'ethers';
 import { VAnchor } from '@webb-tools/anchors';
@@ -201,10 +202,14 @@ export class Web3RelayerManager extends WebbRelayerManager {
       if (validLatestLeaf) {
         // Assume the destination anchor has the same levels as source anchor
         const levels = await vanchor.contract.getLevels();
+        const lastRootBigNumber = await vanchor.contract.getLastRoot();
+
+        // Fixed the last root to be 32 bytes
+        const lastRoot = toFixedHex(lastRootBigNumber.toHexString());
         const tree = MerkleTree.createTreeWithRoot(
           levels,
           relayerLeaves.leaves,
-          (await vanchor.contract.getLastRoot()).toHexString()
+          lastRoot
         );
 
         // If we were able to build the tree, set local storage and break out of the loop

--- a/libs/web3-api-provider/src/webb-provider/vanchor-actions.ts
+++ b/libs/web3-api-provider/src/webb-provider/vanchor-actions.ts
@@ -28,6 +28,7 @@ import {
   Note,
   ResourceId,
   Utxo,
+  toFixedHex,
 } from '@webb-tools/sdk-core';
 import { FungibleTokenWrapper } from '@webb-tools/tokens';
 import { ZERO_ADDRESS, hexToU8a, u8aToHex } from '@webb-tools/utils';
@@ -573,6 +574,9 @@ export class Web3VAnchorActions extends VAnchorActions<WebbWeb3Provider> {
       const edge = await destVAnchor.contract.edgeList(edgeIndex);
       destHistorySourceRoot = edge[1].toHexString();
     }
+
+    // Fixed the root to be 32 bytes
+    destHistorySourceRoot = toFixedHex(destHistorySourceRoot);
 
     // Remove leaves from the leaves map which have not yet been relayed
     const provingTree = MerkleTree.createTreeWithRoot(


### PR DESCRIPTION
## Summary of changes
_Provide a detailed description of proposed changes._
- Fixed the 32-byte consistent issues on the leaves and the roots return on-chain and returns from the relayer
- Passed missing React ref for removing error in the browser console
- Fixed resource Id not updating when switching to another chain because previously we got the `chainId` from object property instead of the provider so that the `chainId` won't update when we switch to another chain.

### Proposed area of change
_Put an `x` in the boxes that apply._

- [x] `apps/bridge-dapp`
- [ ] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)
_Specify any issues that can be closed from these changes (e.g. Closes #233)._
- Closes `NaN`

### Screen Recording
_If possible provide a screen recording of proposed change._


https://user-images.githubusercontent.com/60747384/222206592-ca6e61d3-fb6a-4d0c-a803-e0d31b910e9a.mp4

