### PR TITLE
Adds Terser Webpack plugin to drop console in production

### DIFF
--- a/apps/bridge-dapp/project.json
+++ b/apps/bridge-dapp/project.json
@@ -56,7 +56,8 @@
       },
       "configurations": {
         "production": {
-          "buildTarget": "bridge-dapp:build:production"
+          "buildTarget": "bridge-dapp:build:production",
+          "webpackConfig": "apps/bridge-dapp/webpack.prod.js"
         }
       }
     },

--- a/apps/bridge-dapp/webpack.base.js
+++ b/apps/bridge-dapp/webpack.base.js
@@ -10,6 +10,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const webpack = require('webpack');
 const polkadotBabelWebpackConfig = require('@polkadot/dev/config/babel-config-webpack.cjs');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const findPackages = require('../../tools/scripts/findPackages');
 
@@ -204,6 +205,15 @@ function createWebpack(env, mode = 'production') {
     },
     optimization: {
       minimize: mode === 'production',
+      minimizer: [
+        new TerserPlugin({
+          terserOptions: {
+            compress: {
+              drop_console: true,
+            },
+          },
+        }),
+      ],
       splitChunks: {
         cacheGroups: {
           ...mapChunks('robohash', [

--- a/apps/bridge-dapp/webpack.prod.js
+++ b/apps/bridge-dapp/webpack.prod.js
@@ -11,6 +11,15 @@ module.exports = (env) => {
 
   return merge(baseConfig(env), {
     devtool: process.env.BUILD_ANALYZE ? 'source-map' : false,
+    devServer: {
+      client: {
+        logging: 'error',
+        overlay: {
+          errors: true,
+          warnings: false, // Hide overlay warnings as they present on the terminal
+        },
+      },
+    },
     plugins: [
       new HtmlWebpackPlugin({
         filename: './index.html',

--- a/apps/stats-dapp/project.json
+++ b/apps/stats-dapp/project.json
@@ -59,7 +59,8 @@
       },
       "configurations": {
         "production": {
-          "buildTarget": "stats-dapp:build:production"
+          "buildTarget": "stats-dapp:build:production",
+          "webpackConfig": "apps/stats-dapp/webpack.config.js"
         }
       }
     },

--- a/apps/stats-dapp/webpack.config.js
+++ b/apps/stats-dapp/webpack.config.js
@@ -316,6 +316,7 @@ function createWebpackBase() {
             compress: {
               ecma: 5,
               inline: 2,
+              drop_console: true,
             },
             mangle: {
               // Find work around for Safari 10+


### PR DESCRIPTION
## Summary of changes

- Removes console logs from `bridge` and `stats` dApp using `Terser` webpack plugin.

### Proposed area of change

- [x] `apps/bridge-dapp`
- [x] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

- Closes #797 

### Screen Recording

https://user-images.githubusercontent.com/53374218/223024505-482fd57f-ce0d-4d59-ba0f-3e9606e77ef0.mp4

-----
### Code Checklist 
_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
