### PR TITLE
Filter Relayers by the Environment

### DIFF
--- a/libs/dapp-config/src/relayer-config.ts
+++ b/libs/dapp-config/src/relayer-config.ts
@@ -30,12 +30,6 @@ export const relayerConfig: RelayerConfig[] = [
   {
     endpoint: 'https://relayer3.webb.tools',
   },
-  {
-    endpoint: 'https://relayer4.webb.tools',
-  },
-  {
-    endpoint: 'https://relayer5.webb.tools',
-  },
 ];
 
 export function relayerSubstrateNameToTypedChainId(

--- a/libs/dapp-config/src/relayer-config.ts
+++ b/libs/dapp-config/src/relayer-config.ts
@@ -5,9 +5,11 @@ import { calculateTypedChainId, ChainType } from '@webb-tools/sdk-core';
  * Relayer configuration
  * it's now the endpoint and info/metada ..etc is fetched via http
  * @param endpoint - relayer http endpoint
+ * @param isProduction - is this a production relayer
  **/
 export type RelayerConfig = {
   endpoint: string;
+  isProduction?: boolean;
 };
 
 /**
@@ -23,12 +25,21 @@ export const relayerConfig: RelayerConfig[] = [
   },
   {
     endpoint: 'https://relayer1.webb.tools',
+    isProduction: true,
   },
   {
     endpoint: 'https://relayer2.webb.tools',
+    isProduction: true,
   },
   {
     endpoint: 'https://relayer3.webb.tools',
+    isProduction: true,
+  },
+  {
+    endpoint: 'https://relayer4.webb.tools',
+  },
+  {
+    endpoint: 'https://relayer5.webb.tools',
   },
 ];
 

--- a/libs/relayer-manager-factory/src/relayer-manager-factory.ts
+++ b/libs/relayer-manager-factory/src/relayer-manager-factory.ts
@@ -21,12 +21,20 @@ import { Web3RelayerManager } from '@webb-tools/web3-api-provider';
 let relayerManagerFactory: WebbRelayerManagerFactory | null = null;
 
 export async function getRelayerManagerFactory() {
+  const env = process.env.NODE_ENV ?? 'development';
+
+  // Filter out the relayers which are not enabled for the current environment
+  const filteredRelayerConfigs = relayerConfig.filter(
+    (relayer) => Boolean(relayer.isProduction) === (env === 'production')
+  );
+
   if (!relayerManagerFactory) {
     relayerManagerFactory = await WebbRelayerManagerFactory.init(
-      relayerConfig,
+      filteredRelayerConfigs,
       chainNameAdapter
     );
   }
+
   return relayerManagerFactory;
 }
 


### PR DESCRIPTION
## Summary of changes

This PR removes relayers 4 and 5. The removed relayers will be used solely for development testing of changes and features (e.g. #1049 and / or #1048) whereas, relayers 1 - 3 will be used in production and will not be disrupted until changes land on `prod` environment. This based on the discussion between the dapp team and relayer team @shekohex @salman01zp @devpavan04  @AtelyPham. More details can be read [here](https://www.notion.so/hicommonwealth/Relayer-dApp-Support-ae4f0cd5f43d48579d95dd6f74c4a225).

### Proposed area of change
_Put an `x` in the boxes that apply._

- [x] `apps/bridge-dapp`
- [ ] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)
_Specify any issues that can be closed from these changes (e.g. Closes #233)._
- Closes 

### Screen Recording
_If possible provide a screen recording of proposed change._


-----
### Code Checklist 
_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
