### PR TITLE
Fixes current key progress bar in authorities page

### DIFF
--- a/apps/stats-dapp/src/pages/Authorities.tsx
+++ b/apps/stats-dapp/src/pages/Authorities.tsx
@@ -30,7 +30,9 @@ import { Outlet } from 'react-router-dom';
 import { AuthoritiesTable } from '../containers';
 import {
   DiscreteList,
+  PublicKey,
   UpcomingThreshold,
+  useActiveKeys,
   useThresholds,
 } from '../provider/hooks';
 import { getChipColorByKeyType } from '../utils';
@@ -95,6 +97,23 @@ const columns: ColumnDef<UpcomingThreshold, any>[] = [
 const Authorities = () => {
   const thresholds = useThresholds();
 
+  const {
+    error,
+    isFailed,
+    isLoading: activeKeyDataIsLoading,
+    val: activeKeyData,
+  } = useActiveKeys();
+
+  const { currentKey } = useMemo<{
+    currentKey: PublicKey | null | undefined;
+  }>(() => {
+    return {
+      currentKey: activeKeyData ? activeKeyData[0] : null,
+    };
+  }, [activeKeyData]);
+
+  const { time } = useStatsContext();
+
   const [threshold, upComingThresholds] = useMemo(() => {
     if (thresholds.val) {
       return thresholds.val;
@@ -142,7 +161,6 @@ const Authorities = () => {
     keyGen === undefined ||
     signature === undefined ||
     publicKey === undefined;
-  const { time } = useStatsContext();
 
   return (
     <div className="flex flex-col space-y-4">
@@ -162,8 +180,8 @@ const Authorities = () => {
             <Stats items={statsItems} className="pb-0" />
 
             <TimeProgress
-              startTime={publicKey.start ?? null}
-              endTime={publicKey.end ?? null}
+              startTime={currentKey?.start ?? null}
+              endTime={currentKey?.end ?? null}
               now={time}
             />
 


### PR DESCRIPTION
## Summary of changes
Updates `Authorities` page network threshold component to show `current` key details.

### Proposed area of change
_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [x] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Screenshots

`Keys Overview`
<img width="920" alt="Screenshot 2023-03-30 at 7 32 13 PM" src="https://user-images.githubusercontent.com/53374218/229008351-239f91d9-1f43-4883-9e56-e3f4a6c02dd0.png">

`Authorities Overview`
<img width="924" alt="Screenshot 2023-03-30 at 7 32 28 PM" src="https://user-images.githubusercontent.com/53374218/229008399-6c09b035-c6c6-489b-a723-929cbed6883f.png">


-----
### Code Checklist 
_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
