### PR TITLE
[RELEASE]: Fixes authorities table in authorities page

### DIFF
--- a/apps/stats-dapp/CHANGELOG.md
+++ b/apps/stats-dapp/CHANGELOG.md
@@ -39,3 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/webb-tools/webb-dapp/compare/v0.0.1...HEAD
 [0.0.2]: https://github.com/webb-tools/webb-dapp/releases/tag/v0.0.2
+
+## [0.0.3] - 2023-04-21
+
+### Fixed
+- Bug fix for authorities table in authorities page: https://github.com/webb-tools/webb-dapp/pull/1125

--- a/apps/stats-dapp/package.json
+++ b/apps/stats-dapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webb-tools/stats-dapp",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "./src/index.js",
   "dependencies": {
     "@ngneat/falso": "^5.7.0",

--- a/apps/stats-dapp/src/provider/hooks/useAuthorities.ts
+++ b/apps/stats-dapp/src/provider/hooks/useAuthorities.ts
@@ -300,7 +300,7 @@ export function useAuthorities(
         variables: {
           offset: reqQuery.offset,
           perPage: reqQuery.perPage,
-          sessionId: String(Number(metaData.val.activeSession) - 1),
+          sessionId: metaData.val.activeSession,
           reputationFilter: reputation ?? undefined,
           uptimeFilter: uptime ?? undefined,
           validatorId: filter.search


### PR DESCRIPTION
## Summary of changes

- Fixes authorities table in authorities page. Authorities table now displays authority set of session zero.

### Proposed area of change

- [ ] `apps/bridge-dapp`
- [x] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

- Closes #1122 