### PR TITLE
Unifying `dist` Dirs for all Apps

### DIFF
--- a/.github/workflows/deploy-bridge-dapp-dev.yml
+++ b/.github/workflows/deploy-bridge-dapp-dev.yml
@@ -48,7 +48,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_BRIDGE_SITE_ID }}
         with:
-          args: deploy context=deploy-preview site=$NETLIFY_BRIDGE_SITE_ID --dir=./apps/bridge-dapp/build/
+          args: deploy context=deploy-preview site=$NETLIFY_BRIDGE_SITE_ID --dir=./dist/apps/bridge-dapp/
 
       - name: Netlify Preview URL
         uses: unsplash/comment-on-pr@v1.3.0

--- a/.github/workflows/deploy-stats-dapp-dev.yml
+++ b/.github/workflows/deploy-stats-dapp-dev.yml
@@ -43,7 +43,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         with:
-          args: deploy context=deploy-preview site=$NETLIFY_SITE_ID --dir=./apps/stats-dapp/build/
+          args: deploy context=deploy-preview site=$NETLIFY_SITE_ID --dir=./dist/apps/stats-dapp/
 
       - name: Netlify Preview URL
         uses: unsplash/comment-on-pr@v1.3.0

--- a/apps/bridge-dapp/project.json
+++ b/apps/bridge-dapp/project.json
@@ -9,11 +9,11 @@
       "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "development",
       "options": {
-        "outputPath": "apps/bridge-dapp/build",
+        "outputPath": "dist/apps/bridge-dapp",
         "compiler": "babel",
         "index": "apps/bridge-dapp/src/public/index.html",
         "baseHref": "/",
-        "main": "apps/bridge-dapp/src/main.tsx",
+        "main": "apps/bridge-dapp/src/index.tsx",
         "tsConfig": "apps/bridge-dapp/tsconfig.app.json",
         "assets": [
           "apps/bridge-dapp/src/public/favicon.png",
@@ -21,7 +21,7 @@
         ],
         "generateIndexHtml": false,
         "scripts": [],
-        "postcssConfig": "./postcss.config.js",
+        "postcssConfig": "apps/bridge-dapp/postcss.config.js",
         "webpackConfig": "apps/bridge-dapp/webpack.dev.js"
       },
       "configurations": {

--- a/apps/bridge-dapp/webpack.base.js
+++ b/apps/bridge-dapp/webpack.base.js
@@ -235,7 +235,7 @@ function createWebpack(env, mode = 'production') {
       filename: '[name].[contenthash:8].js',
       globalObject: "(typeof self !== 'undefined' ? self : this)",
       hashFunction: 'xxhash64',
-      path: path.join(env.context, 'build'),
+      path: path.join(env.context, '../../dist/apps/bridge-dapp'),
       publicPath: '',
     },
     performance: {

--- a/apps/stats-dapp/webpack.config.js
+++ b/apps/stats-dapp/webpack.config.js
@@ -68,7 +68,7 @@ function createWebpackBase() {
       filename: '[name].[contenthash:8].js',
       globalObject: "(typeof self !== 'undefined' ? self : this)",
       hashFunction: 'xxhash64',
-      path: path.join(__dirname, 'build'),
+      path: path.join(__dirname, '../../dist/apps/stats-dapp'),
       publicPath: '',
     },
 

--- a/nx.json
+++ b/nx.json
@@ -19,7 +19,11 @@
   "targetDefaults": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["production", "^production"]
+      "inputs": ["production", "^production"],
+      "outputs": [
+        "{workspaceRoot}/dist/apps/bridge-dapp",
+        "{workspaceRoot}/dist/apps/stats-dapp"
+      ]
     },
     "lint": {
       "inputs": ["default", "{workspaceRoot}/.eslintrc.json"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -10403,9 +10403,9 @@ binjumper@^0.1.4:
   resolved "https://registry.yarnpkg.com/binjumper/-/binjumper-0.1.4.tgz#4acc0566832714bd6508af6d666bd9e5e21fc7f8"
   integrity sha512-Gdxhj+U295tIM6cO4bJO1jsvSjBVHNpj2o/OwW7pqDEtaqF6KdOxjtbo93jMMKAkP7+u09+bV8DhSqjIv4qR3w==
 
-"bip32-ed25519@git+https://github.com/Zondax/bip32-ed25519.git":
+"bip32-ed25519@https://github.com/Zondax/bip32-ed25519":
   version "0.0.4"
-  resolved "git+https://github.com/Zondax/bip32-ed25519.git#0949df01b5c93885339bc28116690292088f6134"
+  resolved "https://github.com/Zondax/bip32-ed25519#0949df01b5c93885339bc28116690292088f6134"
   dependencies:
     bn.js "^5.1.1"
     elliptic "^6.4.1"


### PR DESCRIPTION
## Summary of changes
- This PR is unifying the build directories to root `dist` for all apps.
- We need to update the CI of the `bridge-dapp` and `stats-dapp` points to `dist/apps/bridge-dapp` and  `dist/apps/bridge-dapp` for app build directories.

### Proposed area of change
_Put an `x` in the boxes that apply._

- [x] `apps/bridge-dapp`
- [x] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`