### PR TITLE
Adds a check for proposal data on proposal detail page to prevent from crashing

### DIFF
--- a/apps/stats-dapp/src/containers/ProposalDetail/ProposalDetail.tsx
+++ b/apps/stats-dapp/src/containers/ProposalDetail/ProposalDetail.tsx
@@ -235,7 +235,11 @@ export const ProposalDetail = () => {
             <br />
             <Typography variant="mono1" component="p">
               <ProposalData
-                data={getProposalsData(proposalData.type, proposalData.data)}
+                data={
+                  proposalData.data != '0x00'
+                    ? getProposalsData(proposalData.type, proposalData.data)
+                    : { data: { expired: true } }
+                }
               />
             </Typography>
           </div>

--- a/apps/stats-dapp/src/utils/getProposalsData.ts
+++ b/apps/stats-dapp/src/utils/getProposalsData.ts
@@ -22,6 +22,8 @@ export function getProposalsData(
   propType: ProposalType,
   data: string
 ): Record<string, string | Record<string, any>> {
+  if (!data) return { data: '' };
+
   const bytes = hexToU8a(data);
   switch (propType) {
     case ProposalType.AnchorCreateProposal: {


### PR DESCRIPTION
## Summary of changes

- Adds a check for proposal data on proposal detail page to prevent from crashing. This crash is caused as a result of indexing of unknown proposals fix in this [PR](https://github.com/webb-tools/webb-graphql/pull/85) on webb-graphql.
- Currently, when a proposal is added (created later, meaning, created not as a result of `DKGProposalHandlerSection.ProposalAdded` event but created when proposal gets removed i.e as a result of `DKGProposalHandlerSection.ProposalRemoved` event), the event data is missing which causes the crash on stats dapp.
- To prevent this, stats dapp now displays `{expired: true}` in proposal details page when the data is not present and was removed, just like in the tangle event logs shown below.

NOTE: We should further investigate and add a fix to display the missing data. Link to the issue will be added below once created.

Link to issue on `webb-graphql`: https://github.com/webb-tools/webb-graphql/issues/86

### Proposed area of change

- [ ] `apps/bridge-dapp`
- [x] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

Tangle event logs:

![CleanShot 2023-05-30 at 18 04 00](https://github.com/webb-tools/webb-dapp/assets/53374218/dbd0b59d-e405-4e99-9e46-6d15a16727f1)

Stats dapp proposal detail:

![CleanShot 2023-05-30 at 17 51 35](https://github.com/webb-tools/webb-dapp/assets/53374218/28aa4203-3cb4-4369-b78a-82ec5443a926)
