### PR TITLE
Updates proposals query's fetch policy to always fetch latest data

### DIFF
--- a/apps/stats-dapp/src/provider/hooks/useProposals.ts
+++ b/apps/stats-dapp/src/provider/hooks/useProposals.ts
@@ -301,6 +301,8 @@ export function useProposals(reqQuery: ProposalsQuery): ProposalsPage {
               }
             : undefined,
       },
+      pollInterval: 10000,
+      fetchPolicy: 'network-only',
     }).catch((e) => {
       setProposalsPage({
         isLoading: false,
@@ -444,6 +446,8 @@ export function useProposal(
         id: proposalId,
         targetSessionId,
       },
+      pollInterval: 10000,
+      fetchPolicy: 'network-only',
     }).catch((e) => {
       setProposalDetails({
         isLoading: false,


### PR DESCRIPTION
## Summary of changes

- Updates `useProposals` and `useProposal` hooks to make a graphql query with the fetch policy of `network-only` and with a polling interval of ten seconds to make sure we always see the proposal data as they happen in real-time.

### Proposed area of change

- [ ] `apps/bridge-dapp`
- [x] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`