### PR TITLE
Make accordion item in FAQ easier to open and collapsible

### DIFF
--- a/apps/tangle-website/src/components/sections/FAQSection.tsx
+++ b/apps/tangle-website/src/components/sections/FAQSection.tsx
@@ -61,18 +61,14 @@ export const FAQSection = () => {
             with others in our community channels to learn more!
           </Typography>
         </div>
-        <Accordion
-          defaultValue={faqItems[0].question}
-          type="single"
-          className="lg:mx-auto"
-        >
+        <Accordion type="single" collapsible className="lg:mx-auto">
           {faqItems.map((item, index) => (
             <AccordionItem
               key={index}
               value={item.question}
-              className="px-0 border-b border-mono-40"
+              className="p-0 border-b border-mono-40"
             >
-              <AccordionButton className="items-start gap-8 px-0">
+              <AccordionButton className="items-start gap-8 px-0 py-6">
                 <Typography
                   variant="mkt-body1"
                   className="font-black text-mono-200"


### PR DESCRIPTION
## Summary of changes

- Make Accordion Item in FAQ Section collapsible
- Make it easier for users to open an item by making adjusting the padding of AccordionButton
- Remove the default open item to make the UI more clear for the users

### Proposed area of change
_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [X] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

- Closes #1305 

### Screen Recording

https://github.com/webb-tools/webb-dapp/assets/69841784/6fa622ae-02d3-4a16-83a9-0a9bb4d49072




-----
### Code Checklist 
_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
