### PR TITLE
UI updates for improved transaction flow on bridge

### DIFF
--- a/libs/webb-ui-components/src/components/ListCard/TokenListCard.tsx
+++ b/libs/webb-ui-components/src/components/ListCard/TokenListCard.tsx
@@ -123,21 +123,6 @@ export const TokenListCard = forwardRef<HTMLDivElement, TokenListCardProps>(
                   onClick={() => onItemChange(current)}
                 />
               ))}
-              <Typography
-                variant="body4"
-                fw="bold"
-                className="uppercase text-mono-100 dark:text-mono-80 my-2"
-              >
-                Unavailable
-              </Typography>
-              {filteredUnavailable.map((current, idx) => (
-                <AssetListItem
-                  key={`${current.name}-${idx}`}
-                  {...current}
-                  isDisabled
-                  onClick={() => onItemChange(current)}
-                />
-              ))}
             </ul>
           </ScrollArea>
         </div>

--- a/libs/webb-ui-components/src/components/ListCard/TokenListCard.tsx
+++ b/libs/webb-ui-components/src/components/ListCard/TokenListCard.tsx
@@ -127,28 +127,7 @@ export const TokenListCard = forwardRef<HTMLDivElement, TokenListCardProps>(
           </ScrollArea>
         </div>
 
-        <div
-          className={cx(
-            'flex flex-col items-center justify-center px-2 py-1 mt-9'
-          )}
-        >
-          <Typography
-            variant="utility"
-            className="uppercase text-mono-100 dark:text-mono-80  max-w-[334px]"
-            ta="center"
-          >
-            Don't see your asset?
-          </Typography>
-
-          <Button
-            variant="link"
-            size="sm"
-            className="mt-1 text-center"
-            onClick={onConnect}
-          >
-            Try another account or wallet
-          </Button>
-        </div>
+        {/* Alert Component */}
       </ListCardWrapper>
     );
   }

--- a/libs/webb-ui-components/src/components/ListCard/TokenListCard.tsx
+++ b/libs/webb-ui-components/src/components/ListCard/TokenListCard.tsx
@@ -76,7 +76,7 @@ export const TokenListCard = forwardRef<HTMLDivElement, TokenListCardProps>(
           <Input
             id="token"
             rightIcon={<Search />}
-            placeholder="Search token or enter token address"
+            placeholder="Search pool or enter token address"
             value={searchText}
             onChange={(val) => setSearchText(val.toString())}
           />

--- a/libs/webb-ui-components/src/containers/DepositCard/DepositCard.tsx
+++ b/libs/webb-ui-components/src/containers/DepositCard/DepositCard.tsx
@@ -80,6 +80,7 @@ export const DepositCard = forwardRef<HTMLDivElement, DepositCardProps>(
                 <TokenInput
                   {...bridgingTokenProps}
                   title="Shielded Pool"
+                  info="Shielded pools hold mixed crypotcurrency and are used to maintain privacy of the transaction."
                   className="grow shrink-0 basis-1"
                 />
               )}

--- a/libs/webb-ui-components/src/containers/DepositCard/DepositCard.tsx
+++ b/libs/webb-ui-components/src/containers/DepositCard/DepositCard.tsx
@@ -79,7 +79,7 @@ export const DepositCard = forwardRef<HTMLDivElement, DepositCardProps>(
               {bridgingTokenProps && (
                 <TokenInput
                   {...bridgingTokenProps}
-                  title="Bridging Token"
+                  title="Shielded Pool"
                   className="grow shrink-0 basis-1"
                 />
               )}
@@ -88,7 +88,7 @@ export const DepositCard = forwardRef<HTMLDivElement, DepositCardProps>(
             <div className="flex lg:hidden gap-2">
               <TokenInput title="Deposit" className="grow shrink-0 basis-1" />
               <TokenInput
-                title="Bridging Token"
+                title="Shielded Pool"
                 className="lg:hidden grow shrink-0 basis-1"
               />
             </div>

--- a/libs/webb-ui-components/src/containers/TransferCard/TransferCard.tsx
+++ b/libs/webb-ui-components/src/containers/TransferCard/TransferCard.tsx
@@ -44,8 +44,8 @@ export const TransferCard = forwardRef<HTMLDivElement, TransferCardProps>(
     const bridgeAssetProps = useMemo(
       () => ({
         ...bridgeAssetInputProps,
-        title: bridgeAssetInputProps?.title ?? 'Bridging Token',
-        info: bridgeAssetInputProps?.info ?? 'Bridging Token',
+        title: bridgeAssetInputProps?.title ?? 'Shielded Pool',
+        info: bridgeAssetInputProps?.info ?? 'Shielded Pool',
       }),
       [bridgeAssetInputProps]
     );

--- a/libs/webb-ui-components/src/containers/TransferCard/TransferCard.tsx
+++ b/libs/webb-ui-components/src/containers/TransferCard/TransferCard.tsx
@@ -45,7 +45,9 @@ export const TransferCard = forwardRef<HTMLDivElement, TransferCardProps>(
       () => ({
         ...bridgeAssetInputProps,
         title: bridgeAssetInputProps?.title ?? 'Shielded Pool',
-        info: bridgeAssetInputProps?.info ?? 'Shielded Pool',
+        info:
+          bridgeAssetInputProps?.info ??
+          'Shielded pools hold mixed crypotcurrency and are used to maintain privacy of the transaction.',
       }),
       [bridgeAssetInputProps]
     );

--- a/libs/webb-ui-components/src/containers/WithdrawCard/WithdrawCard.tsx
+++ b/libs/webb-ui-components/src/containers/WithdrawCard/WithdrawCard.tsx
@@ -101,7 +101,7 @@ export const WithdrawCard = forwardRef<HTMLDivElement, WithdrawCardProps>(
               <TokenInput
                 {...tokenInputProps}
                 title="Shielded Pool"
-                info='Shielded pools hold mixed crypotcurrency and are used to maintain privacy of the transaction.'
+                info="Shielded pools hold mixed crypotcurrency and are used to maintain privacy of the transaction."
                 className="grow shrink-0 basis-1"
               />
               <TokenInput

--- a/libs/webb-ui-components/src/containers/WithdrawCard/WithdrawCard.tsx
+++ b/libs/webb-ui-components/src/containers/WithdrawCard/WithdrawCard.tsx
@@ -101,6 +101,7 @@ export const WithdrawCard = forwardRef<HTMLDivElement, WithdrawCardProps>(
               <TokenInput
                 {...tokenInputProps}
                 title="Shielded Pool"
+                info='Shielded pools hold mixed crypotcurrency and are used to maintain privacy of the transaction.'
                 className="grow shrink-0 basis-1"
               />
               <TokenInput

--- a/libs/webb-ui-components/src/containers/WithdrawCard/WithdrawCard.tsx
+++ b/libs/webb-ui-components/src/containers/WithdrawCard/WithdrawCard.tsx
@@ -100,10 +100,12 @@ export const WithdrawCard = forwardRef<HTMLDivElement, WithdrawCardProps>(
             <div className="flex space-x-2">
               <TokenInput
                 {...tokenInputProps}
+                title="Shielded Pool"
                 className="grow shrink-0 basis-1"
               />
               <TokenInput
                 {...unwrappingAssetProps}
+                title="Token"
                 className={cx('grow shrink-0 basis-1', {
                   hidden: !switcherChecked,
                 })}


### PR DESCRIPTION
## Summary of changes

-  Replace the term Bridging Token with Shielded Pool on the bridge card for deposit, transfer, and withdrawal flow to improve the understanding of their shielded assets.
- Adds tooltip for Shielded Pool.
- Update search box copy to 'Search pool or enter contract address'.
- Removes unavailable token display (as shown below: AGOR, WETH etc.) from token list.
- Removes the section on 'Don't see your asset? Try another account or wallet' 

### Proposed area of change

- [x] `apps/bridge-dapp`
- [ ] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Issues to be closed
Closes #1197

### Screenshots

![CleanShot 2023-06-07 at 06 04 22](https://github.com/webb-tools/webb-dapp/assets/53374218/a311af25-d249-4c61-8243-7f6ab3909b45)
![CleanShot 2023-06-07 at 06 04 33](https://github.com/webb-tools/webb-dapp/assets/53374218/71e8236f-a55f-4558-9c8c-a73957d7b42e)

