### PR TITLE
Add breakpoint 480px to show one column layout

### DIFF
--- a/apps/bridge-dapp/src/components/EducationCard/EducationCard.tsx
+++ b/apps/bridge-dapp/src/components/EducationCard/EducationCard.tsx
@@ -109,7 +109,7 @@ export const EducationCard = forwardRef<HTMLDivElement, EducationCardProps>(
     }, [defaultOpen]);
 
     return (
-      <div className="">
+      <div className="hidden mob:!block">
         <div
           {...props}
           className={twMerge(

--- a/apps/bridge-dapp/src/components/Header/Header.tsx
+++ b/apps/bridge-dapp/src/components/Header/Header.tsx
@@ -6,6 +6,7 @@ import {
   NavigationMenuContent,
   NavigationMenuTrigger,
 } from '@webb-tools/webb-ui-components';
+import { useCheckMobile } from '@webb-tools/webb-ui-components/hooks';
 import { WEBB_MKT_URL } from '@webb-tools/webb-ui-components/constants';
 import { FC, useCallback, useMemo } from 'react';
 import { NavLink } from 'react-router-dom';
@@ -20,6 +21,7 @@ import { HeaderProps } from './types';
  */
 export const Header: FC<HeaderProps> = () => {
   const { activeAccount, activeWallet, activeChain, loading } = useWebContext();
+  const { isMobile } = useCheckMobile();
 
   const { toggleModal } = useConnectWallet();
 
@@ -42,24 +44,27 @@ export const Header: FC<HeaderProps> = () => {
         </NavLink>
 
         <div className="flex items-center space-x-2">
-          {/** Wallet is actived */}
-          {isDisplayNetworkSwitcherAndWalletButton &&
-          activeAccount &&
-          activeWallet ? (
-            <div className="hidden lg:!flex items-center space-x-2">
-              <ChainSwitcherButton />
-              <WalletButton account={activeAccount} wallet={activeWallet} />
-            </div>
-          ) : (
-            <Button
-              isLoading={loading}
-              loadingText="Connecting..."
-              onClick={handleConnectWalletClick}
-              className="hidden lg:!block"
-            >
-              Connect wallet
-            </Button>
-          )}
+          {!isMobile &&
+            {
+              /** Wallet is actived */
+            }(
+              isDisplayNetworkSwitcherAndWalletButton &&
+                activeAccount &&
+                activeWallet ? (
+                <div className="items-center space-x-2">
+                  <ChainSwitcherButton />
+                  <WalletButton account={activeAccount} wallet={activeWallet} />
+                </div>
+              ) : (
+                <Button
+                  isLoading={loading}
+                  loadingText="Connecting..."
+                  onClick={handleConnectWalletClick}
+                >
+                  Connect wallet
+                </Button>
+              )
+            )}
 
           <NavigationMenu>
             <NavigationMenuTrigger />

--- a/apps/bridge-dapp/src/components/Header/Header.tsx
+++ b/apps/bridge-dapp/src/components/Header/Header.tsx
@@ -44,27 +44,24 @@ export const Header: FC<HeaderProps> = () => {
         </NavLink>
 
         <div className="flex items-center space-x-2">
+          {/** Wallet is actived */}
           {!isMobile &&
-            {
-              /** Wallet is actived */
-            }(
-              isDisplayNetworkSwitcherAndWalletButton &&
-                activeAccount &&
-                activeWallet ? (
-                <div className="items-center space-x-2">
-                  <ChainSwitcherButton />
-                  <WalletButton account={activeAccount} wallet={activeWallet} />
-                </div>
-              ) : (
-                <Button
-                  isLoading={loading}
-                  loadingText="Connecting..."
-                  onClick={handleConnectWalletClick}
-                >
-                  Connect wallet
-                </Button>
-              )
-            )}
+            (isDisplayNetworkSwitcherAndWalletButton &&
+            activeAccount &&
+            activeWallet ? (
+              <div className="items-center space-x-2">
+                <ChainSwitcherButton />
+                <WalletButton account={activeAccount} wallet={activeWallet} />
+              </div>
+            ) : (
+              <Button
+                isLoading={loading}
+                loadingText="Connecting..."
+                onClick={handleConnectWalletClick}
+              >
+                Connect wallet
+              </Button>
+            ))}
 
           <NavigationMenu>
             <NavigationMenuTrigger />

--- a/apps/bridge-dapp/src/pages/PageBridge.tsx
+++ b/apps/bridge-dapp/src/pages/PageBridge.tsx
@@ -227,7 +227,7 @@ const PageBridge = () => {
               'bg-center object-fill bg-no-repeat bg-cover'
             )}
           >
-            <div className="lg:max-w-[1160px] mx-auto lg:grid lg:grid-cols-[minmax(550px,_562px)_1fr] items-start gap-9">
+            <div className="lg:max-w-[1160px] mx-auto mob:grid mob:grid-cols-[minmax(550px,_562px)_1fr] items-start gap-9">
               {customMainComponent}
 
               {/** Bridge tabs */}
@@ -265,7 +265,7 @@ const PageBridge = () => {
                 target="_blank"
                 rel="noreferrer"
                 className={cx(
-                  'lg:!hidden mt-9 ml-auto py-2 px-4 w-fit rounded-2xl',
+                  'mob:!hidden mt-9 ml-auto py-2 px-4 w-fit rounded-2xl',
                   'flex justify-end items-center',
                   'bg-[#ECF4FF] dark:bg-[#181F2B]'
                 )}
@@ -276,7 +276,7 @@ const PageBridge = () => {
                 <ArrowRightUp size="lg" className="!fill-blue-50" />
               </a>
 
-              <div className="hidden lg:!block">
+              <div>
                 {/** Transaction Queue Card */}
                 {isDisplayTxQueueCard && (
                   <TransactionQueueCard

--- a/apps/bridge-dapp/tailwind.config.js
+++ b/apps/bridge-dapp/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 
 const preset = require('@webb-tools/tailwind-preset');
+const defaultTheme = require('tailwindcss/defaultTheme');
 const { createGlobPatternsForDependencies } = require('@nx/react/tailwind');
 const { join } = require('path');
 
@@ -10,4 +11,11 @@ module.exports = {
     join(__dirname, 'src/**/*!(*.stories|*.spec).{ts,tsx,html}'),
     ...createGlobPatternsForDependencies(__dirname),
   ],
+  theme: {
+    screens: {
+      mob: '481px',
+      ...defaultTheme.screens,
+    },
+  },
+  plugins: [],
 };


### PR DESCRIPTION
## Summary of changes
At the 480px breakpoint, the layout switches to a one-column layout displaying only the bridge control card.

### Proposed area of change
_Put an `x` in the boxes that apply._

- [x] `apps/bridge-dapp`
- [ ] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)
_Specify any issues that can be closed from these changes (e.g. Closes #233)._
- Closes #1085 

### Screen Recording
_If possible provide a screen recording of proposed change._


-----
### Code Checklist 
_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
