### PR TITLE
Add Faucet link in navigation menu

### DIFF
--- a/apps/bridge-dapp/src/components/Header/Header.tsx
+++ b/apps/bridge-dapp/src/components/Header/Header.tsx
@@ -72,6 +72,9 @@ export const Header: FC<HeaderProps> = () => {
                   '_blank'
                 )
               }
+              onFaucetClick={() => {
+                window.open('https://faucet.webb.tools/', '_blank');
+              }}
               onHelpCenterClick={() =>
                 window.open('https://t.me/webbprotocol', '_blank')
               }

--- a/libs/webb-ui-components/src/components/NavigationMenu/NavigationMenuContent.tsx
+++ b/libs/webb-ui-components/src/components/NavigationMenu/NavigationMenuContent.tsx
@@ -31,6 +31,7 @@ export const NavigationMenuContent = forwardRef<
       className,
       onAboutClick,
       onDevelopmentClick,
+      onFaucetClick,
       onHelpCenterClick,
       onRequestFeaturesClick,
       onTestnetClick,
@@ -61,13 +62,7 @@ export const NavigationMenuContent = forwardRef<
 
         <NavigationMenuDivider />
 
-        {/* TODO: Update Actions when click on Faucet */}
-        <MenuItem
-          icon={<FaucetIcon size="lg" />}
-          onClick={() => {
-            return;
-          }}
-        >
+        <MenuItem icon={<FaucetIcon size="lg" />} onClick={onFaucetClick}>
           Faucet
         </MenuItem>
 

--- a/libs/webb-ui-components/src/components/NavigationMenu/types.ts
+++ b/libs/webb-ui-components/src/components/NavigationMenu/types.ts
@@ -18,6 +18,11 @@ export interface NavigationMenuContentProps
   onDevelopmentClick?: ComponentProps<typeof MenuItem>['onClick'];
 
   /**
+   * The callback when user hits faucet menu item
+   */
+  onFaucetClick?: ComponentProps<typeof MenuItem>['onClick'];
+
+  /**
    * The callback when user hits help center menu item
    */
   onHelpCenterClick?: ComponentProps<typeof MenuItem>['onClick'];


### PR DESCRIPTION
## Summary of changes
Add the Faucet url in navigation menu in the Bridge site

### Proposed area of change
_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/stats-dapp`
- [x] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [x] `libs/webb-ui-components`

### Reference issue to close (if applicable)
_Specify any issues that can be closed from these changes (e.g. Closes #233)._
- Closes #1297 

### Screen Recording

https://github.com/webb-tools/webb-dapp/assets/69841784/7a1f5db7-5351-4061-9ed3-6454525d6d07


-----
### Code Checklist 
_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
