### PR TITLE
Fix stats progress bar session lenght

### DIFF
--- a/apps/stats-dapp/src/containers/KeyStatusCardContainer/KeyStatusCardContainer.tsx
+++ b/apps/stats-dapp/src/containers/KeyStatusCardContainer/KeyStatusCardContainer.tsx
@@ -12,8 +12,6 @@ import { PublicKey, useActiveKeys } from '../../provider/hooks';
 export const KeyStatusCardContainer = () => {
   const { dkgDataFromPolkadotAPI, sessionHeight } = useStatsContext();
 
-  console.log('Session height', sessionHeight / 60);
-
   const { error, isFailed, isLoading, val: data } = useActiveKeys();
 
   const { currentKey } = useMemo<{
@@ -60,7 +58,7 @@ export const KeyStatusCardContainer = () => {
       keyVal={activeKeyData.key ?? ''}
       startTime={currentKey?.start ?? new Date()}
       endTime={
-        currentKey?.end ?? new Date(new Date().getTime() + 2 * 60 * 60 * 1000)
+        currentKey?.end ?? new Date(new Date().getTime() + sessionHeight * 1000)
       }
       authorities={authorities ?? new Set<string>()}
       totalAuthorities={authorities.size ?? 0}

--- a/apps/stats-dapp/src/containers/KeyStatusCardContainer/KeyStatusCardContainer.tsx
+++ b/apps/stats-dapp/src/containers/KeyStatusCardContainer/KeyStatusCardContainer.tsx
@@ -10,7 +10,9 @@ import { PublicKey, useActiveKeys } from '../../provider/hooks';
  * The wrapper of UI component. Handle logic and mapping fields between backend API and component API
  */
 export const KeyStatusCardContainer = () => {
-  const { dkgDataFromPolkadotAPI } = useStatsContext();
+  const { dkgDataFromPolkadotAPI, sessionHeight } = useStatsContext();
+
+  console.log('Session height', sessionHeight / 60);
 
   const { error, isFailed, isLoading, val: data } = useActiveKeys();
 

--- a/apps/stats-dapp/src/provider/stats-provider.tsx
+++ b/apps/stats-dapp/src/provider/stats-provider.tsx
@@ -237,8 +237,7 @@ export const StatsProvider: React.FC<
         (Number(await apiPromise.consts.timestamp.minimumPeriod) * 2) / 1000;
       setBlockTime(blockTime);
       const sessionPeriod = await apiPromise.consts.dkg.sessionPeriod;
-      console.log('✅', Number(sessionPeriod.toString()))
-      const sessionHeight = Number(sessionPeriod.toString()) * 12;
+      const sessionHeight = Number(sessionPeriod.toString()) * blockTime;
       setSessionHeight(sessionHeight);
 
       // Get DKG data from Polkadot API

--- a/apps/stats-dapp/src/provider/stats-provider.tsx
+++ b/apps/stats-dapp/src/provider/stats-provider.tsx
@@ -237,6 +237,7 @@ export const StatsProvider: React.FC<
         (Number(await apiPromise.consts.timestamp.minimumPeriod) * 2) / 1000;
       setBlockTime(blockTime);
       const sessionPeriod = await apiPromise.consts.dkg.sessionPeriod;
+      console.log('✅', Number(sessionPeriod.toString()))
       const sessionHeight = Number(sessionPeriod.toString()) * 12;
       setSessionHeight(sessionHeight);
 

--- a/libs/webb-ui-components/src/components/KeyStatusCard/KeyStatusCard.tsx
+++ b/libs/webb-ui-components/src/components/KeyStatusCard/KeyStatusCard.tsx
@@ -45,11 +45,6 @@ export const KeyStatusCard: React.FC<KeyStatusCardProps> = ({
       <Avatar sourceVariant="address" key={idx} value={randomAddress} />
     ));
 
-  console.log('Instance', instance);
-  console.log('startTime', startTime);
-  console.log('endTime', endTime);
-  console.log('end - start', (endTime.getTime() - startTime.getTime()) / 1000 / 60);
-
   return (
     <Card {...props}>
       {/** Top */}

--- a/libs/webb-ui-components/src/components/KeyStatusCard/KeyStatusCard.tsx
+++ b/libs/webb-ui-components/src/components/KeyStatusCard/KeyStatusCard.tsx
@@ -45,6 +45,11 @@ export const KeyStatusCard: React.FC<KeyStatusCardProps> = ({
       <Avatar sourceVariant="address" key={idx} value={randomAddress} />
     ));
 
+  console.log('Instance', instance);
+  console.log('startTime', startTime);
+  console.log('endTime', endTime);
+  console.log('end - start', (endTime.getTime() - startTime.getTime()) / 1000 / 60);
+
   return (
     <Card {...props}>
       {/** Top */}


### PR DESCRIPTION
## Summary of changes

- Stats progress bar now uses dynamic block time to calculate session length.

### Proposed area of change

- [ ] `apps/bridge-dapp`
- [x] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

- Closes #1259 

### Screenshot
![CleanShot 2023-06-21 at 04 31 03](https://github.com/webb-tools/webb-dapp/assets/53374218/c16b3d4d-b7cd-471d-837b-0952cde75e58)

