### PR TITLE
Fixes inconsistent stats background image

### DIFF
--- a/apps/stats-dapp/src/containers/Layout/Layout.tsx
+++ b/apps/stats-dapp/src/containers/Layout/Layout.tsx
@@ -143,7 +143,7 @@ export const Layout: FC<PropsWithChildren> = ({ children }) => {
         className={cx(
           'w-full mx-auto flex-1 pb-10 h-[1900px]',
           "bg-[url('assets/stats-bg.png')] dark:bg-[url('assets/stats-dark-bg.png')]",
-          'bg-no-repeat bg-cover',
+          'bg-no-repeat bg-cover'
         )}
       >
         <Header

--- a/apps/stats-dapp/src/containers/Layout/Layout.tsx
+++ b/apps/stats-dapp/src/containers/Layout/Layout.tsx
@@ -138,12 +138,12 @@ export const Layout: FC<PropsWithChildren> = ({ children }) => {
   );
 
   return (
-    <>
+    <div>
       <div
         className={cx(
-          'w-full mx-auto flex-1 pb-10',
+          'w-full mx-auto flex-1 pb-10 h-[1900px]',
           "bg-[url('assets/stats-bg.png')] dark:bg-[url('assets/stats-dark-bg.png')]",
-          'bg-top object-fill bg-no-repeat bg-cover'
+          'bg-no-repeat bg-cover',
         )}
       >
         <Header
@@ -173,6 +173,6 @@ export const Layout: FC<PropsWithChildren> = ({ children }) => {
       <div className="max-w-[1160px] mx-auto">
         <Footer />
       </div>
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
## Summary of changes

- Adds fixed height for the layout component in stats dapp to have same background image orientation across different tabs. 

### Proposed area of change

- [ ] `apps/bridge-dapp`
- [x] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

- Closes #1295 

### Screen Recording

https://github.com/webb-tools/webb-dapp/assets/53374218/52e7d55c-8111-47d2-833f-168d38818212