### PR TITLE
Remove extra bg image on bridge

### DIFF
--- a/apps/bridge-dapp/src/pages/PageBridge.tsx
+++ b/apps/bridge-dapp/src/pages/PageBridge.tsx
@@ -218,15 +218,7 @@ const PageBridge = () => {
     <>
       <div className="w-full h-full">
         <ErrorBoundary fallback={<ErrorFallback className="mx-auto mt-4" />}>
-          <div
-            className={cx(
-              'min-h-[1100px] lg:min-h-fit',
-              'p-4 lg:p-9',
-              "bg-[url('assets/bridge-bg-mobile.png')] dark:bg-none dark:bg-mono-200",
-              "lg:bg-[url('assets/bridge-bg.png')] lg:dark:bg-[url('assets/bridge-dark-bg.png')]",
-              'bg-center object-fill bg-no-repeat bg-cover'
-            )}
-          >
+          <div className={cx('min-h-[1100px] lg:min-h-fit', 'p-4 lg:p-9')}>
             <div className="lg:max-w-[1160px] mx-auto mob:grid mob:grid-cols-[minmax(550px,_562px)_1fr] items-start gap-9">
               {customMainComponent}
 


### PR DESCRIPTION
## Summary of changes

- Removes extra bg image on bridge - use of two same bg image for txn containers and spend notes table.

### Proposed area of change

- [x] `apps/bridge-dapp`
- [ ] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Screenshots

Before:

![CleanShot 2023-06-22 at 03 30 15](https://github.com/webb-tools/webb-dapp/assets/53374218/e45371a8-64df-4982-a7bc-d164156c410e)

After:

![CleanShot 2023-06-22 at 03 32 24](https://github.com/webb-tools/webb-dapp/assets/53374218/84e7fb5e-dc16-4f60-822c-0f8803a0ee68)
