### PR TITLE
[RELEASE] Relayer URL and Disable Radio When No Chains To Select

### DIFF
--- a/apps/bridge-dapp/CHANGELOG.md
+++ b/apps/bridge-dapp/CHANGELOG.md
@@ -151,3 +151,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Utilize Circom Proving for Substrate, Centralized the shared types, Move fetchOnChainConfig logic into webpack ([#1361](https://github.com/webb-tools/webb-dapp/pull/1361))
 - Close confirm containers when txn is dismissed ([#1362](https://github.com/webb-tools/webb-dapp/pull/1362))
 - Removes extra bg image on bridge ([#1367](https://github.com/webb-tools/webb-dapp/pull/1367))
+- Relayer URL and Disable Radio When No Chains To Select ([#1379](https://github.com/webb-tools/webb-dapp/pull/1379))

--- a/apps/bridge-dapp/src/containers/TransferContainer/TransferContainer.tsx
+++ b/apps/bridge-dapp/src/containers/TransferContainer/TransferContainer.tsx
@@ -428,7 +428,7 @@ export const TransferContainer = forwardRef<
 
           return {
             address: relayerData?.beneficiary ?? '',
-            externalUrl: relayer.endpoint,
+            externalUrl: relayer.infoUri,
             theme,
           };
         })
@@ -442,7 +442,7 @@ export const TransferContainer = forwardRef<
           onChange={(nextRelayer) => {
             setRelayer(
               relayers.find((relayer) => {
-                return relayer.endpoint === nextRelayer.externalUrl;
+                return relayer.infoUri === nextRelayer.externalUrl;
               }) ?? null
             );
             setMainComponent(undefined);

--- a/apps/bridge-dapp/src/containers/WithdrawContainer/WithdrawContainer.tsx
+++ b/apps/bridge-dapp/src/containers/WithdrawContainer/WithdrawContainer.tsx
@@ -818,7 +818,7 @@ export const WithdrawContainer = forwardRef<
 
             return {
               address: relayerData?.beneficiary ?? '',
-              externalUrl: relayer.endpoint,
+              externalUrl: relayer.infoUri,
               theme,
             };
           })
@@ -827,7 +827,7 @@ export const WithdrawContainer = forwardRef<
         onChange={(nextRelayer) => {
           setRelayer(
             relayers.find((relayer) => {
-              return relayer.endpoint === nextRelayer.externalUrl;
+              return relayer.infoUri === nextRelayer.externalUrl;
             }) ?? null
           );
           setMainComponent(undefined);

--- a/libs/abstract-api-provider/src/relayer/webb-relayer.ts
+++ b/libs/abstract-api-provider/src/relayer/webb-relayer.ts
@@ -200,6 +200,13 @@ class RelayedWithdraw {
 export class WebbRelayer {
   constructor(readonly endpoint: string, readonly capabilities: Capabilities) {}
 
+  readonly infoRoute = '/api/v1/info';
+
+  get infoUri() {
+    // Use URL class to ensure the full url is valid (e.g. with trailing slash)
+    return new URL(this.infoRoute, this.endpoint).toString();
+  }
+
   async initWithdraw<Target extends RelayerCMDKey>(target: Target) {
     const ws = new WebSocket(this.endpoint.replace('http', 'ws') + '/ws');
 

--- a/libs/webb-ui-components/src/components/ListCard/ChainListCard.tsx
+++ b/libs/webb-ui-components/src/components/ListCard/ChainListCard.tsx
@@ -93,6 +93,16 @@ export const ChainListCard = forwardRef<HTMLDivElement, ChainListCardProps>(
       ];
     }, [currentActiveChain, filteredChains]);
 
+    // Count the number of chains in each category
+    const [liveCount, devCount, testCount] = useMemo(
+      () => [
+        chains.filter((chain) => chain.tag === 'live').length,
+        chains.filter((chain) => chain.tag === 'dev').length,
+        chains.filter((chain) => chain.tag === 'test').length,
+      ],
+      [chains]
+    );
+
     return (
       <ListCardWrapper
         {...props}
@@ -195,7 +205,8 @@ export const ChainListCard = forwardRef<HTMLDivElement, ChainListCardProps>(
               id="live"
               value="live"
               overrideRadixRadioItemProps={{
-                disabled: onlyCategory && onlyCategory !== 'live',
+                disabled:
+                  (onlyCategory && onlyCategory !== 'live') || !liveCount, // Disable if there are no live chains
               }}
             >
               Live
@@ -205,7 +216,8 @@ export const ChainListCard = forwardRef<HTMLDivElement, ChainListCardProps>(
               id="test"
               value="test"
               overrideRadixRadioItemProps={{
-                disabled: onlyCategory && onlyCategory !== 'test',
+                disabled:
+                  (onlyCategory && onlyCategory !== 'test') || !testCount, // Disable if there are no test chains
               }}
             >
               Testnet
@@ -215,7 +227,7 @@ export const ChainListCard = forwardRef<HTMLDivElement, ChainListCardProps>(
               id="dev"
               value="dev"
               overrideRadixRadioItemProps={{
-                disabled: onlyCategory && onlyCategory !== 'dev',
+                disabled: (onlyCategory && onlyCategory !== 'dev') || !devCount, // Disable if there are no dev chains
               }}
             >
               Development


### PR DESCRIPTION
## Summary of changes
- Update the external URL of the relayer to the info URL
- Disable the radio button on the ChainListCard when no chains to select

### Proposed area of change

- [x] `apps/bridge-dapp`
- [ ] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [x] `libs/webb-ui-components`

### Reference issue to close (if applicable)
- Closes https://github.com/webb-tools/webb-dapp/issues/1363
- Closes https://github.com/webb-tools/webb-dapp/issues/1379