### PR TITLE
Change to font Satoshi for marketing sites

### DIFF
--- a/apps/tangle-website/src/pages/_document.tsx
+++ b/apps/tangle-website/src/pages/_document.tsx
@@ -2,7 +2,7 @@ import { Html, Head, Main, NextScript } from 'next/document';
 
 const Document = () => {
   return (
-    <Html lang="en-us" className="font-satoshi-var">
+    <Html lang="en-us" className="font-satoshi">
       <Head />
       <body>
         <Main />

--- a/apps/webbsite/src/pages/_document.tsx
+++ b/apps/webbsite/src/pages/_document.tsx
@@ -2,7 +2,7 @@ import { Html, Head, Main, NextScript } from 'next/document';
 
 const Document = () => {
   return (
-    <Html lang="en-us" className="font-satoshi-var">
+    <Html lang="en-us" className="font-satoshi">
       <Head />
       <body>
         <Main />


### PR DESCRIPTION
## Summary of changes
As discussed with @monaiuu, we will set the font `Satoshi` to the marketing sites due to the fact that the font `Satoshi-Variable` is not well-supported on ios devices

### Proposed area of change
_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/stats-dapp`
- [x] `apps/webbsite`
- [ ] `apps/faucet`
- [x] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)
_Specify any issues that can be closed from these changes (e.g. Closes #233)._
- Closes #1281 

### Screenshots
![IMG_2397](https://github.com/webb-tools/webb-dapp/assets/69841784/1fa05214-49ac-4130-b1ac-abf4253021c6)
![IMG_2398](https://github.com/webb-tools/webb-dapp/assets/69841784/ef943165-e935-4227-b1ff-c28d993ab05f)


-----
### Code Checklist 
_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
