### PR TITLE
Adding missing hubble-stats netlify config

### DIFF
--- a/apps/hubble-stats/netlify.toml
+++ b/apps/hubble-stats/netlify.toml
@@ -1,0 +1,6 @@
+[[plugins]]
+package = "@netlify/plugin-nextjs"
+
+[build]
+command = "yarn nx build hubble-stats"
+publish = "./dist/apps/hubble-stats/.next"


### PR DESCRIPTION
## Summary of changes
- Adding the missing Netlify config file for the `hubble-stats` app.