### PR TITLE
The `getViemChain` function should use chain in the chainsConfig

### DIFF
--- a/libs/dapp-config/src/chains/evm/index.tsx
+++ b/libs/dapp-config/src/chains/evm/index.tsx
@@ -102,6 +102,7 @@ const additionalRpcUrls = {
   [PresetTypedChainId.MoonbaseAlpha]: [
     'https://moonbase-alpha.public.blastapi.io',
     'https://moonbeam-alpha.api.onfinality.io/public',
+    'https://moonbase.unitedbloc.com:1000',
   ],
   [PresetTypedChainId.Sepolia]: [
     'https://endpoints.omniatech.io/v1/eth/sepolia/public',

--- a/libs/web3-api-provider/src/utils/getViemClient.ts
+++ b/libs/web3-api-provider/src/utils/getViemClient.ts
@@ -1,15 +1,21 @@
 import { parseTypedChainId } from '@webb-tools/sdk-core';
-import { PublicClient, createPublicClient, fallback, http } from 'viem';
+import { Chain, PublicClient, createPublicClient, fallback, http } from 'viem';
 import {
   VIEM_NOT_SUPPORTED_MULTICALL_CHAINS,
   defineViemChain,
   getViemChain,
 } from './getViemChain';
+import { chainsConfig } from '@webb-tools/dapp-config/chains/evm';
 
 function getViemClient(typedChainId: number): PublicClient {
   const { chainId } = parseTypedChainId(typedChainId);
 
-  let chain = getViemChain(chainId);
+  let chain: Chain | undefined = chainsConfig[typedChainId];
+
+  if (!chain) {
+    chain = getViemChain(typedChainId);
+  }
+
   if (!chain || VIEM_NOT_SUPPORTED_MULTICALL_CHAINS.includes(chainId)) {
     chain = defineViemChain(typedChainId);
   }

--- a/tools/scripts/fetchingOnChainConfig.ts
+++ b/tools/scripts/fetchingOnChainConfig.ts
@@ -1,6 +1,6 @@
-import path from 'path';
-import { workspaceRoot } from 'nx/src/utils/workspace-root';
 import { config } from 'dotenv';
+import { workspaceRoot } from 'nx/src/utils/workspace-root';
+import path from 'path';
 
 config({
   path: path.join(workspaceRoot, '.env'),
@@ -11,12 +11,12 @@ config({
 });
 
 import { ApiPromise } from '@polkadot/api';
-import merge from 'lodash/merge';
 import {
   anchorDeploymentBlock,
   parsedAnchorConfig,
 } from '@webb-tools/dapp-config/src/anchors/anchor-config';
 import { chainsConfig } from '@webb-tools/dapp-config/src/chains/chain-config';
+import { DEFAULT_NATIVE_INDEX } from '@webb-tools/dapp-config/src/constants';
 import {
   AnchorMetadata,
   ConfigType,
@@ -27,14 +27,14 @@ import {
   ChainType,
   parseTypedChainId,
 } from '@webb-tools/sdk-core/typed-chain-id';
+import { ZERO_ADDRESS } from '@webb-tools/utils';
 import evmProviderFactory from '@webb-tools/web3-api-provider/src/utils/evmProviderFactory';
 import fs from 'fs';
 import { Listr, color } from 'listr2';
+import merge from 'lodash/merge';
 import { ON_CHAIN_CONFIG_PATH } from './constants';
 import fetchAnchorMetadata from './utils/on-chain-utils/fetchAnchorMetadata';
 import mergeConfig from './utils/on-chain-utils/mergeConfig';
-import { ZERO_ADDRESS } from '@webb-tools/utils';
-import { DEFAULT_NATIVE_INDEX } from '@webb-tools/dapp-config/src/constants';
 
 const configPath = path.join(workspaceRoot, ON_CHAIN_CONFIG_PATH);
 
@@ -69,6 +69,7 @@ async function filterActiveEVMChains(
             await provider.getChainId();
             return typedChainId;
           } catch (error) {
+            console.log(error);
             return null;
           }
         })
@@ -152,6 +153,12 @@ async function fetchAnchorMetadataTask(
           fetchAnchorMetadata(address, typedChainId, provider)
         )
       );
+
+      metadataSettled.forEach((res) => {
+        if (res.status === 'rejected') {
+          console.log(res.reason);
+        }
+      });
 
       const metadata = metadataSettled
         .filter(


### PR DESCRIPTION
## Summary of changes
- Fix the rate limit issue in the `getViemChain` function as it does not use chain in the chainsConfg.

### Proposed area of change
_Put an `x` in the boxes that apply._

- [x] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)
_Specify any issues that can be closed from these changes (e.g. Closes #233)._
- Closes `NaN`