### PR TITLE
[RELEASE] Faucet, DKG Stats, Tangle Website, Webbsite - Aug 07, 2023

### DIFF
--- a/.github/workflows/deploy-faucet.yml
+++ b/.github/workflows/deploy-faucet.yml
@@ -53,7 +53,11 @@ jobs:
         run: yarn add -D -W netlify-cli
 
       - name: Build project
-        run: yarn nx build faucet
+        # Fix: JavaScript heap out of memory
+        # https://github.com/actions/runner-images/issues/70#issuecomment-1191708172
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
+        run: yarn build:faucet
 
       - name: Deploy site
         id: deploy-netlify

--- a/.github/workflows/deploy-hubble-stats.yml
+++ b/.github/workflows/deploy-hubble-stats.yml
@@ -46,7 +46,11 @@ jobs:
         run: yarn add -D -W netlify-cli
 
       - name: Build project
-        run: yarn nx build hubble-stats
+        # Fix: JavaScript heap out of memory
+        # https://github.com/actions/runner-images/issues/70#issuecomment-1191708172
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
+        run: yarn build:hubble-stats
 
       - name: Deploy site
         id: deploy-netlify

--- a/.github/workflows/deploy-tangle-website.yml
+++ b/.github/workflows/deploy-tangle-website.yml
@@ -54,7 +54,11 @@ jobs:
         run: yarn add -D -W netlify-cli
 
       - name: Build project
-        run: yarn nx build tangle-website
+        # Fix: JavaScript heap out of memory
+        # https://github.com/actions/runner-images/issues/70#issuecomment-1191708172
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
+        run: yarn build:tangle-website
 
       - name: Deploy site
         id: deploy-netlify

--- a/apps/faucet/CHANGELOG.md
+++ b/apps/faucet/CHANGELOG.md
@@ -75,3 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed, Changed and Added
 
 - Setup Secure Headers and Detect Inactive Issues ([#1370](https://github.com/webb-tools/webb-dapp/pull/1370))
+
+## [0.0.6] - 2023-08-07
+
+- Improve the Faucet UI ([#1454](https://github.com/webb-tools/webb-dapp/pull/1454))

--- a/apps/faucet/package.json
+++ b/apps/faucet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webb-tools/faucet",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "APACHE-2.0",
   "description": "Official Webb Faucet"
 }

--- a/apps/faucet/src/pages/_document.tsx
+++ b/apps/faucet/src/pages/_document.tsx
@@ -2,7 +2,7 @@ import { Head, Html, Main, NextScript } from 'next/document';
 
 const Document = () => {
   return (
-    <Html lang="en-us" className="font-satoshi-var">
+    <Html lang="en-us" className="font-satoshi">
       <Head />
       <body>
         <Main />

--- a/apps/stats-dapp/CHANGELOG.md
+++ b/apps/stats-dapp/CHANGELOG.md
@@ -118,3 +118,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes stats progress bar session length ([#1358](https://github.com/webb-tools/webb-dapp/pull/1358))
 - Fixes inconsistent stats background image ([#1359](https://github.com/webb-tools/webb-dapp/pull/1359))
 - Fixes keys table real-time update & progress bar reset ([#1371](https://github.com/webb-tools/webb-dapp/pull/1371))
+
+## [0.0.12] - 2023-08-07
+
+### Fixed, Changed and Added
+
+- Removes proposal page and addresses bugs in keys and authorities page ([#1501](https://github.com/webb-tools/webb-dapp/pull/1501))

--- a/apps/stats-dapp/package.json
+++ b/apps/stats-dapp/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@webb-tools/stats-dapp",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "main": "./src/index.js"
 }

--- a/apps/tangle-website/CHANGELOG.md
+++ b/apps/tangle-website/CHANGELOG.md
@@ -79,3 +79,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes UI break on Governance System section ([#1364](https://github.com/webb-tools/webb-dapp/pull/1364))
 - Setup Secure Headers and Detect Inactive Issues ([#1370](https://github.com/webb-tools/webb-dapp/pull/1370))
 - Privacy Policy and Terms Conditions pages for the Tangle Website ([#1375](https://github.com/webb-tools/webb-dapp/pull/1375))
+
+## [0.0.6] - 2023-08-07
+
+### Fixed, Changed and Added
+
+- chore: update privacy & policy page in mkt sites based on latest design ([#1492](https://github.com/webb-tools/webb-dapp/pull/1492))

--- a/apps/tangle-website/package.json
+++ b/apps/tangle-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webb-tools/tangle-website",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "APACHE-2.0",
   "description": "Official Tangle Network website"
 }

--- a/apps/webbsite/CHANGELOG.md
+++ b/apps/webbsite/CHANGELOG.md
@@ -73,3 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adds shielded pool protocol pages ([#1335](https://github.com/webb-tools/webb-dapp/pull/1335))
 - Setup Secure Headers and Detect Inactive Issues ([#1370](https://github.com/webb-tools/webb-dapp/pull/1370))
+
+## [0.0.6] - 2023-08-07
+
+### Fixed, Changed and Added
+
+- Fixed font family and font size in webbsite.

--- a/apps/webbsite/package.json
+++ b/apps/webbsite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webb-tools/webbsite",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "APACHE-2.0",
   "description": "Official Webb webbsite"
 }


### PR DESCRIPTION
**⚠️ Note**: This does not include the bridge dApp. Once we release the bridge dApp, the new relayer API (utilizing HTTP) will no longer be compatible with the current live relayer (WSS). Before releasing the bridge dApp, we must inform our users to withdraw all their funds and temporarily discontinue the bridge. This will allow us to update the relayer and carry out QA with the new API.

## Summary of changes
- Release apps Aug 07, 2023

### Proposed area of change
_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [x] `apps/stats-dapp`
- [x] `apps/webbsite`
- [x] `apps/faucet`
- [x] `apps/tangle-website`
- [ ] `libs/webb-ui-components`