### PR TITLE
Fix JS Heap Out Of Memory when Releasing Apps & Update Broken Links

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -57,3 +57,7 @@ jobs:
 
       - name: build
         run: yarn nx run-many --all --target=build
+        # Fix: JavaScript heap out of memory
+        # https://github.com/actions/runner-images/issues/70#issuecomment-1191708172
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'

--- a/.github/workflows/deploy-bridge-dapp-dev.yml
+++ b/.github/workflows/deploy-bridge-dapp-dev.yml
@@ -45,6 +45,10 @@ jobs:
 
       - name: Build project
         run: yarn build:bridge
+        # Fix: JavaScript heap out of memory
+        # https://github.com/actions/runner-images/issues/70#issuecomment-1191708172
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
 
       - name: Deploy to Netlify
         id: deploy-netlify

--- a/.github/workflows/deploy-stats-dapp-dev.yml
+++ b/.github/workflows/deploy-stats-dapp-dev.yml
@@ -35,6 +35,10 @@ jobs:
 
       - name: Build project
         run: yarn build:stats
+        # Fix: JavaScript heap out of memory
+        # https://github.com/actions/runner-images/issues/70#issuecomment-1191708172
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
 
       - name: Deploy to Netlify
         id: deploy-netlify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,10 @@ jobs:
         run: yarn gql:codegen
 
       - name: build
+        # Fix: JavaScript heap out of memory
+        # https://github.com/actions/runner-images/issues/70#issuecomment-1191708172
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
         run: yarn nx run-many --all --target=build
 
       # Create github release

--- a/apps/bridge-dapp/src/components/EducationCard/EducationCard.tsx
+++ b/apps/bridge-dapp/src/components/EducationCard/EducationCard.tsx
@@ -11,13 +11,13 @@ const links = [
   {
     label: 'Usage Guide',
     getLink: (tab: EducationCardProps['currentTab']) => {
-      return `https://docs.webb.tools/docs/dapps/hubble-bridge/usage-guide/${tab.toLowerCase()}/`;
+      return `https://docs.webb.tools/docs/projects/hubble-bridge/usage-guide/${tab.toLowerCase()}/`;
     },
     Icon: UsageGuideIcon,
   },
   {
     label: 'Getting Started',
-    href: 'https://docs.webb.tools/docs/dapps/hubble-bridge/overview/',
+    href: 'https://docs.webb.tools/docs/projects/hubble-bridge/overview/',
     Icon: UsageGuideIcon,
   },
 ];


### PR DESCRIPTION
## Summary of changes
- Fix JS heap out of memory when releasing apps
- Update broken links

### Proposed area of change
_Put an `x` in the boxes that apply._

- [x] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)
_Specify any issues that can be closed from these changes (e.g. Closes #233)._
- Closes https://github.com/webb-tools/webb-dapp/issues/1504