### PR TITLE
Adds proposal hooks in stats-dapp to fetch batched proposals

### DIFF
--- a/apps/stats-dapp/src/gql/proposals.graphql
+++ b/apps/stats-dapp/src/gql/proposals.graphql
@@ -1,0 +1,32 @@
+query ProposalBatches($perPage: Int!, $offset: Int!) {
+  proposalBatches(offset: $offset, first: $perPage) {
+    totalCount
+
+    nodes {
+      id
+      blockNumber
+      timestamp
+      proposals
+      chain
+      status
+    }
+
+    pageInfo {
+      endCursor
+      hasNextPage
+      hasPreviousPage
+      startCursor
+    }
+  }
+}
+
+query ProposalBatch($batchId: String!) {
+  proposalBatch(id: $batchId) {
+    id
+    blockNumber
+    timestamp
+    proposals
+    chain
+    status
+  }
+}

--- a/apps/stats-dapp/src/pages/Proposals.tsx
+++ b/apps/stats-dapp/src/pages/Proposals.tsx
@@ -1,14 +1,21 @@
-import { Outlet } from 'react-router-dom';
-import { ProposalsTable } from '../containers';
+import { useBatchedProposal, useBatchedProposals } from '../provider';
 
 const Proposals = () => {
-  return (
-    <div className="flex flex-col space-y-4">
-      <ProposalsTable />
+  // All Batched Proposals
+  const batchedProposals = useBatchedProposals({
+    offset: 0,
+    perPage: 10,
+    filter: null,
+  });
 
-      <Outlet />
-    </div>
-  );
+  // Single Batched Proposal
+  const batchedProposal = useBatchedProposal('10');
+
+  // console.log('Batched Proposals', batchedProposals);
+
+  // console.log('Batched Proposal', batchedProposal);
+
+  return <div className="flex flex-col space-y-4"></div>;
 };
 
 export default Proposals;

--- a/apps/stats-dapp/src/pages/Proposals.tsx
+++ b/apps/stats-dapp/src/pages/Proposals.tsx
@@ -15,7 +15,7 @@ const Proposals = () => {
 
   // console.log('Batched Proposal', batchedProposal);
 
-  return <div className="flex flex-col space-y-4"></div>;
+  return <div className="flex flex-col space-y-4">Proposal Page</div>;
 };
 
 export default Proposals;

--- a/apps/stats-dapp/src/provider/hooks/index.ts
+++ b/apps/stats-dapp/src/provider/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './types';
 export * from './mappers';
 export * from './useSession';
 export * from './useBlocks';
+export * from './useProposals';

--- a/apps/stats-dapp/src/provider/hooks/useProposals.ts
+++ b/apps/stats-dapp/src/provider/hooks/useProposals.ts
@@ -1,0 +1,172 @@
+import { useEffect, useState } from 'react';
+import { Loadable, Page, PageInfoQuery } from './types';
+import {
+  useProposalBatchesLazyQuery,
+  useProposalBatchQuery,
+} from '../../generated/graphql';
+
+export type Proposal = {
+  data: string;
+  type: string;
+};
+
+export type ProposalBatch = {
+  id: string;
+  status: string;
+  height: number;
+  proposals: Proposal[];
+  chain: string;
+};
+
+export type BatchedProposalsQuery = PageInfoQuery;
+
+export type BatchedProposals = Loadable<Page<ProposalBatch>>;
+
+export type BatchedProposalQuery = string;
+
+export type BatchedProposal = Loadable<ProposalBatch>;
+
+// FOR BATCHED PROPOSALS TABLE
+export const useBatchedProposals = (
+  batchedProposalsQuery: BatchedProposalsQuery
+): BatchedProposals => {
+  const { offset, perPage } = batchedProposalsQuery;
+
+  const [call, query] = useProposalBatchesLazyQuery();
+
+  const [batchedProposals, setBatchedProposals] = useState<BatchedProposals>({
+    isLoading: false,
+    isFailed: false,
+    val: {
+      items: [],
+      pageInfo: {
+        count: 0,
+        hasNext: false,
+        hasPrevious: false,
+      },
+    },
+  });
+
+  useEffect(() => {
+    call({
+      variables: {
+        offset,
+        perPage,
+      },
+    });
+  }, [offset, perPage]);
+
+  useEffect(() => {
+    const subscription = query.observable
+      .map((res): BatchedProposals => {
+        if (res.data) {
+          const data = res.data.proposalBatches?.nodes
+            .filter((batch) => batch !== null)
+            .map((batch) => {
+              return {
+                id: batch?.id,
+                status: batch?.status,
+                height: Number(batch?.blockNumber),
+                proposals: batch?.proposals?.map((proposal: any) => {
+                  return {
+                    type: proposal?.kind,
+                    data: proposal?.data,
+                  };
+                }),
+                chain: batch?.chain,
+              };
+            });
+
+          return {
+            isFailed: false,
+            isLoading: false,
+            val: {
+              items: data as ProposalBatch[],
+              pageInfo: {
+                count: res.data.proposalBatches?.totalCount ?? 0,
+                hasPrevious:
+                  res.data.proposalBatches?.pageInfo.hasPreviousPage ?? false,
+                hasNext:
+                  res.data.proposalBatches?.pageInfo.hasNextPage ?? false,
+              },
+            },
+          };
+        }
+
+        return {
+          isLoading: res.loading,
+          isFailed: Boolean(res.error),
+          error: res.error?.message ?? undefined,
+          val: null,
+        };
+      })
+      .subscribe(setBatchedProposals);
+
+    return () => subscription.unsubscribe();
+  }, [query]);
+
+  return batchedProposals;
+};
+
+// FOR INDIVIDUAL BATCHED PROPOSAL DETAILS
+export const useBatchedProposal = (
+  batchedProposalQuery: BatchedProposalQuery
+) => {
+  const { data, error, loading } = useProposalBatchQuery({
+    variables: {
+      batchId: batchedProposalQuery,
+    },
+  });
+
+  const [batchedProposal, setBatchedProposal] = useState<BatchedProposal>({
+    isLoading: false,
+    isFailed: false,
+    val: null,
+  });
+
+  useEffect(() => {
+    if (data) {
+      const batch = data.proposalBatch;
+
+      const proposalBatch = {
+        id: batch?.id,
+        status: batch?.status,
+        height: Number(batch?.blockNumber),
+        proposals: batch?.proposals?.map((proposal: any) => {
+          return {
+            type: proposal?.kind,
+            data: proposal?.data,
+          };
+        }),
+        chain: batch?.chain,
+      };
+
+      setBatchedProposal({
+        isLoading: false,
+        isFailed: false,
+        val: proposalBatch as ProposalBatch,
+      });
+
+      return;
+    }
+
+    if (error) {
+      setBatchedProposal({
+        isLoading: false,
+        isFailed: true,
+        error: error.message,
+        val: null,
+      });
+    }
+
+    if (loading) {
+      setBatchedProposal({
+        isLoading: true,
+        isFailed: false,
+        val: null,
+      });
+    }
+  }, [data, error, loading]);
+
+  return batchedProposal;
+};


### PR DESCRIPTION
## Summary of changes

- Adds proposal hooks in `stats-dapp` to fetch batched proposals.
- Mainly two hooks - `useBatchedProposals` and `useBatchedProposal` which returns paginated batched proposals and a single batched proposal accordingly.

### Proposed area of change

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [x] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

- Closes #1475 

### Screenshots

- Batched Proposals

![CleanShot 2023-08-08 at 03 52 51](https://github.com/webb-tools/webb-dapp/assets/53374218/b5fd8e7b-4525-4332-a2a6-a803a62b05c3)

- Batched Proposal

![CleanShot 2023-08-08 at 03 53 26](https://github.com/webb-tools/webb-dapp/assets/53374218/ec016b5f-0056-45b4-ad55-13efca0d1624)