### PR TITLE
Stats dApp Fixes: footer, compressed key flex & proposal detail page color

### DIFF
--- a/apps/stats-dapp/src/containers/KeyDetail/KeyDetail.tsx
+++ b/apps/stats-dapp/src/containers/KeyDetail/KeyDetail.tsx
@@ -43,8 +43,9 @@ import cx from 'classnames';
 import getUnicodeFlagIcon from 'country-flag-icons/unicode';
 import { forwardRef, useCallback, useMemo } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-
 import { KeyDetailProps, KeyGenAuthoredTableProps } from './types';
+import { ECPairFactory } from 'ecpair';
+import * as tinysecp from 'tiny-secp256k1';
 
 export const KeyDetail = forwardRef<HTMLDivElement, KeyDetailProps>(
   ({ isPage }, ref) => {
@@ -197,11 +198,11 @@ export const KeyDetail = forwardRef<HTMLDivElement, KeyDetailProps>(
               keyValue={keyDetail.compressed}
               className="grow shrink basis-0 max-w-none"
             />
-            {/* <KeyCard
+            <KeyCard
               title="Uncompressed key"
-              keyValue={keyDetail.uncompressed}
+              keyValue={uncompressPublicKey(keyDetail.compressed)}
               className="grow shrink basis-0 max-w-none"
-            /> */}
+            />
           </div>
         </div>
 
@@ -440,4 +441,16 @@ const KeyGenAuthoredTable: React.FC<KeyGenAuthoredTableProps> = ({ data }) => {
       title="DKG Authorities"
     />
   );
+};
+
+const uncompressPublicKey = (compressed: string): `0x${string}` => {
+  const ECPair = ECPairFactory(tinysecp);
+  const dkgPubKey = ECPair.fromPublicKey(
+    Buffer.from(compressed.slice(2), 'hex'),
+    {
+      compressed: false,
+    }
+  ).publicKey.toString('hex');
+  // now we remove the `04` prefix byte and return it.
+  return `0x${dkgPubKey.slice(2)}`;
 };

--- a/apps/stats-dapp/src/containers/Layout/Layout.tsx
+++ b/apps/stats-dapp/src/containers/Layout/Layout.tsx
@@ -162,6 +162,8 @@ export const Layout: FC<PropsWithChildren> = ({ children }) => {
               currentSessionNumber: 0,
               nextKey: '',
               nextSessionNumber: 0,
+              proposerCount: 0,
+              proposerThreshold: 0,
             }}
           >
             <NavBoxInfoContainer />

--- a/apps/stats-dapp/src/containers/ProposalDetail/ProposalDetail.tsx
+++ b/apps/stats-dapp/src/containers/ProposalDetail/ProposalDetail.tsx
@@ -329,7 +329,7 @@ const ProposalDecodedData: FC<{ data: Record<string, any> }> = ({ data }) => {
   }, [data]);
 
   return (
-    <div className="whitespace-pre-wrap !text-mono-80">
+    <div className="whitespace-pre-wrap !dark:text-mono-80 text-mono-200">
       {JSON.stringify(knowProposal ? data.data : data, null, 2)}
     </div>
   );

--- a/apps/stats-dapp/src/containers/ProposalDetail/ProposalDetail.tsx
+++ b/apps/stats-dapp/src/containers/ProposalDetail/ProposalDetail.tsx
@@ -330,7 +330,7 @@ const ProposalDecodedData: FC<{ data: Record<string, any> }> = ({ data }) => {
 
   return (
     <div className="whitespace-pre-wrap !dark:text-mono-80 text-mono-200">
-      {JSON.stringify(knowProposal ? data.data : data, null, 2)}
+      {JSON.stringify(knowProposal ? data.data : data, null, 4)}
     </div>
   );
 };

--- a/libs/webb-ui-components/src/components/Footer/Footer.tsx
+++ b/libs/webb-ui-components/src/components/Footer/Footer.tsx
@@ -20,7 +20,7 @@ export const Footer = forwardRef<HTMLElement, FooterProps>(
       <footer
         {...props}
         className={twMerge(
-          'flex flex-col space-y-4 max-w-[1160px] mx-auto mt-[72px] mb-[98px]',
+          'flex flex-col space-y-4 max-w-[1160px] mx-auto py-[72px]',
           className
         )}
         ref={ref}

--- a/libs/webb-ui-components/src/components/KeyCard/KeyCard.tsx
+++ b/libs/webb-ui-components/src/components/KeyCard/KeyCard.tsx
@@ -24,7 +24,7 @@ export const KeyCard = forwardRef<HTMLDivElement, KeyCardProps>(
     return (
       <div {...props} className={mergedClsx} ref={ref}>
         {/** Top */}
-        <div className="items-center justify-between">
+        <div className="flex items-center justify-between">
           <Typography variant="utility" className="uppercase">
             {title}
           </Typography>


### PR DESCRIPTION
## Summary of changes

- Fixes extra spacing below stats footer.
- Fixes key details page compressed key copy button's flex.
- Fixes proposal data text color in proposal details page in light mode.

### Proposed area of change

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [x] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

- Closes #1545 
- Closes https://github.com/webb-tools/webb-dapp/issues/1351

### Screenshots

![CleanShot 2023-08-21 at 09 45 54](https://github.com/webb-tools/webb-dapp/assets/53374218/43342835-9ec3-4e0f-aff7-10aa52553aca)

![CleanShot 2023-08-21 at 09 46 04](https://github.com/webb-tools/webb-dapp/assets/53374218/319b5225-3cd0-4313-8901-9283fbd9be95)

![CleanShot 2023-08-21 at 09 52 43](https://github.com/webb-tools/webb-dapp/assets/53374218/cd650300-cf69-41c7-b31d-0aaf03573e3e)

![CleanShot 2023-08-21 at 09 54 19](https://github.com/webb-tools/webb-dapp/assets/53374218/7ab3c53c-fc9b-4b47-a183-4622c22887ad)