### PR TITLE
Stats dApp fixes and adds rotated key status to key timeline

### DIFF
--- a/apps/stats-dapp/src/containers/AuthoritiesTable/AuthoritiesTable.tsx
+++ b/apps/stats-dapp/src/containers/AuthoritiesTable/AuthoritiesTable.tsx
@@ -201,10 +201,6 @@ export const AuthoritiesTable: FC<AuthoritiesTableProps> = ({
     getFilteredRowModel: getFilteredRowModel(),
   });
 
-  const tableIsLoading = useMemo(() => {
-    return totalItems === 0 ? true : false;
-  }, [totalItems]);
-
   return (
     <CardTable
       titleProps={{
@@ -271,7 +267,7 @@ export const AuthoritiesTable: FC<AuthoritiesTableProps> = ({
         </Filter>
       }
     >
-      {!tableIsLoading ? (
+      {!authorities.isLoading ? (
         <Table
           tableProps={table as RTTable<unknown>}
           isPaginated

--- a/apps/stats-dapp/src/containers/AuthoritiesTable/AuthoritiesTable.tsx
+++ b/apps/stats-dapp/src/containers/AuthoritiesTable/AuthoritiesTable.tsx
@@ -40,6 +40,7 @@ import { FC, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { AuthoritiesTableProps } from './types';
 import { CountryIcon } from '../../components/CountryIcon/CountryIcon';
+import { Spinner } from '@webb-tools/icons';
 
 const columnHelper = createColumnHelper<AuthorityListItem>();
 
@@ -200,6 +201,10 @@ export const AuthoritiesTable: FC<AuthoritiesTableProps> = ({
     getFilteredRowModel: getFilteredRowModel(),
   });
 
+  const tableIsLoading = useMemo(() => {
+    return totalItems === 0 ? true : false;
+  }, [totalItems]);
+
   return (
     <CardTable
       titleProps={{
@@ -266,12 +271,18 @@ export const AuthoritiesTable: FC<AuthoritiesTableProps> = ({
         </Filter>
       }
     >
-      <Table
-        tableProps={table as RTTable<unknown>}
-        isPaginated
-        totalRecords={totalItems}
-        title="DKG Authorities"
-      />
+      {!tableIsLoading ? (
+        <Table
+          tableProps={table as RTTable<unknown>}
+          isPaginated
+          totalRecords={totalItems}
+          title="DKG Authorities"
+        />
+      ) : (
+        <div className="h-[400px] flex items-center flex-col justify-center">
+          <Spinner size="xl" />
+        </div>
+      )}
     </CardTable>
   );
 };

--- a/apps/stats-dapp/src/containers/KeyDetail/KeyDetail.tsx
+++ b/apps/stats-dapp/src/containers/KeyDetail/KeyDetail.tsx
@@ -236,14 +236,6 @@ export const KeyDetail = forwardRef<HTMLDivElement, KeyDetailProps>(
                       time={at}
                       blockHash={hash}
                       externalUrl={POLKADOT_EXPLORER_URL + hash}
-                      extraContent={
-                        <div className="flex items-center space-x-2">
-                          {/* <KeyValueWithButton
-                            keyValue={keyDetail.uncompressed}
-                            size="sm"
-                          /> */}
-                        </div>
-                      }
                     />
                   );
                 }
@@ -256,37 +248,6 @@ export const KeyDetail = forwardRef<HTMLDivElement, KeyDetailProps>(
                       time={at}
                       blockHash={hash}
                       externalUrl={POLKADOT_EXPLORER_URL + hash}
-                      extraContent={
-                        <div className="flex items-center space-x-4">
-                          <LabelWithValue
-                            label="Height"
-                            value={keyDetail.height}
-                          />
-                          {/** TODO: Proposal type */}
-                          <LabelWithValue
-                            label="Proposal"
-                            value="KeyRotation"
-                          />
-                          {keyDetail.authorities.length && (
-                            <LabelWithValue
-                              label="Proposers"
-                              value={
-                                <AvatarGroup
-                                  total={keyDetail.authorities.length}
-                                >
-                                  {keyDetail.authorities.map((author, idx) => (
-                                    <Avatar
-                                      key={author.id}
-                                      value={author.account}
-                                      sourceVariant="address"
-                                    />
-                                  ))}
-                                </AvatarGroup>
-                              }
-                            />
-                          )}
-                        </div>
-                      }
                     />
                   );
                 }

--- a/apps/stats-dapp/src/provider/hooks/useAuthorities.ts
+++ b/apps/stats-dapp/src/provider/hooks/useAuthorities.ts
@@ -468,7 +468,7 @@ export function useAuthority(pageQuery: AuthorityQuery): AuthorityDetails {
               return {
                 id: publicKey.id,
                 session: session && session.id ? session.id : '',
-                publicKey: '', // publicKey.uncompressed!
+                publicKey: publicKey.compressed ?? '',
                 height: `${publicKey.block?.number ?? '-'}`,
                 authority: {
                   count: session.sessionValidators.totalCount,

--- a/libs/webb-ui-components/src/components/TitleWithInfo/TitleWithInfo.tsx
+++ b/libs/webb-ui-components/src/components/TitleWithInfo/TitleWithInfo.tsx
@@ -54,7 +54,7 @@ export const TitleWithInfo = forwardRef<HTMLDivElement, TitleWithInfoProps>(
             </TooltipTrigger>
             <TooltipBody>
               {typeof info === 'string' ? (
-                <Typography variant={'body3'} className="break-normal">
+                <Typography variant={'body1'} className="break-normal">
                   {info}
                 </Typography>
               ) : (

--- a/libs/webb-ui-components/src/components/Tooltip/Tooltip.tsx
+++ b/libs/webb-ui-components/src/components/Tooltip/Tooltip.tsx
@@ -36,13 +36,12 @@ export const TooltipBody: React.FC<TooltipBodyProps> = ({
           'bg-mono-20 dark:bg-mono-160',
           'webb-shadow-sm'
         )}
-        side="bottom"
         {...props}
       >
         <TooltipPrimitive.Arrow className="fill-current text-mono-20 dark:text-mono-160 webb-shadow-sm" />
         <div
           className={twMerge(
-            'text-mono-140 dark:text-mono-80 font-normal',
+            'body4 text-mono-140 dark:text-mono-80 font-normal',
             className
           )}
         >


### PR DESCRIPTION
## Summary of changes

- Adds `Rotated` status to key `Timeline` component in `Key Details` page.
- Adds a spinner to `Authorities Table` when in loading state.
- Now `Keygen Table` in `Authority Detail` page shows `Public Key` value.

### Proposed area of change

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [x] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

- Closes #1260 

### Screen Recording

https://github.com/webb-tools/webb-dapp/assets/53374218/844a3bd6-d0e5-46a6-9967-395b248f1926

![CleanShot 2023-08-31 at 11 07 00](https://github.com/webb-tools/webb-dapp/assets/53374218/44d00fce-fe19-40c3-81d5-618504391aba)