### PR TITLE
fix chart tooltip bug

### DIFF
--- a/apps/hubble-stats/components/charts/AreaChart.tsx
+++ b/apps/hubble-stats/components/charts/AreaChart.tsx
@@ -56,33 +56,29 @@ const AreaChart: FC<AreaChartProps> = ({
           tickMargin={16}
           interval="preserveStartEnd"
         />
-        {showTooltip && (
-          <Tooltip
-            content={({ active, payload }) => {
-              if (active && payload && payload.length) {
-                return (
-                  <ChartTooltipContent
-                    date={payload[0].payload['date']}
-                    info={[
-                      {
-                        color: fillColor,
-                        label: tooltipLabel,
-                        value: payload[0].payload['value'],
-                        valuePrefix: tooltipValuePrefix,
-                        valueSuffix: tooltipValueSuffix,
-                      },
-                    ]}
-                    onContentDisplayedFnc={() => {
-                      setValue && setValue(payload[0].payload['value']);
-                      setDate && setDate(payload[0].payload['date']);
-                    }}
-                  />
-                );
-              }
-              return null;
-            }}
-          />
-        )}
+        <Tooltip
+          content={({ active, payload }) => {
+            return (
+              <ChartTooltipContent
+                date={payload?.[0]?.payload['date']}
+                info={[
+                  {
+                    color: fillColor,
+                    label: tooltipLabel,
+                    value: payload?.[0]?.payload['value'],
+                    valuePrefix: tooltipValuePrefix,
+                    valueSuffix: tooltipValueSuffix,
+                  },
+                ]}
+                onContentDisplayedFnc={() => {
+                  setValue && setValue(payload?.[0]?.payload['value']);
+                  setDate && setDate(payload?.[0]?.payload['date']);
+                }}
+                hide={!showTooltip || !(active && payload && payload.length)}
+              />
+            );
+          }}
+        />
         <Area
           dataKey="value"
           stroke={fillColor}

--- a/apps/hubble-stats/components/charts/BarChart.tsx
+++ b/apps/hubble-stats/components/charts/BarChart.tsx
@@ -64,27 +64,25 @@ const BarChart: FC<BarChartProps> = ({
         {showTooltip && (
           <Tooltip
             content={({ active, payload }) => {
-              if (active && payload && payload.length) {
-                return (
-                  <ChartTooltipContent
-                    date={payload[0].payload['date']}
-                    info={[
-                      {
-                        color: fillColor,
-                        label: tooltipLabel,
-                        value: payload[0].payload['value'],
-                        valuePrefix: tooltipValuePrefix,
-                        valueSuffix: tooltipValueSuffix,
-                      },
-                    ]}
-                    onContentDisplayedFnc={() => {
-                      setValue && setValue(payload[0].payload['value']);
-                      setDate && setDate(payload[0].payload['date']);
-                    }}
-                  />
-                );
-              }
-              return null;
+              return (
+                <ChartTooltipContent
+                  date={payload?.[0]?.payload['date']}
+                  info={[
+                    {
+                      color: fillColor,
+                      label: tooltipLabel,
+                      value: payload?.[0]?.payload['value'],
+                      valuePrefix: tooltipValuePrefix,
+                      valueSuffix: tooltipValueSuffix,
+                    },
+                  ]}
+                  onContentDisplayedFnc={() => {
+                    setValue && setValue(payload?.[0]?.payload['value']);
+                    setDate && setDate(payload?.[0]?.payload['date']);
+                  }}
+                  hide={!showTooltip || !(active && payload && payload.length)}
+                />
+              );
             }}
           />
         )}

--- a/apps/hubble-stats/components/charts/BarChart.tsx
+++ b/apps/hubble-stats/components/charts/BarChart.tsx
@@ -61,31 +61,29 @@ const BarChart: FC<BarChartProps> = ({
           tickMargin={16}
           interval="preserveStartEnd"
         />
-        {showTooltip && (
-          <Tooltip
-            content={({ active, payload }) => {
-              return (
-                <ChartTooltipContent
-                  date={payload?.[0]?.payload['date']}
-                  info={[
-                    {
-                      color: fillColor,
-                      label: tooltipLabel,
-                      value: payload?.[0]?.payload['value'],
-                      valuePrefix: tooltipValuePrefix,
-                      valueSuffix: tooltipValueSuffix,
-                    },
-                  ]}
-                  onContentDisplayedFnc={() => {
-                    setValue && setValue(payload?.[0]?.payload['value']);
-                    setDate && setDate(payload?.[0]?.payload['date']);
-                  }}
-                  hide={!showTooltip || !(active && payload && payload.length)}
-                />
-              );
-            }}
-          />
-        )}
+        <Tooltip
+          content={({ active, payload }) => {
+            return (
+              <ChartTooltipContent
+                date={payload?.[0]?.payload['date']}
+                info={[
+                  {
+                    color: fillColor,
+                    label: tooltipLabel,
+                    value: payload?.[0]?.payload['value'],
+                    valuePrefix: tooltipValuePrefix,
+                    valueSuffix: tooltipValueSuffix,
+                  },
+                ]}
+                onContentDisplayedFnc={() => {
+                  setValue && setValue(payload?.[0]?.payload['value']);
+                  setDate && setDate(payload?.[0]?.payload['date']);
+                }}
+                hide={!showTooltip || !(active && payload && payload.length)}
+              />
+            );
+          }}
+        />
         <Bar dataKey="value" fill={fillColor} />
       </BarChartCmp>
     </ResponsiveContainer>

--- a/apps/hubble-stats/components/charts/ChartToolTipContent.tsx
+++ b/apps/hubble-stats/components/charts/ChartToolTipContent.tsx
@@ -8,10 +8,15 @@ const ChartTooltipContent: FC<ChartTooltipContentProps> = ({
   date,
   info,
   onContentDisplayedFnc,
+  hide,
 }) => {
   useEffect(() => {
     onContentDisplayedFnc();
   }, [onContentDisplayedFnc]);
+
+  if (hide || date === undefined) {
+    return null;
+  }
 
   return (
     <div className="rounded-lg p-2 bg-[rgba(255,255,255,0.70)] dark:bg-[rgba(31,29,43,0.70)]">

--- a/apps/hubble-stats/components/charts/VolumeChart.tsx
+++ b/apps/hubble-stats/components/charts/VolumeChart.tsx
@@ -47,34 +47,32 @@ const VolumeChart: FC<VolumeChartProps> = ({
         <Tooltip
           cursor={{ opacity: isDarkMode ? 0.2 : 1 }}
           content={({ active, payload }) => {
-            if (active && payload && payload.length) {
-              return (
-                <ChartTooltipContent
-                  date={payload[0].payload['date']}
-                  info={[
-                    {
-                      color: '#624FBE',
-                      label: 'Deposits',
-                      value: payload[0].payload['deposit'],
-                      valuePrefix: tooltipValuePrefix,
-                      valueSuffix: tooltipValueSuffix,
-                    },
-                    {
-                      color: '#B5A9F2',
-                      label: 'Withdrawals',
-                      value: payload[0].payload['withdrawal'],
-                      valuePrefix: tooltipValuePrefix,
-                      valueSuffix: tooltipValueSuffix,
-                    },
-                  ]}
-                  onContentDisplayedFnc={() => {
-                    setValue && setValue(payload[0].payload['deposit']);
-                    setDate && setDate(payload[0].payload['date']);
-                  }}
-                />
-              );
-            }
-            return null;
+            return (
+              <ChartTooltipContent
+                date={payload?.[0]?.payload['date']}
+                info={[
+                  {
+                    color: '#624FBE',
+                    label: 'Deposits',
+                    value: payload?.[0]?.payload['deposit'],
+                    valuePrefix: tooltipValuePrefix,
+                    valueSuffix: tooltipValueSuffix,
+                  },
+                  {
+                    color: '#B5A9F2',
+                    label: 'Withdrawals',
+                    value: payload?.[0]?.payload['withdrawal'],
+                    valuePrefix: tooltipValuePrefix,
+                    valueSuffix: tooltipValueSuffix,
+                  },
+                ]}
+                onContentDisplayedFnc={() => {
+                  setValue && setValue(payload?.[0]?.payload['deposit']);
+                  setDate && setDate(payload?.[0]?.payload['date']);
+                }}
+                hide={!(active && payload && payload.length)}
+              />
+            );
           }}
         />
         <Bar dataKey="deposit" fill="#624FBE" />

--- a/apps/hubble-stats/components/charts/types.ts
+++ b/apps/hubble-stats/components/charts/types.ts
@@ -29,11 +29,11 @@ export interface VolumeChartProps
 }
 
 export interface ChartTooltipContentProps {
-  date: Date;
+  date?: Date;
   info: Array<{
     color: string;
     label: string;
-    value: number;
+    value?: number;
     valuePrefix?: string;
     valueSuffix?: string;
   }>;
@@ -41,4 +41,5 @@ export interface ChartTooltipContentProps {
    * A function to call when the content of Tooltip is being displayed
    */
   onContentDisplayedFnc: () => void;
+  hide: boolean;
 }


### PR DESCRIPTION
## Summary of changes
_Provide a detailed description of proposed changes._
- Fix the bug when the number displayed still remained after not hovering on anything on the charts

### Proposed area of change
_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [x] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)
_Specify any issues that can be closed from these changes (e.g. Closes #233)._
- Closes #1663 

### Screen Recording
_If possible provide a screen recording of proposed change._

https://github.com/webb-tools/webb-dapp/assets/69841784/235cdf41-9877-4121-91d6-f9502fff692a



-----
### Code Checklist 
_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
