### PR TITLE
Remove chain id from signing message for note account creation

### DIFF
--- a/apps/bridge-dapp/src/constants/signIn.ts
+++ b/apps/bridge-dapp/src/constants/signIn.ts
@@ -8,7 +8,6 @@ Logging into Webb's Hubble Bridge!
 Domain: {domain}
 Origin: {origin}
 Address: {address}
-Chain ID: {chainId}
 
 To access your account and continue your journey, please sign in with your Ethereum account.
 
@@ -17,9 +16,8 @@ Your privacy is important to us. We will never store or share your private keys.
 By signing in, you acknowledge and agree to our terms of service and privacy policy.
 `;
 
-export function createSignInMessage(address: string, chainId: number) {
+export function createSignInMessage(address: string) {
   return SIGN_IN_MESSAGE.replace('{domain}', domain)
     .replace('{origin}', origin)
-    .replace('{address}', address)
-    .replace('{chainId}', chainId.toString());
+    .replace('{address}', address);
 }

--- a/apps/bridge-dapp/src/containers/CreateAccountModal/CreateAccountModal.tsx
+++ b/apps/bridge-dapp/src/containers/CreateAccountModal/CreateAccountModal.tsx
@@ -83,10 +83,7 @@ export const CreateAccountModal: FC<CreateAccountModalProps> = ({
         throw WebbError.from(WebbErrorCodes.NoAccountAvailable);
       }
 
-      const msg = createSignInMessage(
-        account.address,
-        await activeApi.getChainId()
-      );
+      const msg = createSignInMessage(account.address);
 
       const signedString = await activeApi.sign(msg);
 


### PR DESCRIPTION
## Summary of changes
- Remove chain id from signing message for note account creation

### Proposed area of change
_Put an `x` in the boxes that apply._

- [x] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)
_Specify any issues that can be closed from these changes (e.g. Closes #233)._
- Closes https://github.com/webb-tools/webb-dapp/issues/1666