### PR TITLE
Fix prev session's active period incorrect progress bar

### DIFF
--- a/apps/stats-dapp/src/containers/KeygenTable/KeygenTable.tsx
+++ b/apps/stats-dapp/src/containers/KeygenTable/KeygenTable.tsx
@@ -224,6 +224,16 @@ export const KeygenTable: FC = () => {
 
   const keysStats = useKeys(pageQuery, currentKey);
 
+  useEffect(() => {
+    if (keysStats.val) {
+      const keysList = keysStats.val.items.map((item) => {
+        return item.compressed;
+      });
+
+      localStorage.setItem('keys', JSON.stringify(keysList));
+    }
+  }, [keysStats]);
+
   const data = useMemo(() => {
     if (keysStats.val) {
       return keysStats.val.items


### PR DESCRIPTION
## Summary of changes

- Fixes previous session's active period incorrect progress bar. This issue occurs only when a session rotation happens soon after (not after session height) previous session rotation block (maybe like 10 -15 blocks after prev session rotation block).
- We should show full progress bar for all the previous keys other than current key. This PR fixes that.

### Proposed area of change

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [x] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

- Closes #1605 

### Screenshots

**Current Key**:

![CleanShot 2023-09-28 at 14 51 11](https://github.com/webb-tools/webb-dapp/assets/53374218/48992428-7185-47c6-b401-2dec7b856d6a)

**Previous key before fix**:

![CleanShot 2023-09-28 at 14 51 30](https://github.com/webb-tools/webb-dapp/assets/53374218/7a8941a7-850d-49a6-a5b7-aea0e5e10e15)

**Previous key after fix (Progress bar is full)**:

![CleanShot 2023-09-28 at 14 53 07](https://github.com/webb-tools/webb-dapp/assets/53374218/66e55326-7f67-4760-b2f9-46e3c7057ec4)

