### PR TITLE
Fix warning badge 0 balance state

### DIFF
--- a/apps/bridge-dapp/src/pages/Hubble/Bridge/SelectToken.tsx
+++ b/apps/bridge-dapp/src/pages/Hubble/Bridge/SelectToken.tsx
@@ -150,7 +150,7 @@ const getBalanceProps = (
   balances[currencyCfg.id] &&
   (txType !== 'withdraw' || currencyCfg.role !== CurrencyRole.Governable)
     ? { balance: balances[currencyCfg.id] }
-    : undefined;
+    : { balance: 0 };
 
 const getBadgeProps = (
   currencyCfg: CurrencyConfig,


### PR DESCRIPTION
## Summary of changes
- Show's zero balance instead of yellow warning badge.

### Proposed area of change
_Put an `x` in the boxes that apply._

- [x] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [x] `libs/webb-ui-components`

### Reference issue to close (if applicable)
- Closes #1710 

### Screen Recording
_If possible provide a screen recording of proposed change._
<img width="538" alt="image" src="https://github.com/webb-tools/webb-dapp/assets/13153687/9a8386b9-12ea-462e-9b2b-c33575a4bd46">


-----
### Code Checklist 
_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
