### PR TITLE
Adds faucet banner link to bridge dapp

### DIFF
--- a/apps/bridge-dapp/src/containers/Layout/Layout.tsx
+++ b/apps/bridge-dapp/src/containers/Layout/Layout.tsx
@@ -8,7 +8,7 @@ import cx from 'classnames';
 import { FC, useState } from 'react';
 import { Outlet } from 'react-router';
 import { Header } from '../../components/Header';
-import { WEBB_DAPP_NEW_ISSUE_URL } from '../../constants';
+import { WEBB_FAUCET_URL } from '../../constants';
 import sidebarProps from '../../constants/sidebar';
 
 const heightClsx = cx('h-screen');
@@ -25,38 +25,31 @@ export const Layout: FC<{ children?: React.ReactNode }> = ({ children }) => {
       <div className={cx('flex', heightClsx)}>
         <SideBar {...sidebarProps} className="hidden lg:flex" />
 
-        <div className="flex flex-col justify-between w-full gap-6 px-4 mx-auto overflow-y-auto">
+        <div className="flex flex-col justify-between w-full gap-6 mx-auto overflow-y-auto">
+          <Transition show={showBanner}>
+            <Banner
+              className="py-2"
+              onClose={onCloseHandler}
+              dappName="bridge"
+              buttonText="ACCESS FAUCET"
+              bannerText="Explore Hubble Bridge Beta, get test tokens to experience private bridging."
+              buttonProps={{
+                href: WEBB_FAUCET_URL,
+                target: '_blank',
+              }}
+            />
+          </Transition>
+
           <div className="space-y-6 max-w-[1565px] mx-auto w-full">
             <Header />
+
             <main className="w-full">
               <Outlet />
             </main>
           </div>
-
           <Footer isMinimal className="w-full py-12 mx-auto" />
         </div>
       </div>
-
-      <Transition
-        show={showBanner}
-        className={cx(
-          'hidden lg:block [transform-style:preserve-3d] origin-top duration-300 h-[60px]'
-        )}
-        leaveFrom={cx('[transform:rotateX(0deg)]', 'h-[60px]')}
-        leaveTo={cx('[transform:rotateX(-180deg)]', 'h-0')}
-      >
-        <Banner
-          className="[backface-visibility:hidden] h-full"
-          onClose={onCloseHandler}
-          dappName="stats"
-          buttonText="Report Bug"
-          bannerText="Hubble Bridge is in beta version."
-          buttonProps={{
-            href: WEBB_DAPP_NEW_ISSUE_URL,
-            target: '_blank',
-          }}
-        />
-      </Transition>
     </div>
   );
 };

--- a/libs/webb-ui-components/src/components/Banner/Banner.tsx
+++ b/libs/webb-ui-components/src/components/Banner/Banner.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { twMerge } from 'tailwind-merge';
 import { Button } from '../buttons';
 import { BannerPropsType } from './types';
-import { BlockIcon, Close, GraphIcon } from '@webb-tools/icons';
+import { Close, GraphIcon, ContrastTwoLine } from '@webb-tools/icons';
 import { Typography } from '../../typography';
 
 /**
@@ -59,9 +59,9 @@ export const Banner = React.forwardRef<HTMLDivElement, BannerPropsType>(
         <span className="flex items-center">
           {dappName === 'bridge' ? (
             <span className="mr-2">
-              <BlockIcon
+              <ContrastTwoLine
                 size="lg"
-                className="stroke-blue-70 dark:stroke-mono-0"
+                className="fill-blue-70 dark:fill-mono-0"
               />
             </span>
           ) : dappName === 'stats' ? (

--- a/libs/webb-ui-components/src/components/SideBar/SideBar.tsx
+++ b/libs/webb-ui-components/src/components/SideBar/SideBar.tsx
@@ -91,24 +91,6 @@ export const SideBar = forwardRef<HTMLDivElement, SidebarProps>(
             className={isSidebarOpen ? 'p-2' : 'pl-1'}
           />
         </div>
-
-        {isHovering && (
-          <div
-            className="absolute top-0 right-0 px-3 pt-12"
-            style={{ transform: 'translateX(100%)' }}
-          >
-            <div
-              onClick={() => setIsSidebarOpen(!isSidebarOpen)}
-              className="p-1 rounded-full shadow-lg cursor-pointer bg-mono-0 dark:bg-mono-180"
-            >
-              {isSidebarOpen ? (
-                <ChevronLeft size="md" />
-              ) : (
-                <ChevronRight size="md" />
-              )}
-            </div>
-          </div>
-        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary of changes

- Adds banner on the hubble bridge to open faucet.
- Removes sidenav chevron on hover (open & close sidenav control).

### Proposed area of change

- [x] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [x] `libs/webb-ui-components`

### Reference issue to close (if applicable)

- Closes #1712 

### Screen Recording

https://github.com/webb-tools/webb-dapp/assets/53374218/07de0e06-4ba5-45bb-9e40-76560ab493f8