### PR TITLE
Improve balance display across all flows on Hubble Bridge

### DIFF
--- a/apps/bridge-dapp/src/containers/TxInfoContainer/TxInfoContainer.tsx
+++ b/apps/bridge-dapp/src/containers/TxInfoContainer/TxInfoContainer.tsx
@@ -4,16 +4,12 @@ import ShieldKeyholeFillIcon from '@webb-tools/icons/ShieldKeyholeFillIcon';
 
 const TxInfoContainer = ({
   hasRefund,
-  receivingAmount,
-  receivingToken,
   refundAmount,
   refundToken,
   remaining,
   remainingToken,
 }: {
   hasRefund?: boolean;
-  receivingAmount?: number;
-  receivingToken?: string;
   refundAmount?: string;
   refundToken?: string;
   remaining?: number;
@@ -21,21 +17,6 @@ const TxInfoContainer = ({
 }) => {
   return (
     <div className="space-y-2">
-      <TxInfoItem
-        leftContent={{
-          title: 'Receiving',
-        }}
-        rightIcon={<WalletFillIcon />}
-        rightText={
-          typeof receivingAmount === 'number'
-            ? receivingAmount < 0
-              ? '< 0'
-              : `${receivingAmount.toString().slice(0, 10)} ${
-                  receivingToken ?? ''
-                }`.trim()
-            : '--'
-        }
-      />
       {refundAmount && hasRefund && (
         <TxInfoItem
           leftContent={{

--- a/apps/bridge-dapp/src/pages/Hubble/Bridge/Transfer/index.tsx
+++ b/apps/bridge-dapp/src/pages/Hubble/Bridge/Transfer/index.tsx
@@ -247,7 +247,7 @@ const Transfer = () => {
               <TransactionInputCard.ChainSelector
                 onClick={() => handleChainClick()}
               />
-              <TransactionInputCard.MaxAmountButton />
+              <TransactionInputCard.MaxAmountButton accountType="note" />
             </TransactionInputCard.Header>
 
             <TransactionInputCard.Body
@@ -263,7 +263,7 @@ const Transfer = () => {
           <TransactionInputCard.Root
             typedChainId={destTypedChainId ?? undefined}
             tokenSymbol={fungibleCfg?.symbol}
-            amount={amount}
+            amount={receivingAmount?.toString().slice(0, 10)}
             onAmountChange={setAmount}
           >
             <TransactionInputCard.Header>
@@ -380,8 +380,6 @@ const Transfer = () => {
               refundToken={destChainCfg?.nativeCurrency.symbol}
               remaining={remainingBalance}
               remainingToken={fungibleCfg?.symbol}
-              receivingAmount={receivingAmount}
-              receivingToken={fungibleCfg?.symbol}
             />
           </div>
 

--- a/apps/bridge-dapp/src/pages/Hubble/Bridge/Withdraw/index.tsx
+++ b/apps/bridge-dapp/src/pages/Hubble/Bridge/Withdraw/index.tsx
@@ -233,7 +233,10 @@ const Withdraw = () => {
           >
             <TransactionInputCard.Header>
               <TransactionInputCard.ChainSelector onClick={handleChainClick} />
-              <TransactionInputCard.MaxAmountButton />
+              <TransactionInputCard.MaxAmountButton
+                accountType="note"
+                disabled={!isCustom}
+              />
             </TransactionInputCard.Header>
 
             <TransactionInputCard.Body
@@ -260,9 +263,8 @@ const Withdraw = () => {
           <TransactionInputCard.Root
             typedChainId={srcTypedChainId ?? undefined}
             tokenSymbol={wrappableCfg?.symbol}
-            amount={amount}
+            amount={receivingAmount?.toString().slice(0, 10)}
             onAmountChange={setAmount}
-            isFixedAmount={!isCustom}
             onIsFixedAmountChange={() => setCustomAmount(!isCustom)}
           >
             <TransactionInputCard.Header>
@@ -278,10 +280,6 @@ const Withdraw = () => {
             <TransactionInputCard.Body
               tokenSelectorProps={{
                 onClick: () => handleTokenClick(),
-              }}
-              fixedAmountProps={{
-                isDisabled: true,
-                step: 0.01,
               }}
               customAmountProps={{
                 isDisabled: true,
@@ -399,8 +397,6 @@ const Withdraw = () => {
               refundToken={activeChain?.nativeCurrency.symbol}
               remaining={remainingBalance}
               remainingToken={fungibleCfg?.symbol}
-              receivingAmount={receivingAmount}
-              receivingToken={wrappableCfg?.symbol}
             />
           </div>
 

--- a/libs/webb-ui-components/src/components/TransactionInputCard/TransactionInputCard.tsx
+++ b/libs/webb-ui-components/src/components/TransactionInputCard/TransactionInputCard.tsx
@@ -21,6 +21,7 @@ import { Typography } from '../../typography';
 import { getRoundedAmountString, toFixed } from '../../utils';
 import { AdjustAmount } from '../BridgeInputs';
 import { Switcher } from '../Switcher';
+import { Tooltip, TooltipTrigger, TooltipBody } from '../Tooltip';
 import TextField from '../TextField';
 import { TitleWithInfo } from '../TitleWithInfo';
 import TokenSelector from '../TokenSelector';
@@ -177,6 +178,7 @@ const TransactionMaxAmountButton = forwardRef<
       maxAmount: maxAmountProp,
       accountType: accountTypeProp,
       onAmountChange: onAmountChangeProp,
+      disabled: disabledProp,
       ...props
     },
     ref
@@ -197,32 +199,45 @@ const TransactionMaxAmountButton = forwardRef<
       return `${fmtAmount} ${tokenSym}`.trim();
     }, [maxAmount, tokenSymbol]);
 
+    const disabled = useMemo(
+      () => disabledProp ?? typeof maxAmount !== 'number',
+      [disabledProp, maxAmount]
+    );
+
     return (
-      <TransactionButton
-        {...props}
-        ref={ref}
-        disabled={props.disabled ?? typeof maxAmount !== 'number'}
-        onClick={
-          typeof maxAmount === 'number'
-            ? () => onAmountChange?.(`${toFixed(maxAmount, 5)}`)
-            : undefined
-        }
-        Icon={
-          accountType === 'note' ? (
-            <>
-              <ShieldKeyholeLineIcon className="!fill-current group-hover:group-enabled:hidden group-disabled:hidden" />
-              <ShieldKeyholeFillIcon className="!fill-current hidden group-hover:group-enabled:block group-disabled:block" />
-            </>
-          ) : (
-            <>
-              <WalletLineIcon className="!fill-current group-hover:group-enabled:hidden group-disabled:hidden" />
-              <WalletFillIcon className="!fill-current hidden group-hover:group-enabled:block group-disabled:block" />
-            </>
-          )
-        }
-      >
-        {buttonCnt}
-      </TransactionButton>
+      <Tooltip>
+        <TooltipTrigger>
+          <TransactionButton
+            {...props}
+            ref={ref}
+            disabled={disabled}
+            onClick={
+              typeof maxAmount === 'number'
+                ? () => onAmountChange?.(`${toFixed(maxAmount, 5)}`)
+                : undefined
+            }
+            Icon={
+              accountType === 'note' ? (
+                <>
+                  <ShieldKeyholeLineIcon className="!fill-current group-hover:group-enabled:hidden group-disabled:hidden" />
+                  <ShieldKeyholeFillIcon className="!fill-current hidden group-hover:group-enabled:block group-disabled:block" />
+                </>
+              ) : (
+                <>
+                  <WalletLineIcon className="!fill-current group-hover:group-enabled:hidden group-disabled:hidden" />
+                  <WalletFillIcon className="!fill-current hidden group-hover:group-enabled:block group-disabled:block" />
+                </>
+              )
+            }
+            className={disabled ? 'cursor-not-allowed' : ''}
+          >
+            {buttonCnt}
+          </TransactionButton>
+        </TooltipTrigger>
+        <TooltipBody>
+          {accountType === 'note' ? 'Shielded Balance' : 'Wallet Balance'}
+        </TooltipBody>
+      </Tooltip>
     );
   }
 );


### PR DESCRIPTION
## Summary of changes
_Provide a detailed description of proposed changes._
- Deposit: Replace `wallet balance` with `shielded balance` in `destination transaction input`
- Transfer: replace `amount input` with the `remaining amount` (amount input - fees) in `destination transaction input`
- Withdraw: same as Transfer + disable MaxAmountButton in `source transaction input` when in fixed amount mode
- Remove the remaining amount in `TxInfoContainer`

### Proposed area of change
_Put an `x` in the boxes that apply._

- [x] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [ ] `apps/webbsite`
- [ ] `apps/faucet`
- [ ] `apps/tangle-website`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)
_Specify any issues that can be closed from these changes (e.g. Closes #233)._
- Closes #1727 

### Screen Recording
_If possible provide a screen recording of proposed change._

https://github.com/webb-tools/webb-dapp/assets/69841784/b07990e3-a6af-4743-9d6e-4d76f32ebd58

-----
### Code Checklist 
_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
