### PR TITLE
Align Margins and Width in Hubble Bridge and Hubble Statistics

### DIFF
--- a/apps/bridge-dapp/src/components/Header/Header.tsx
+++ b/apps/bridge-dapp/src/components/Header/Header.tsx
@@ -48,7 +48,7 @@ export const Header: FC<HeaderProps> = () => {
   const items = location.pathname.split('/').filter((item) => item !== '');
 
   return (
-    <header className="flex justify-between py-4">
+    <header className="flex justify-between pt-6 pb-4">
       <div className="flex items-center gap-2">
         <SideBarMenu
           {...sidebarProps}

--- a/apps/bridge-dapp/src/containers/Layout/Layout.tsx
+++ b/apps/bridge-dapp/src/containers/Layout/Layout.tsx
@@ -40,7 +40,7 @@ export const Layout: FC<{ children?: React.ReactNode }> = ({ children }) => {
             />
           </Transition>
 
-          <div className="px-3 md:!px-5 lg:!px-10">
+          <div className="flex-1 px-3 md:!px-5 lg:!px-10">
             <div className="max-w-[1565px] mx-auto w-full h-full flex flex-col justify-between">
               <div className="space-y-6">
                 <Header />

--- a/apps/bridge-dapp/src/containers/Layout/Layout.tsx
+++ b/apps/bridge-dapp/src/containers/Layout/Layout.tsx
@@ -5,7 +5,7 @@ import {
   SideBar,
 } from '@webb-tools/webb-ui-components/components';
 import cx from 'classnames';
-import { FC, useState } from 'react';
+import { type FC, useState } from 'react';
 import { Outlet } from 'react-router';
 import { Header } from '../../components/Header';
 import { WEBB_FAUCET_URL } from '../../constants';
@@ -25,7 +25,12 @@ export const Layout: FC<{ children?: React.ReactNode }> = ({ children }) => {
       <div className={cx('flex', heightClsx)}>
         <SideBar {...sidebarProps} className="hidden lg:flex" />
 
-        <div className="flex flex-col w-full mx-auto overflow-y-auto">
+        <div
+          className={cx(
+            'flex flex-col w-full mx-auto overflow-y-auto',
+            'px-3 md:!px-5 lg:!px-10'
+          )}
+        >
           <Transition show={showBanner} className="hidden lg:!block">
             <Banner
               className="py-2"
@@ -43,8 +48,7 @@ export const Layout: FC<{ children?: React.ReactNode }> = ({ children }) => {
           <div
             className={cx(
               'max-w-[1565px] mx-auto w-full h-full',
-              'flex flex-col justify-between',
-              'px-3 md:!px-5 lg:!px-10'
+              'flex flex-col justify-between'
             )}
           >
             <div className="space-y-6">

--- a/apps/bridge-dapp/src/containers/Layout/Layout.tsx
+++ b/apps/bridge-dapp/src/containers/Layout/Layout.tsx
@@ -25,12 +25,7 @@ export const Layout: FC<{ children?: React.ReactNode }> = ({ children }) => {
       <div className={cx('flex', heightClsx)}>
         <SideBar {...sidebarProps} className="hidden lg:flex" />
 
-        <div
-          className={cx(
-            'flex flex-col w-full mx-auto overflow-y-auto',
-            'px-3 md:!px-5 lg:!px-10'
-          )}
-        >
+        <div className="flex flex-col w-full mx-auto overflow-y-auto px-3 md:!px-5 lg:!px-10">
           <Transition show={showBanner} className="hidden lg:!block">
             <Banner
               className="py-2"
@@ -45,12 +40,7 @@ export const Layout: FC<{ children?: React.ReactNode }> = ({ children }) => {
             />
           </Transition>
 
-          <div
-            className={cx(
-              'max-w-[1565px] mx-auto w-full h-full',
-              'flex flex-col justify-between'
-            )}
-          >
+          <div className="max-w-[1565px] mx-auto w-full h-full flex flex-col justify-between">
             <div className="space-y-6">
               <Header />
 

--- a/apps/bridge-dapp/src/containers/Layout/Layout.tsx
+++ b/apps/bridge-dapp/src/containers/Layout/Layout.tsx
@@ -25,7 +25,7 @@ export const Layout: FC<{ children?: React.ReactNode }> = ({ children }) => {
       <div className={cx('flex', heightClsx)}>
         <SideBar {...sidebarProps} className="hidden lg:flex" />
 
-        <div className="flex flex-col w-full mx-auto overflow-y-auto px-3 md:!px-5 lg:!px-10">
+        <div className="flex flex-col w-full mx-auto overflow-y-auto">
           <Transition show={showBanner} className="hidden lg:!block">
             <Banner
               className="py-2"
@@ -40,16 +40,18 @@ export const Layout: FC<{ children?: React.ReactNode }> = ({ children }) => {
             />
           </Transition>
 
-          <div className="max-w-[1565px] mx-auto w-full h-full flex flex-col justify-between">
-            <div className="space-y-6">
-              <Header />
+          <div className="px-3 md:!px-5 lg:!px-10">
+            <div className="max-w-[1565px] mx-auto w-full h-full flex flex-col justify-between">
+              <div className="space-y-6">
+                <Header />
 
-              <main className="w-full">
-                <Outlet />
-              </main>
+                <main className="w-full">
+                  <Outlet />
+                </main>
+              </div>
+
+              <Footer isMinimal className="w-full py-12" />
             </div>
-
-            <Footer isMinimal className="w-full py-12" />
           </div>
         </div>
       </div>

--- a/apps/bridge-dapp/src/containers/Layout/Layout.tsx
+++ b/apps/bridge-dapp/src/containers/Layout/Layout.tsx
@@ -40,7 +40,13 @@ export const Layout: FC<{ children?: React.ReactNode }> = ({ children }) => {
             />
           </Transition>
 
-          <div className="max-w-[1565px] mx-auto w-full h-full flex flex-col justify-between px-4">
+          <div
+            className={cx(
+              'max-w-[1565px] mx-auto w-full h-full',
+              'flex flex-col justify-between',
+              'px-3 md:!px-5 lg:!px-10'
+            )}
+          >
             <div className="space-y-6">
               <Header />
 

--- a/apps/bridge-dapp/src/pages/Hubble/Bridge/index.tsx
+++ b/apps/bridge-dapp/src/pages/Hubble/Bridge/index.tsx
@@ -11,7 +11,7 @@ import {
   Typography,
   useWebbUI,
 } from '@webb-tools/webb-ui-components';
-import { DKG_STATS_URL } from '@webb-tools/webb-ui-components/constants';
+import { HUBBLE_STATS_URL } from '@webb-tools/webb-ui-components/constants';
 import cx from 'classnames';
 import { FC, useCallback, useMemo, useState } from 'react';
 import { Outlet } from 'react-router-dom';
@@ -196,7 +196,7 @@ const Bridge: FC = () => {
           <Outlet />
 
           <a
-            href={DKG_STATS_URL}
+            href={HUBBLE_STATS_URL}
             target="_blank"
             rel="noreferrer"
             className={cx(

--- a/apps/hubble-stats/containers/Layout/Layout.tsx
+++ b/apps/hubble-stats/containers/Layout/Layout.tsx
@@ -10,8 +10,8 @@ const Layout: FC<PropsWithChildren> = ({ children }) => {
   return (
     <>
       <SideBar isExpandedAtDefault={isSideBarInitiallyExpanded} />
-      <main className="flex flex-col justify-between flex-1 h-full px-3 overflow-y-auto md:px-5 lg:px-10">
-        <div className="flex-[1]">
+      <main className="flex-1 h-full px-3 overflow-y-auto md:px-5 lg:px-10">
+        <div className="mx-auto max-w-[1565px]">
           {/* Header */}
           <div className="flex items-center justify-between pt-6 pb-4">
             <div className="flex items-center gap-2">
@@ -24,10 +24,10 @@ const Layout: FC<PropsWithChildren> = ({ children }) => {
 
           {/* Body */}
           {children}
-        </div>
 
-        {/* Footer */}
-        <Footer isMinimal className="py-12 mx-0 max-w-none" />
+          {/* Footer */}
+          <Footer isMinimal className="py-12 w-full" />
+        </div>
       </main>
     </>
   );

--- a/apps/hubble-stats/containers/Layout/Layout.tsx
+++ b/apps/hubble-stats/containers/Layout/Layout.tsx
@@ -11,19 +11,21 @@ const Layout: FC<PropsWithChildren> = ({ children }) => {
     <>
       <SideBar isExpandedAtDefault={isSideBarInitiallyExpanded} />
       <main className="flex-1 h-full px-3 overflow-y-auto md:px-5 lg:px-10">
-        <div className="mx-auto max-w-[1565px]">
-          {/* Header */}
-          <div className="flex items-center justify-between pt-6 pb-4">
-            <div className="flex items-center gap-2">
-              <SideBarMenu />
-              <Breadcrumbs />
+        <div className="h-full flex flex-col justify-between mx-auto max-w-[1565px]">
+          <div>
+            {/* Header */}
+            <div className="flex items-center justify-between pt-6 pb-4">
+              <div className="flex items-center gap-2">
+                <SideBarMenu />
+                <Breadcrumbs />
+              </div>
+
+              <HeaderChipsContainer />
             </div>
 
-            <HeaderChipsContainer />
+            {/* Body */}
+            {children}
           </div>
-
-          {/* Body */}
-          {children}
 
           {/* Footer */}
           <Footer isMinimal className="py-12 w-full" />


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._
- Align Margins and Width in Hubble Bridge and Hubble Statistics
- Minor UI Update on Bridge
- Navigate to Hubble Stats instead of DKG Stats when it 'Explore Stats' button on bridge

### Proposed area of change

_Put an `x` in the boxes that apply._

- [x] `apps/bridge-dapp`
- [x] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [ ] `apps/tangle-dapp`
- [ ] `apps/faucet`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. Closes #233)._

- Closes #1616

### Screen Recording

_If possible provide a screen recording of proposed change._

https://github.com/webb-tools/webb-dapp/assets/69841784/33ed3c73-b581-4f4f-8933-0e2568b7e727

https://github.com/webb-tools/webb-dapp/assets/69841784/7211c993-d142-44f9-9d43-a9455e19936b

---

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
