### PR TITLE
Fix Decimal input in amount field gets auto-deleted

### DIFF
--- a/apps/bridge-dapp/src/hooks/useAmountWithRoute.ts
+++ b/apps/bridge-dapp/src/hooks/useAmountWithRoute.ts
@@ -48,6 +48,13 @@ const useAmountWithRoute = (key = AMOUNT_KEY) => {
         return;
       }
 
+      // users need to type 0.00 before getting to 0.001
+      // we need to check for zero number (ex: 0.00, .00, 00.0) to prevent the input to reset to 0 in those cases
+      const zeroNumberRegex = /^0*\.0*$/;
+      if (zeroNumberRegex.test(amount)) {
+        return;
+      }
+
       try {
         setAmountParam(parseEther(amount).toString());
       } catch (error) {


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Fix "Decimal input in amount field gets auto-deleted" in Bridge

### Proposed area of change

_Put an `x` in the boxes that apply._

- [x] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [ ] `apps/tangle-dapp`
- [ ] `apps/faucet`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. Closes #233)._

- Closes #1737 

### Screen Recording

_If possible provide a screen recording of proposed change._

https://github.com/webb-tools/webb-dapp/assets/69841784/5ccd4964-7519-4aa2-95d2-4e822da83ef9

---

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
