### PR TITLE
EVM Staking - Initial Delegations & Payouts Table

### DIFF
--- a/apps/tangle-dapp/app/page.tsx
+++ b/apps/tangle-dapp/app/page.tsx
@@ -1,6 +1,7 @@
 import { Typography } from '@webb-tools/webb-ui-components';
 
 import {
+  DelegationsPayoutsContainer,
   HeaderChipsContainer,
   KeyStatsContainer,
   NominatorStatsContainer,
@@ -24,6 +25,10 @@ export default async function Index() {
 
       <div className="mt-12">
         <NominatorStatsContainer />
+      </div>
+
+      <div className="mt-12">
+        <DelegationsPayoutsContainer />
       </div>
 
       <div className="mt-12">

--- a/apps/tangle-dapp/components/DelegatorTable/DelegatorTable.tsx
+++ b/apps/tangle-dapp/components/DelegatorTable/DelegatorTable.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { ExternalLinkLine } from '@webb-tools/icons';
+import {
+  Avatar,
+  Chip,
+  fuzzyFilter,
+  shortenString,
+  Table,
+  Typography,
+} from '@webb-tools/webb-ui-components';
+import { TANGLE_STAKING_URL } from '@webb-tools/webb-ui-components/constants';
+import { type FC, useCallback } from 'react';
+
+import { Delegator } from '../../types';
+import { HeaderCell, StringCell } from '../tableCells';
+import { DelegatorTableProps } from './types';
+
+const columnHelper = createColumnHelper<Delegator>();
+
+const columns = [
+  columnHelper.accessor('address', {
+    header: () => <HeaderCell title="Validator" className="justify-start" />,
+    cell: (props) => {
+      const address = props.getValue();
+      const identity = props.row.original.identity;
+
+      return (
+        <div className="flex space-x-1 items-center">
+          <Avatar sourceVariant="address" value={address}>
+            {address}
+          </Avatar>
+
+          <Typography variant="body1" fw="normal" className="truncate">
+            {identity === address ? shortenString(address, 6) : identity}
+          </Typography>
+
+          <ExternalLinkLine />
+        </div>
+      );
+    },
+  }),
+  columnHelper.accessor('isActive', {
+    header: () => <HeaderCell title="Status" className="justify-start" />,
+    cell: (props) => {
+      const isActive = props.getValue();
+      return (
+        <Chip color={isActive ? 'green' : 'blue'}>
+          {isActive ? 'Active' : 'Waiting'}
+        </Chip>
+      );
+    },
+  }),
+  columnHelper.accessor('totalStaked', {
+    header: () => (
+      <HeaderCell title="Delegated/Staked" className="justify-center" />
+    ),
+    cell: (props) => (
+      <StringCell value={props.getValue()} className="text-center" />
+    ),
+  }),
+];
+
+const DelegatorTable: FC<DelegatorTableProps> = ({ data = [], pageSize }) => {
+  const table = useReactTable({
+    data,
+    columns,
+    initialState: {
+      pagination: {
+        pageSize,
+      },
+    },
+    filterFns: {
+      fuzzy: fuzzyFilter,
+    },
+    globalFilterFn: fuzzyFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  });
+
+  const onRowClick = useCallback(() => {
+    window.open(TANGLE_STAKING_URL, '_blank');
+  }, []);
+
+  return (
+    <div className="overflow-hidden border rounded-lg bg-mono-0 dark:bg-mono-180 border-mono-40 dark:border-mono-160">
+      <Table
+        tableClassName="block overflow-x-auto max-w-[-moz-fit-content] max-w-fit md:table md:max-w-none"
+        thClassName="border-t-0 bg-mono-0"
+        trClassName="cursor-pointer"
+        paginationClassName="bg-mono-0 dark:bg-mono-180 pl-6"
+        tableProps={table}
+        isPaginated
+        totalRecords={data.length}
+        onRowClick={onRowClick}
+      />
+    </div>
+  );
+};
+
+export default DelegatorTable;

--- a/apps/tangle-dapp/components/DelegatorTable/index.ts
+++ b/apps/tangle-dapp/components/DelegatorTable/index.ts
@@ -1,0 +1,1 @@
+export { default as DelegatorTable } from './DelegatorTable';

--- a/apps/tangle-dapp/components/DelegatorTable/types.ts
+++ b/apps/tangle-dapp/components/DelegatorTable/types.ts
@@ -1,0 +1,6 @@
+import { Delegator } from '../../types';
+
+export interface DelegatorTableProps {
+  data?: Delegator[];
+  pageSize: number;
+}

--- a/apps/tangle-dapp/components/TableStatus/TableStatus.tsx
+++ b/apps/tangle-dapp/components/TableStatus/TableStatus.tsx
@@ -38,7 +38,7 @@ const TableStatus = ({
         </Typography>
       </div>
 
-      <Button {...buttonProps}>{buttonText}</Button>
+      {buttonText && <Button {...buttonProps}>{buttonText}</Button>}
     </div>
   );
 };

--- a/apps/tangle-dapp/components/TableStatus/TableStatus.tsx
+++ b/apps/tangle-dapp/components/TableStatus/TableStatus.tsx
@@ -1,0 +1,46 @@
+import { Button, Typography } from '@webb-tools/webb-ui-components';
+import { twMerge } from 'tailwind-merge';
+
+import { TableStatusProps } from './types';
+
+const TableStatus = ({
+  title,
+  description,
+  icon,
+  buttonText,
+  buttonProps,
+  className,
+}: TableStatusProps) => {
+  return (
+    <div
+      className={twMerge(
+        'rounded-lg border border-mono-40 dark:border-mono-160',
+        'bg-mono-0 dark:bg-mono-180 h-[228px]',
+        'flex flex-col items-center justify-center gap-6 p-8',
+        className
+      )}
+    >
+      <div className="flex flex-col items-center justify-center gap-2">
+        {icon}
+        <Typography
+          variant="h5"
+          fw="bold"
+          className="text-mono-200 dark:text-mono-0 text-center"
+        >
+          {title}
+        </Typography>
+        <Typography
+          variant="body1"
+          fw="semibold"
+          className="text-mono-120 dark:text-mono-80 text-center"
+        >
+          {description}
+        </Typography>
+      </div>
+
+      <Button {...buttonProps}>{buttonText}</Button>
+    </div>
+  );
+};
+
+export default TableStatus;

--- a/apps/tangle-dapp/components/TableStatus/index.ts
+++ b/apps/tangle-dapp/components/TableStatus/index.ts
@@ -1,0 +1,1 @@
+export { default as TableStatus } from './TableStatus';

--- a/apps/tangle-dapp/components/TableStatus/types.ts
+++ b/apps/tangle-dapp/components/TableStatus/types.ts
@@ -1,0 +1,10 @@
+import { ButtonProps } from '@webb-tools/webb-ui-components';
+
+export type TableStatusProps = {
+  icon?: string;
+  title: string;
+  description: string;
+  buttonText: string;
+  buttonProps?: ButtonProps;
+  className?: string;
+};

--- a/apps/tangle-dapp/components/TableStatus/types.ts
+++ b/apps/tangle-dapp/components/TableStatus/types.ts
@@ -4,7 +4,7 @@ export type TableStatusProps = {
   icon?: string;
   title: string;
   description: string;
-  buttonText: string;
+  buttonText?: string;
   buttonProps?: ButtonProps;
   className?: string;
 };

--- a/apps/tangle-dapp/components/index.ts
+++ b/apps/tangle-dapp/components/index.ts
@@ -6,5 +6,6 @@ export * from './KeyStatsItem';
 export * from './NominatorStatsItem';
 export * from './sideBar';
 export * from './skeleton';
+export * from './TableStatus';
 export * from './ValidatorTable';
 export * from './WalletDropdown';

--- a/apps/tangle-dapp/components/index.ts
+++ b/apps/tangle-dapp/components/index.ts
@@ -1,5 +1,6 @@
 export * from './Breadcrumbs';
 export * from './ChainSelector';
+export * from './DelegatorTable';
 export * from './HeaderChip';
 export * from './InfoIconWithTooltip';
 export * from './KeyStatsItem';

--- a/apps/tangle-dapp/containers/DelegationsPayoutsContainer/DelegationsPayoutsContainer.tsx
+++ b/apps/tangle-dapp/containers/DelegationsPayoutsContainer/DelegationsPayoutsContainer.tsx
@@ -10,14 +10,29 @@ import {
   TableAndChartTabs,
   useCheckMobile,
 } from '@webb-tools/webb-ui-components';
+import { TANGLE_STAKING_URL } from '@webb-tools/webb-ui-components/constants';
+import { useMemo } from 'react';
 
 import { ContainerSkeleton, TableStatus } from '../../components';
+import useDelegations from '../../data/DelegationsPayouts/useDelegations';
+import { convertEthereumToSubstrateAddress } from '../../utils';
+import DelegatorTableContainer from './DelegatorTableContainer';
 
+const pageSize = 5;
 const delegationsTableTab = 'Delegations';
 const payoutsTableTab = 'Payouts';
 
 const DelegationsPayoutsContainer = () => {
   const { activeAccount, loading } = useWebContext();
+
+  const nominatorSubstrateAddress = useMemo(() => {
+    if (!activeAccount?.address) return '';
+
+    return convertEthereumToSubstrateAddress(activeAccount.address);
+  }, [activeAccount?.address]);
+
+  const { data: delegatorsData, isLoading: delegatorsIsLoading } =
+    useDelegations(nominatorSubstrateAddress);
 
   const { isMobile } = useCheckMobile();
 
@@ -47,13 +62,28 @@ const DelegationsPayoutsContainer = () => {
             }}
             icon="🔗"
           />
-        ) : (
+        ) : delegatorsIsLoading ? (
           <ContainerSkeleton />
-        )}
+        ) : delegatorsData && delegatorsData.delegators.length === 0 ? (
+          <TableStatus
+            title="Ready to Explore Delegations?"
+            description="It looks like you haven't delegated any tokens yet. Start by choosing a validator to support and earn rewards!"
+            buttonText="Delegate"
+            buttonProps={{
+              isDisabled: true,
+            }}
+            icon="🔍"
+          />
+        ) : delegatorsData ? (
+          <DelegatorTableContainer
+            value={delegatorsData.delegators}
+            pageSize={pageSize}
+          />
+        ) : null}
       </TabContent>
 
       {/* Payouts Table */}
-      <TabContent value={payoutsTableTab}>
+      <TabContent value={payoutsTableTab} aria-disabled>
         {!activeAccount ? (
           <TableStatus
             title="Wallet Not Connected"
@@ -72,7 +102,15 @@ const DelegationsPayoutsContainer = () => {
             icon="🔗"
           />
         ) : (
-          <ContainerSkeleton />
+          <TableStatus
+            title="Work In Progress"
+            description="This feature is currently under development."
+            buttonText="View Network"
+            buttonProps={{
+              onClick: () => window.open(TANGLE_STAKING_URL, '_blank'),
+            }}
+            icon="🔧"
+          />
         )}
       </TabContent>
     </TableAndChartTabs>

--- a/apps/tangle-dapp/containers/DelegationsPayoutsContainer/DelegationsPayoutsContainer.tsx
+++ b/apps/tangle-dapp/containers/DelegationsPayoutsContainer/DelegationsPayoutsContainer.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import {
+  useConnectWallet,
+  useWebContext,
+} from '@webb-tools/api-provider-environment';
+import { PresetTypedChainId } from '@webb-tools/dapp-types';
+import {
+  TabContent,
+  TableAndChartTabs,
+  useCheckMobile,
+} from '@webb-tools/webb-ui-components';
+
+import { ContainerSkeleton, TableStatus } from '../../components';
+
+const delegationsTableTab = 'Delegations';
+const payoutsTableTab = 'Payouts';
+
+const DelegationsPayoutsContainer = () => {
+  const { activeAccount, loading } = useWebContext();
+
+  const { isMobile } = useCheckMobile();
+
+  const { toggleModal } = useConnectWallet();
+
+  return (
+    <TableAndChartTabs
+      tabs={[delegationsTableTab, payoutsTableTab]}
+      headerClassName="w-full overflow-x-auto"
+    >
+      {/* Delegations Table */}
+      <TabContent value={delegationsTableTab}>
+        {!activeAccount ? (
+          <TableStatus
+            title="Wallet Not Connected"
+            description="Connect your wallet to view and manage your staking details."
+            buttonText="Connect"
+            buttonProps={{
+              isLoading: loading,
+              isDisabled: isMobile,
+              loadingText: 'Connecting...',
+              onClick: () =>
+                toggleModal(
+                  true,
+                  PresetTypedChainId.TangleTestnet ?? undefined
+                ),
+            }}
+            icon="🔗"
+          />
+        ) : (
+          <ContainerSkeleton />
+        )}
+      </TabContent>
+
+      {/* Payouts Table */}
+      <TabContent value={payoutsTableTab}>
+        {!activeAccount ? (
+          <TableStatus
+            title="Wallet Not Connected"
+            description="Connect your wallet to view and manage your staking details."
+            buttonText="Connect"
+            buttonProps={{
+              isLoading: loading,
+              isDisabled: isMobile,
+              loadingText: 'Connecting...',
+              onClick: () =>
+                toggleModal(
+                  true,
+                  PresetTypedChainId.TangleTestnet ?? undefined
+                ),
+            }}
+            icon="🔗"
+          />
+        ) : (
+          <ContainerSkeleton />
+        )}
+      </TabContent>
+    </TableAndChartTabs>
+  );
+};
+
+export default DelegationsPayoutsContainer;

--- a/apps/tangle-dapp/containers/DelegationsPayoutsContainer/DelegatorTableContainer.tsx
+++ b/apps/tangle-dapp/containers/DelegationsPayoutsContainer/DelegatorTableContainer.tsx
@@ -1,0 +1,12 @@
+import { DelegatorTable } from '../../components';
+import { Delegator } from '../../types';
+
+export default function DelegatorTableContainer({
+  pageSize,
+  value,
+}: {
+  pageSize: number;
+  value: Delegator[];
+}) {
+  return <DelegatorTable data={value} pageSize={pageSize} />;
+}

--- a/apps/tangle-dapp/containers/DelegationsPayoutsContainer/index.ts
+++ b/apps/tangle-dapp/containers/DelegationsPayoutsContainer/index.ts
@@ -1,0 +1,1 @@
+export { default as DelegationsPayoutsContainer } from './DelegationsPayoutsContainer';

--- a/apps/tangle-dapp/containers/Layout/Layout.tsx
+++ b/apps/tangle-dapp/containers/Layout/Layout.tsx
@@ -3,7 +3,7 @@ import { getSideBarStateFromCookie } from '@webb-tools/webb-ui-components/next-u
 import React, { type FC, type PropsWithChildren } from 'react';
 
 import { Breadcrumbs, SideBar, SideBarMenu } from '../../components';
-import WalletAndChainCointainer from '../WalletAndChainContainer/WalletAndChainContainer';
+import WalletAndChainChainContainer from '../WalletAndChainContainer/WalletAndChainContainer';
 import { WalletModalContainer } from '../WalletModalContainer';
 
 const Layout: FC<PropsWithChildren> = ({ children }) => {
@@ -22,7 +22,7 @@ const Layout: FC<PropsWithChildren> = ({ children }) => {
               <Breadcrumbs />
             </div>
 
-            <WalletAndChainCointainer />
+            <WalletAndChainChainContainer />
           </div>
 
           {children}

--- a/apps/tangle-dapp/containers/Layout/Layout.tsx
+++ b/apps/tangle-dapp/containers/Layout/Layout.tsx
@@ -3,7 +3,7 @@ import { getSideBarStateFromCookie } from '@webb-tools/webb-ui-components/next-u
 import React, { type FC, type PropsWithChildren } from 'react';
 
 import { Breadcrumbs, SideBar, SideBarMenu } from '../../components';
-import WalletAndChainChainContainer from '../WalletAndChainContainer/WalletAndChainContainer';
+import WalletAndChainContainer from '../WalletAndChainContainer/WalletAndChainContainer';
 import { WalletModalContainer } from '../WalletModalContainer';
 
 const Layout: FC<PropsWithChildren> = ({ children }) => {
@@ -22,7 +22,7 @@ const Layout: FC<PropsWithChildren> = ({ children }) => {
               <Breadcrumbs />
             </div>
 
-            <WalletAndChainChainContainer />
+            <WalletAndChainContainer />
           </div>
 
           {children}

--- a/apps/tangle-dapp/containers/ValidatorTablesContainer/ValidatorTablesContainer.tsx
+++ b/apps/tangle-dapp/containers/ValidatorTablesContainer/ValidatorTablesContainer.tsx
@@ -14,7 +14,7 @@ const pageSize = 10;
 const activeValidatorsTableTab = 'Active Validators';
 const waitingValidatorsTableTab = 'Waiting';
 
-const ShieldedTablesContainer = () => {
+const ValidatorTablesContainer = () => {
   const { data: activeValidatorsData, isLoading: activeValidatorsDataLoading } =
     useSWR([getActiveValidators.name], ([, ...args]) =>
       getActiveValidators(...args)
@@ -59,4 +59,4 @@ const ShieldedTablesContainer = () => {
   );
 };
 
-export default ShieldedTablesContainer;
+export default ValidatorTablesContainer;

--- a/apps/tangle-dapp/containers/index.ts
+++ b/apps/tangle-dapp/containers/index.ts
@@ -1,3 +1,4 @@
+export * from './DelegationsPayoutsContainer';
 export * from './HeaderChipsContainer';
 export * from './KeyStatsContainer';
 export { Layout } from './Layout';

--- a/apps/tangle-dapp/data/DelegationsPayouts/useDelegations.ts
+++ b/apps/tangle-dapp/data/DelegationsPayouts/useDelegations.ts
@@ -1,0 +1,115 @@
+'use client';
+
+import { u128 } from '@polkadot/types';
+import { WebbError, WebbErrorCodes } from '@webb-tools/dapp-types/WebbError';
+import { useEffect, useState } from 'react';
+import { Subscription } from 'rxjs';
+
+import {
+  formatTokenBalance,
+  getPolkadotApiPromise,
+  getPolkadotApiRx,
+  getValidatorIdentity,
+} from '../../constants';
+import useFormatReturnType from '../../hooks/useFormatReturnType';
+import { Delegator } from '../../types';
+
+export default function useDelegations(
+  address: string,
+  defaultValue: { delegators: Delegator[] } = {
+    delegators: [],
+  }
+) {
+  const [delegators, setDelegators] = useState(defaultValue.delegators);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    let sub: Subscription | null = null;
+
+    const subscribeData = async () => {
+      if (!address) {
+        if (isMounted) {
+          setDelegators([]);
+          setIsLoading(false);
+        }
+        return;
+      }
+
+      try {
+        const apiSub = await getPolkadotApiRx();
+        const apiPromise = await getPolkadotApiPromise();
+        if (!apiSub || !apiPromise) {
+          throw WebbError.from(WebbErrorCodes.ApiNotReady);
+        }
+
+        setIsLoading(true);
+
+        sub = apiSub.query.staking
+          .nominators(address)
+          .subscribe(async (nominatorData) => {
+            const targets = nominatorData.unwrapOrDefault().targets;
+
+            const delegators: Delegator[] = await Promise.all(
+              targets.map(async (target) => {
+                const ledger = await apiPromise.query.staking.ledger(
+                  target.toString()
+                );
+                const ledgerData = ledger.unwrapOrDefault();
+                const totalStaked = new u128(
+                  apiPromise.registry,
+                  ledgerData.total.toString()
+                );
+                const totalStakedBalance = await formatTokenBalance(
+                  totalStaked
+                );
+
+                const isActive = await apiPromise.query.session
+                  .validators()
+                  .then((activeValidators) =>
+                    activeValidators.some(
+                      (val) => val.toString() === target.toString()
+                    )
+                  );
+
+                const identity = await getValidatorIdentity(target.toString());
+
+                return {
+                  address: target.toString(),
+                  identity: identity ?? '',
+                  totalStaked: totalStakedBalance ?? '',
+                  isActive,
+                };
+              })
+            );
+
+            if (isMounted) {
+              setDelegators(delegators);
+              setIsLoading(false);
+            }
+          });
+      } catch (e) {
+        if (isMounted) {
+          setError(
+            e instanceof Error ? e : WebbError.from(WebbErrorCodes.UnknownError)
+          );
+          setIsLoading(false);
+        }
+      }
+    };
+
+    subscribeData();
+
+    return () => {
+      isMounted = false;
+      sub?.unsubscribe();
+    };
+  }, [address]);
+
+  return useFormatReturnType({
+    isLoading,
+    error,
+    data: { delegators },
+  });
+}

--- a/apps/tangle-dapp/types/index.ts
+++ b/apps/tangle-dapp/types/index.ts
@@ -5,3 +5,10 @@ export type Validator = {
   effectiveAmountStaked: string;
   delegations: string;
 };
+
+export type Delegator = {
+  address: string;
+  identity: string;
+  totalStaked: string;
+  isActive: boolean;
+};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "nx run-many --all --target=test",
     "lint": "nx run-many --all --target=lint",
     "gql:codegen": "graphql-codegen --config apps/stats-dapp/codegen.yml",
-    "fetch:onChainConfig": "TS_NODE_PROJECT=\"tools/tsconfig.json\" ts-node-esm tools/scripts/fetchingOnChainConfig.ts",
+    "fetch:onChainConfig": "TS_NODE_PROJECT=\"tools/tsconfig.json\" yarn ts-node-esm tools/scripts/fetchingOnChainConfig.ts",
     "build:bridge": "nx build bridge-dapp",
     "build:stats": "nx build stats-dapp",
     "build:webbsite": "nx build webbsite",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "nx run-many --all --target=test",
     "lint": "nx run-many --all --target=lint",
     "gql:codegen": "graphql-codegen --config apps/stats-dapp/codegen.yml",
-    "fetch:onChainConfig": "TS_NODE_PROJECT=\"tools/tsconfig.json\" node --loader ts-node/esm tools/scripts/fetchingOnChainConfig.ts",
+    "fetch:onChainConfig": "TS_NODE_PROJECT=\"tools/tsconfig.json\" yarn ts-node tools/scripts/fetchingOnChainConfig.ts",
     "build:bridge": "nx build bridge-dapp",
     "build:stats": "nx build stats-dapp",
     "build:webbsite": "nx build webbsite",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "nx run-many --all --target=test",
     "lint": "nx run-many --all --target=lint",
     "gql:codegen": "graphql-codegen --config apps/stats-dapp/codegen.yml",
-    "fetch:onChainConfig": "TS_NODE_PROJECT=\"tools/tsconfig.json\" yarn ts-node-esm tools/scripts/fetchingOnChainConfig.ts",
+    "fetch:onChainConfig": "TS_NODE_PROJECT=\"tools/tsconfig.json\" node --loader ts-node/esm tools/scripts/fetchingOnChainConfig.ts",
     "build:bridge": "nx build bridge-dapp",
     "build:stats": "nx build stats-dapp",
     "build:webbsite": "nx build webbsite",

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "extends": "../tsconfig.base.json",
   "ts-node": {
+    "transpileOnly": true,
     "require": ["tsconfig-paths/register"],
     "compilerOptions": {
       "target": "es6",
-      "module": "commonjs",
-      "esModuleInterop": true
+      "module": "commonjs"
     }
   },
   "compilerOptions": {


### PR DESCRIPTION
## Summary of changes

- Adds initial delegations and payouts table (Does not include all the data)
- Adds different table states (Wallet not connected, No delegation, Work In-Progress)
- Delegations table shows the following data:
    - Validator address
    - Validator status - Active/Waiting
    - Total Validator Staked (Delegated/Staked)
- Payouts table shows work in-progress temporarily.

### Proposed area of change

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `libs/webb-ui-components`

### Screen Recording

https://github.com/webb-tools/webb-dapp/assets/53374218/d442955e-9dcb-4dcd-9884-39677a4c12c0