### PR TITLE
Fix `zk-explorer` deployment failing on Netlify

### DIFF
--- a/apps/zk-explorer/app/providers.tsx
+++ b/apps/zk-explorer/app/providers.tsx
@@ -1,10 +1,8 @@
-import { WebbUIProvider } from '@webb-tools/webb-ui-components/provider';
 import type { PropsWithChildren } from 'react';
+import NextThemeProvider from '@webb-tools/api-provider-environment/NextThemeProvider';
 
 const Providers = ({ children }: PropsWithChildren) => {
-  return <WebbUIProvider hasErrorBoudary>{children}</WebbUIProvider>;
+  return <NextThemeProvider>{children}</NextThemeProvider>;
 };
-
-//
 
 export default Providers;

--- a/apps/zk-explorer/app/providers.tsx
+++ b/apps/zk-explorer/app/providers.tsx
@@ -5,4 +5,6 @@ const Providers = ({ children }: PropsWithChildren) => {
   return <WebbUIProvider hasErrorBoudary>{children}</WebbUIProvider>;
 };
 
+//
+
 export default Providers;

--- a/apps/zk-explorer/components/GitHubOAuthButton/GitHubOAuthButton.tsx
+++ b/apps/zk-explorer/components/GitHubOAuthButton/GitHubOAuthButton.tsx
@@ -3,7 +3,7 @@
 import { Typography } from '@webb-tools/webb-ui-components';
 import { GithubFill } from '@webb-tools/icons';
 import { twMerge } from 'tailwind-merge';
-import { FC, MouseEventHandler, useEffect } from 'react';
+import { FC, MouseEventHandler, useCallback, useEffect } from 'react';
 import { GitHubOAuthButtonProps } from './types';
 
 export const GitHubOAuthButton: FC<GitHubOAuthButtonProps> = ({
@@ -16,34 +16,38 @@ export const GitHubOAuthButton: FC<GitHubOAuthButtonProps> = ({
   onOAuthSuccess,
   onOAuthError,
   onSignedInClick,
+  onClick,
   ...rest
 }) => {
-  const handleClick: MouseEventHandler<HTMLButtonElement> = (e) => {
-    if (rest.onClick !== undefined) {
-      rest.onClick(e);
-    }
-
-    const isSignedIn = username !== undefined;
-
-    if (isSignedIn) {
-      if (onSignedInClick !== undefined) {
-        onSignedInClick(e);
-      }
-    } else {
-      const authUrl = new URL('https://github.com/login/oauth/authorize');
-      const finalRedirectUri = redirectUri ?? window.location.href;
-
-      authUrl.searchParams.append('client_id', clientId);
-      authUrl.searchParams.append('redirect_uri', finalRedirectUri);
-      authUrl.searchParams.append('scope', scope);
-
-      if (state !== undefined) {
-        authUrl.searchParams.append('state', state);
+  const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
+    (e) => {
+      if (onClick !== undefined) {
+        onClick(e);
       }
 
-      window.location.href = authUrl.toString();
-    }
-  };
+      const isSignedIn = username !== undefined;
+
+      if (isSignedIn) {
+        if (onSignedInClick !== undefined) {
+          onSignedInClick(e);
+        }
+      } else {
+        const authUrl = new URL('https://github.com/login/oauth/authorize');
+        const finalRedirectUri = redirectUri ?? window.location.href;
+
+        authUrl.searchParams.append('client_id', clientId);
+        authUrl.searchParams.append('redirect_uri', finalRedirectUri);
+        authUrl.searchParams.append('scope', scope);
+
+        if (state !== undefined) {
+          authUrl.searchParams.append('state', state);
+        }
+
+        window.location.href = authUrl.toString();
+      }
+    },
+    [clientId, redirectUri, scope, state, username, onSignedInClick, onClick]
+  );
 
   // TODO: Effect is being executed twice. Likely caused by SSR or React's strict mode.
   // Handle possible GitHub OAuth redirect and error query parameters.

--- a/apps/zk-explorer/components/GitHubOAuthButton/GitHubOAuthButton.tsx
+++ b/apps/zk-explorer/components/GitHubOAuthButton/GitHubOAuthButton.tsx
@@ -6,35 +6,44 @@ import { twMerge } from 'tailwind-merge';
 import { FC, MouseEventHandler, useEffect } from 'react';
 import { GitHubOAuthButtonProps } from './types';
 
-export const GitHubOAuthButton: FC<GitHubOAuthButtonProps> = (props) => {
+export const GitHubOAuthButton: FC<GitHubOAuthButtonProps> = ({
+  clientId,
+  redirectUri,
+  scope,
+  state,
+  doInterceptOauthRedirect,
+  username,
+  onOAuthSuccess,
+  onOAuthError,
+  onSignedInClick,
+  ...rest
+}) => {
   const handleClick: MouseEventHandler<HTMLButtonElement> = (e) => {
-    if (props.onClick !== undefined) {
-      props.onClick(e);
+    if (rest.onClick !== undefined) {
+      rest.onClick(e);
     }
 
-    const isSignedIn = props.username !== undefined;
+    const isSignedIn = username !== undefined;
 
     if (isSignedIn) {
-      if (props.onSignedInClick !== undefined) {
-        props.onSignedInClick(e);
+      if (onSignedInClick !== undefined) {
+        onSignedInClick(e);
       }
     } else {
       const authUrl = new URL('https://github.com/login/oauth/authorize');
-      const finalRedirectUri = props.redirectUri ?? window.location.href;
+      const finalRedirectUri = redirectUri ?? window.location.href;
 
-      authUrl.searchParams.append('client_id', props.clientId);
+      authUrl.searchParams.append('client_id', clientId);
       authUrl.searchParams.append('redirect_uri', finalRedirectUri);
-      authUrl.searchParams.append('scope', props.scope);
+      authUrl.searchParams.append('scope', scope);
 
-      if (props.state !== undefined) {
-        authUrl.searchParams.append('state', props.state);
+      if (state !== undefined) {
+        authUrl.searchParams.append('state', state);
       }
 
       window.location.href = authUrl.toString();
     }
   };
-
-  const { doInterceptOauthRedirect, onOAuthSuccess, onOAuthError } = props;
 
   // TODO: Effect is being executed twice. Likely caused by SSR or React's strict mode.
   // Handle possible GitHub OAuth redirect and error query parameters.
@@ -62,7 +71,7 @@ export const GitHubOAuthButton: FC<GitHubOAuthButtonProps> = (props) => {
 
   return (
     <button
-      {...props}
+      {...rest}
       type="button"
       className={twMerge(
         'rounded-full border-2 py-2 px-4',
@@ -70,7 +79,7 @@ export const GitHubOAuthButton: FC<GitHubOAuthButtonProps> = (props) => {
         'hover:bg-mono-0/30',
         'dark:bg-mono-0/5 dark:border-mono-140',
         'dark:hover:bg-mono-0/10',
-        props.className
+        rest.className
       )}
       onClick={handleClick}
     >
@@ -78,7 +87,7 @@ export const GitHubOAuthButton: FC<GitHubOAuthButtonProps> = (props) => {
         <GithubFill size="lg" />
 
         <Typography variant="body1" fw="bold" component="p">
-          {props.username ? `@${props.username}` : 'Sign in with GitHub'}
+          {username ? `@${username}` : 'Sign in with GitHub'}
         </Typography>
       </div>
     </button>

--- a/apps/zk-explorer/components/Header.tsx
+++ b/apps/zk-explorer/components/Header.tsx
@@ -16,8 +16,9 @@ import {
 } from '@webb-tools/icons';
 import { FC } from 'react';
 import { GitHubOAuthButton } from './GitHubOAuthButton/GitHubOAuthButton';
+import { PropsOf } from '@webb-tools/webb-ui-components/types';
 
-export const Header: FC<unknown> = () => {
+export const Header: FC<PropsOf<'header'>> = (props) => {
   const githubOAuthClientId = process.env.ZK_EXPLORER_GITHUB_CLIENT_ID;
 
   if (githubOAuthClientId === undefined || githubOAuthClientId === '') {
@@ -27,7 +28,7 @@ export const Header: FC<unknown> = () => {
   }
 
   return (
-    <header className="py-4 flex flex-col sm:flex-row gap-4">
+    <header className="py-4 flex flex-col sm:flex-row gap-4" {...props}>
       {/* TODO: Base breadcrumbs on the pathname */}
       <Breadcrumbs>
         <BreadcrumbsItem icon={<CheckboxBlankCircleLine />}>

--- a/apps/zk-explorer/tailwind.config.js
+++ b/apps/zk-explorer/tailwind.config.js
@@ -18,15 +18,5 @@ module.exports = {
     ),
     ...createGlobPatternsForDependencies(__dirname),
   ],
-  theme: {
-    extend: {
-      backgroundImage: {
-        glass:
-          'linear-gradient(180deg,rgba(255,255,255,0.80) 0%,rgba(255,255,255,0.00) 100%)',
-        glass_dark:
-          'linear-gradient(180deg,rgba(43,47,64,0.80) 0%,rgba(43,47,64,0.00) 100%)',
-      },
-    },
-  },
   plugins: [],
 };


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- A `public` folder is required, otherwise the build fails.
- Added an empty public folder, using `.gitkeep` to be able to stage it into a commit.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [ ] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [x] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

---

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
