### PR TITLE
Update testnet RPC endpoints and opt out data cache

### DIFF
--- a/apps/testnet-leaderboard/components/RankingTableSection/fetchLeaderboardData.ts
+++ b/apps/testnet-leaderboard/components/RankingTableSection/fetchLeaderboardData.ts
@@ -17,7 +17,8 @@ const fetchLeaderboardData = async (
   }
 
   const response = await fetch(
-    `${BACKEND_URL}/leaderboard?${searchParams.toString()}`
+    `${BACKEND_URL}/leaderboard?${searchParams.toString()}`,
+    { next: { revalidate: 60 } } // seconds
   );
 
   const data = await response.json();

--- a/libs/dapp-config/src/chains/evm/index.tsx
+++ b/libs/dapp-config/src/chains/evm/index.tsx
@@ -325,12 +325,18 @@ export const chainsConfig: Record<number, ChainConfig> = {
       default: {
         http: process.env['USING_LOCAL_TANGLE']
           ? ['http://localhost:9944']
-          : ['https://rpc-archive.tangle.tools', 'https://rpc.tangle.tools'],
+          : [
+              'https://testnet-rpc-archive.tangle.tools',
+              'https://testnet-rpc.tangle.tools',
+            ],
       },
       public: {
         http: process.env['USING_LOCAL_TANGLE']
           ? ['http://localhost:9944']
-          : ['https://rpc-archive.tangle.tools', 'https://rpc.tangle.tools'],
+          : [
+              'https://testnet-rpc-archive.tangle.tools',
+              'https://testnet-rpc.tangle.tools',
+            ],
       },
     },
     contracts: hostedOrbitMulticall3Address

--- a/libs/dapp-config/src/chains/substrate/index.tsx
+++ b/libs/dapp-config/src/chains/substrate/index.tsx
@@ -62,7 +62,7 @@ export const chainsConfig: Record<number, ChainConfig> = {
         name: 'Tangle Explorer',
         url: process.env['USING_LOCAL_TANGLE']
           ? populateBlockExplorerStub('ws://127.0.0.1:9944')
-          : populateBlockExplorerStub('wss://rpc-archive.tangle.tools'),
+          : populateBlockExplorerStub('wss://testnet-rpc-archive.tangle.tools'),
       },
     },
     rpcUrls: {
@@ -70,13 +70,19 @@ export const chainsConfig: Record<number, ChainConfig> = {
         http: [],
         webSocket: process.env['USING_LOCAL_TANGLE']
           ? ['ws://127.0.0.1:9944']
-          : ['wss://rpc-archive.tangle.tools', 'wss://rpc.tangle.tools'],
+          : [
+              'wss://testnet-rpc-archive.tangle.tools',
+              'wss://testnet-rpc.tangle.tools',
+            ],
       },
       public: {
         http: [],
         webSocket: process.env['USING_LOCAL_TANGLE']
           ? ['ws://127.0.0.1:9944']
-          : ['wss://rpc-archive.tangle.tools', 'wss://rpc.tangle.tools'],
+          : [
+              'wss://testnet-rpc-archive.tangle.tools',
+              'wss://testnet-rpc.tangle.tools',
+            ],
       },
     },
     env: ['development'],

--- a/libs/webb-ui-components/src/constants/index.ts
+++ b/libs/webb-ui-components/src/constants/index.ts
@@ -72,7 +72,7 @@ export const WEBB_CAREERS_URL = 'https://wellfound.com/company/webb-4/jobs';
 export const TANGLE_TESTNET_EXPLORER_URL = 'https://explorer.tangle.tools';
 
 export const TANGLE_STANDALONE_EXPLORER_URL =
-  'https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-archive.tangle.tools#/explorer';
+  'https://cloudflare-ipfs.com/ipns/dotapps.io/?rpc=wss%3A%2F%2Ftestnet-rpc-archive.tangle.tools#/explorer';
 
 export const WEBB_DAPP_NEW_ISSUE_URL =
   'https://github.com/webb-tools/webb-dapp/issues/new/choose';
@@ -85,7 +85,7 @@ export const GITHUB_BUG_REPORT_URL =
   'https://github.com/webb-tools/webb-dapp/issues/new?assignees=&labels=bug+%F0%9F%AA%B2&projects=&template=bug_report.md&title=%5BBUG%5D+';
 
 export const POLKADOT_EXPLORER_URL =
-  'https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-archive.tangle.tools#/explorer/query';
+  'https://cloudflare-ipfs.com/ipns/dotapps.io/?rpc=wss%3A%2F%2Ftestnet-rpc-archive.tangle.tools#/explorer/query';
 
 export const FOLLOW_WEBB_TWITTER_URL =
   'https://twitter.com/intent/follow?screen_name=webbprotocol';
@@ -94,12 +94,12 @@ export const DKG_STATS_KEYS_URL = `${DKG_STATS_URL}/#/keys`;
 export const DKG_STATS_AUTHORITIES_URL = `${DKG_STATS_URL}/#/authorities`;
 export const DKG_STATS_PROPOSALS_URL = `${DKG_STATS_URL}/#/proposals`;
 
-export const TANGLE_RPC_ENDPOINT = 'wss://rpc-archive.tangle.tools';
+export const TANGLE_RPC_ENDPOINT = 'wss://testnet-rpc-archive.tangle.tools';
 export const SUBQUERY_ENDPOINT =
   'https://standalone-subql.tangle.tools/graphql';
 
 export const TANGLE_STAKING_URL =
-  'https://polkadot.js.org/apps/?rpc=wss://rpc-archive.tangle.tools#/staking';
+  'https://cloudflare-ipfs.com/ipns/dotapps.io/?rpc=wss%3A%2F%2Ftestnet-rpc-archive.tangle.tools#/staking';
 
 export const STAKING_PRECOMPILE_LINK =
   'https://github.com/webb-tools/tangle/blob/main/precompiles/staking/StakingInterface.sol';


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

This pull request updates the testnet RPC endpoints to use the new URLs and also adds an option to opt out of the data cache when fetching leaderboard data. This ensures that the latest data is always fetched from the server.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [x] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [x] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `libs/webb-ui-components`