### PR TITLE
chore: prevent text wrapping for buttons for one-line constraint

### DIFF
--- a/libs/webb-ui-components/src/components/buttons/Button.tsx
+++ b/libs/webb-ui-components/src/components/buttons/Button.tsx
@@ -111,7 +111,8 @@ function ButtonContent(props: ButtonContentProps) {
           {leftIcon}
         </span>
       )}
-      <span className={cx('block !text-inherit')}>{children}</span>
+     {/* The whitespace-nowrap class is added here to prevent text wrapping */}
+      <span className={cx('block !text-inherit whitespace-nowrap')}>{children}</span>
       {rightIcon && (
         <span
           className={cx(


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

-

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [ ] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [x] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes

### Screen Recording

_If possible provide a screen recording of proposed change._

---

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
