### PR TITLE
chore: added extra margins display for tablet/mobile breakpoints

### DIFF
--- a/apps/tangle-dapp/containers/Layout/Layout.tsx
+++ b/apps/tangle-dapp/containers/Layout/Layout.tsx
@@ -13,7 +13,7 @@ const Layout: FC<PropsWithChildren> = ({ children }) => {
     <div className="flex bg-body h-screen">
       <SideBar isExpandedAtDefault={isSideBarInitiallyExpanded} />
 
-      <main className="flex flex-col justify-between flex-1 h-full max-w-[1448px] m-auto px-10 overflow-y-auto scrollbar-hide">
+      <main className="flex flex-col justify-between flex-1 h-full max-w-[1448px] m-auto lg:px-12 md:px-8 px-4 overflow-y-auto scrollbar-hide">
         <div className="flex flex-col justify-between space-y-5">
           <div className="flex items-center justify-between py-6">
             <div className="flex items-center space-x-4 lg:space-x-0">


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Improved margins display across various breakpoints for Tangle dApp. 

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [ ] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes

### Screen Recording

_If possible provide a screen recording of proposed change._

---

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
