### PR TITLE
fix: Change to optional RelayerChainConfig type attributes that are EVM-specific or Substrate-specific in types.ts

### DIFF
--- a/libs/abstract-api-provider/src/relayer/types.ts
+++ b/libs/abstract-api-provider/src/relayer/types.ts
@@ -18,9 +18,9 @@ export type RelayedChainConfig<BaseOn extends RelayerCMDBase> = {
   account: string;
   beneficiary?: string;
   enabled?: boolean;
-  contracts: BaseOn extends 'evm' ? Contract[] : never;
-  pallets: BaseOn extends 'substrate' ? Pallet[] : never;
-  relayerFeeConfig: BaseOn extends 'evm'
+  contracts?: BaseOn extends 'evm' ? Contract[] : never;
+  pallets?: BaseOn extends 'substrate' ? Pallet[] : never;
+  relayerFeeConfig?: BaseOn extends 'evm'
     ?
         | {
             relayerProfitPercent: number;


### PR DESCRIPTION
## Summary of changes

These attributes need to be optional. Otherwise if you create an EVM-specific RelayChainConfig you get error that it is missing 'pallets' attribute even though it shouldn't be required. Or if you create a Substrate-specific RelayChainConfig you get error that it is missing 'contracts' and 'relayerFeeConfig' even though they aren't relevant for Substrate.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [X] `apps/bridge-dapp`

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
