### PR TITLE
fix(tangle-dapp): getValidatorIdentity function

### DIFF
--- a/apps/tangle-dapp/utils/polkadot/nominators.ts
+++ b/apps/tangle-dapp/utils/polkadot/nominators.ts
@@ -42,15 +42,10 @@ export const getValidatorIdentity = async (
   // and use that as the name instead of the address.
   if (identityOption.isSome) {
     const identity = identityOption.unwrap();
-    if (identity[0]) {
-      const displayName = identity[0].info.display.toString();
-      const displayNameObject: { raw?: `0x${string}` } =
-        JSON.parse(displayName);
-      if (displayNameObject.raw !== undefined) {
-        const hexString = displayNameObject.raw;
-        name = Buffer.from(hexString.slice(2), 'hex').toString('utf8');
-      }
-    }
+    name = Buffer.from(
+      JSON.parse(JSON.stringify(identity, null, 2)).info.display.raw.slice(2),
+      'hex'
+    ).toString('utf8');
   }
 
   return name;


### PR DESCRIPTION
## Summary of changes

-  Fixes `getValidatorIdentity` function to return validator identity display name.

### Proposed area of change

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

- Closes #2153 

### Screenshot

![CleanShot 2024-03-28 at 12 56 33](https://github.com/webb-tools/webb-dapp/assets/53374218/2f596c03-99d9-4d21-9c65-18e07b1c1822)
