### PR TITLE
feat(tangle-dapp): Add `Remaining` column to locked balance details

### DIFF
--- a/apps/tangle-dapp/components/account/Actions.tsx
+++ b/apps/tangle-dapp/components/account/Actions.tsx
@@ -22,7 +22,7 @@ import { twMerge } from 'tailwind-merge';
 import TransferTxContainer from '../../containers/TransferTxContainer/TransferTxContainer';
 import useNetworkStore from '../../context/useNetworkStore';
 import useAirdropEligibility from '../../data/claims/useAirdropEligibility';
-import usePayoutsAvailability from '../../data/payouts/usePayoutsAvailability';
+import usePayoutsAvailability from '../../data/usePayoutsAvailability';
 import useVestingInfo from '../../data/vesting/useVestingInfo';
 import useVestTx from '../../data/vesting/useVestTx';
 import { TxStatus } from '../../hooks/useSubstrateTx';

--- a/apps/tangle-dapp/components/account/Actions.tsx
+++ b/apps/tangle-dapp/components/account/Actions.tsx
@@ -22,7 +22,7 @@ import { twMerge } from 'tailwind-merge';
 import TransferTxContainer from '../../containers/TransferTxContainer/TransferTxContainer';
 import useNetworkStore from '../../context/useNetworkStore';
 import useAirdropEligibility from '../../data/claims/useAirdropEligibility';
-import usePayoutsAvailability from '../../data/Payouts/usePayoutsAvailability';
+import usePayoutsAvailability from '../../data/payouts/usePayoutsAvailability';
 import useVestingInfo from '../../data/vesting/useVestingInfo';
 import useVestTx from '../../data/vesting/useVestTx';
 import { TxStatus } from '../../hooks/useSubstrateTx';

--- a/apps/tangle-dapp/components/account/Actions.tsx
+++ b/apps/tangle-dapp/components/account/Actions.tsx
@@ -22,7 +22,7 @@ import { twMerge } from 'tailwind-merge';
 import TransferTxContainer from '../../containers/TransferTxContainer/TransferTxContainer';
 import useNetworkStore from '../../context/useNetworkStore';
 import useAirdropEligibility from '../../data/claims/useAirdropEligibility';
-import usePayoutsAvailability from '../../data/usePayoutsAvailability';
+import usePayoutsAvailability from '../../data/payouts/usePayoutsAvailability';
 import useVestingInfo from '../../data/vesting/useVestingInfo';
 import useVestTx from '../../data/vesting/useVestTx';
 import { TxStatus } from '../../hooks/useSubstrateTx';

--- a/apps/tangle-dapp/containers/BalancesTableContainer/BalancesTableContainer.tsx
+++ b/apps/tangle-dapp/containers/BalancesTableContainer/BalancesTableContainer.tsx
@@ -74,7 +74,7 @@ const BalancesTableContainer: FC = () => {
             <HeaderCell title="Asset" />
 
             <AssetCell
-              title="Transferrable Balance"
+              title="Free Balance"
               tooltip="The amount of tokens you can freely transfer right now. These tokens are not subject to any limitations."
             />
 

--- a/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/DemocracyBalance.tsx
+++ b/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/DemocracyBalance.tsx
@@ -1,43 +1,17 @@
-import { LockUnlockLineIcon } from '@webb-tools/icons';
 import { FC } from 'react';
 
 import useDemocracy from '../../../data/democracy/useDemocracy';
-import useDemocracyUnlockTx from '../../../data/democracy/useDemocracyUnlockTx';
-import { TxStatus } from '../../../hooks/useSubstrateTx';
-import BalanceAction from '../BalanceAction';
 import BalanceCell from '../BalanceCell';
 
 const DemocracyBalance: FC = () => {
   const { lockedBalance: lockedDemocracyBalance, isInDemocracy } =
     useDemocracy();
 
-  // TODO: Need to remove all expired democracy votes, and THEN perform the unlock transaction.
-  const { execute: executeDemocracyUnlockTx, status: democracyUnlockTxStatus } =
-    useDemocracyUnlockTx();
-
   if (!isInDemocracy || lockedDemocracyBalance === null) {
     return;
   }
 
-  return (
-    <div className="flex flex-row justify-between items-center">
-      <BalanceCell amount={lockedDemocracyBalance} />
-
-      <BalanceAction
-        Icon={LockUnlockLineIcon}
-        tooltip="Clear expired democracy locks."
-        isDisabled={
-          executeDemocracyUnlockTx === null ||
-          democracyUnlockTxStatus === TxStatus.PROCESSING
-        }
-        onClick={
-          executeDemocracyUnlockTx !== null
-            ? executeDemocracyUnlockTx
-            : undefined
-        }
-      />
-    </div>
-  );
+  return <BalanceCell amount={lockedDemocracyBalance} />;
 };
 
 export default DemocracyBalance;

--- a/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/DemocracyUnlockAction.tsx
+++ b/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/DemocracyUnlockAction.tsx
@@ -1,0 +1,36 @@
+import { LockUnlockLineIcon } from '@webb-tools/icons';
+import { FC } from 'react';
+
+import useDemocracy from '../../../data/democracy/useDemocracy';
+import useDemocracyUnlockTx from '../../../data/democracy/useDemocracyUnlockTx';
+import { TxStatus } from '../../../hooks/useSubstrateTx';
+import BalanceAction from '../BalanceAction';
+
+const DemocracyUnlockAction: FC = () => {
+  const { lockedBalance: lockedDemocracyBalance, isInDemocracy } =
+    useDemocracy();
+
+  // TODO: Need to remove all expired democracy votes, and THEN perform the unlock transaction.
+  const { execute: executeDemocracyUnlockTx, status: democracyUnlockTxStatus } =
+    useDemocracyUnlockTx();
+
+  if (!isInDemocracy || lockedDemocracyBalance === null) {
+    return;
+  }
+
+  return (
+    <BalanceAction
+      Icon={LockUnlockLineIcon}
+      tooltip="Clear expired democracy locks."
+      isDisabled={
+        executeDemocracyUnlockTx === null ||
+        democracyUnlockTxStatus === TxStatus.PROCESSING
+      }
+      onClick={
+        executeDemocracyUnlockTx !== null ? executeDemocracyUnlockTx : undefined
+      }
+    />
+  );
+};
+
+export default DemocracyUnlockAction;

--- a/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/LockedBalanceDetails.tsx
+++ b/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/LockedBalanceDetails.tsx
@@ -14,8 +14,10 @@ import BalanceAction from '../BalanceAction';
 import BalanceCell from '../BalanceCell';
 import HeaderCell from '../HeaderCell';
 import DemocracyBalance from './DemocracyBalance';
+import DemocracyUnlockAction from './DemocracyUnlockAction';
 import DemocracyUnlockingAt from './DemocracyUnlockingAt';
 import TextCell from './TextCell';
+import VestingRemainingBalances from './VestingRemainingBalances';
 import VestingScheduleBalances from './VestingScheduleBalances';
 import VestingSchedulesUnlockingAt from './VestingSchedulesUnlockingAt';
 
@@ -77,51 +79,78 @@ const LockedBalanceDetails: FC = () => {
 
           <DemocracyUnlockingAt />
 
-          {stakingLockedBalance !== null && <TextCell text="—" />}
+          {stakingLockedBalance !== null && <TextCell text="--" />}
 
           {currentEra !== null &&
             unbondingEntries !== null &&
             unbondingEntries.length > 0 &&
-            unbondingEntries.map((entry, index) => (
-              <TextCell
-                key={index}
-                text={`Era #${formatDecimal(entry.unlockEra.toString())}`}
-                status={`${formatDecimal(
-                  entry.remainingEras.toString()
-                )} era(s) remaining.`}
-              />
-            ))}
+            unbondingEntries.map((entry, index) => {
+              const status = entry.remainingEras.isZero()
+                ? undefined
+                : `${formatDecimal(
+                    entry.remainingEras.toString()
+                  )} era(s) remaining.`;
+
+              const text = entry.remainingEras.isZero()
+                ? 'Ready to withdraw'
+                : `Era #${formatDecimal(entry.unlockEra.toString())}`;
+
+              return <TextCell key={index} text={text} status={status} />;
+            })}
         </div>
       </div>
 
-      {/* Balances */}
-      <div className="flex flex-col w-full">
-        <HeaderCell title="Balance" />
+      <div className="flex flex-row w-full">
+        {/* Balances */}
+        <div className="flex flex-col w-full">
+          <HeaderCell title="Balance" />
 
-        <VestingScheduleBalances />
+          <VestingScheduleBalances />
 
-        <DemocracyBalance />
+          <DemocracyBalance />
 
-        {stakingLockedBalance !== null && (
-          <div className="flex flex-row justify-between items-center">
+          {stakingLockedBalance !== null && (
             <BalanceCell amount={stakingLockedBalance} />
+          )}
 
-            {visitNominationPageAction}
-          </div>
-        )}
-
-        {unbondingEntries !== null &&
-          unbondingEntries.length > 0 &&
-          unbondingEntries.map((entry, index) => (
-            <div
-              key={index}
-              className="flex flex-row justify-between items-center"
-            >
+          {unbondingEntries !== null &&
+            unbondingEntries.length > 0 &&
+            unbondingEntries.map((entry, index) => (
               <BalanceCell key={index} amount={entry.amount} />
+            ))}
+        </div>
+
+        {/* Remaining */}
+        <div className="flex flex-col w-full">
+          <HeaderCell title="Remaining" />
+
+          <VestingRemainingBalances />
+
+          <div className="flex justify-end">
+            <DemocracyUnlockAction />
+          </div>
+
+          {stakingLockedBalance !== null && (
+            <div className="flex flex-row justify-between items-center">
+              <TextCell text="--" />
 
               {visitNominationPageAction}
             </div>
-          ))}
+          )}
+
+          {unbondingEntries !== null &&
+            unbondingEntries.length > 0 &&
+            unbondingEntries.map((_entry, index) => (
+              <div
+                key={index}
+                className="flex flex-row justify-between items-center"
+              >
+                <TextCell text="--" />
+
+                {visitNominationPageAction}
+              </div>
+            ))}
+        </div>
       </div>
     </div>
   );

--- a/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/TextCell.tsx
+++ b/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/TextCell.tsx
@@ -1,4 +1,5 @@
 import { StatusIndicator } from '@webb-tools/icons';
+import { StatusVariant } from '@webb-tools/icons/StatusIndicator/types';
 import {
   SkeletonLoader,
   Tooltip,
@@ -11,7 +12,8 @@ import { FC, ReactNode } from 'react';
 const TextCell: FC<{
   text: string | null;
   status?: ReactNode;
-}> = ({ text, status }) => {
+  statusVariant?: StatusVariant;
+}> = ({ text, status, statusVariant = 'info' }) => {
   return (
     <div className="flex flex-row p-3 gap-2">
       {text !== null ? (
@@ -25,7 +27,7 @@ const TextCell: FC<{
       {status !== undefined && (
         <Tooltip>
           <TooltipTrigger className="cursor-default">
-            <StatusIndicator size={12} variant="info" />
+            <StatusIndicator size={12} variant={statusVariant} />
           </TooltipTrigger>
 
           <TooltipBody className="break-normal max-w-[250px] text-center">

--- a/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/VestingRemainingBalances.tsx
+++ b/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/VestingRemainingBalances.tsx
@@ -1,12 +1,11 @@
-import { BN, BN_ZERO, formatDecimal } from '@polkadot/util';
+import { BN, BN_ZERO } from '@polkadot/util';
 import { FC, useCallback } from 'react';
 
 import useVestingInfo from '../../../data/vesting/useVestingInfo';
 import usePolkadotApiRx from '../../../hooks/usePolkadotApiRx';
-import { formatTokenBalance } from '../../../utils/polkadot';
 import BalanceCell from '../BalanceCell';
 
-const VestingScheduleBalances: FC = () => {
+const VestingRemainingBalances: FC = () => {
   const { schedulesOpt: vestingSchedulesOpt } = useVestingInfo();
 
   const { data: currentBlockNumber } = usePolkadotApiRx(
@@ -30,23 +29,9 @@ const VestingScheduleBalances: FC = () => {
       : BN_ZERO;
 
     const remaining = schedule.locked.sub(amountAlreadyVested);
-    const allVested = remaining.isZero();
 
-    // The unlock column already shows a status message about the
-    // tokens being fully vested, so don't repeat it here.
-    const status = allVested ? undefined : amountAlreadyVested.isZero() ? (
-      `No tokens have vested yet. This vesting schedule will start unlocking at block #${formatDecimal(
-        schedule.startingBlock.toString()
-      )}.`
-    ) : (
-      <>
-        <strong>{formatTokenBalance(amountAlreadyVested)}</strong> has vested,
-        with <strong>{formatTokenBalance(remaining)}</strong> remaining.
-      </>
-    );
-
-    return <BalanceCell key={index} amount={schedule.locked} status={status} />;
+    return <BalanceCell key={index} amount={remaining} />;
   });
 };
 
-export default VestingScheduleBalances;
+export default VestingRemainingBalances;

--- a/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/VestingSchedulesUnlockingAt.tsx
+++ b/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/VestingSchedulesUnlockingAt.tsx
@@ -41,20 +41,18 @@ const VestingSchedulesUnlockingAt: FC = () => {
     const isComplete = currentBlockNumber.gte(endingBlockNumber);
 
     const progressText = isComplete
-      ? 'All of the tokens in this vesting schedule have vested and are now available to claim.'
+      ? undefined
       : `${timeRemaining} remaining. Currently at block #${formatDecimal(
           currentBlockNumber.toString()
         )}, with ${formatDecimal(
           endingBlockNumber.sub(currentBlockNumber).toString()
         )} blocks left until all vested tokens are available to claim.`;
 
-    return (
-      <TextCell
-        key={index}
-        text={`Block #${formatDecimal(endingBlockNumber.toString())}`}
-        status={progressText}
-      />
-    );
+    const text = isComplete
+      ? 'Fully vested'
+      : `Block #${formatDecimal(endingBlockNumber.toString())}`;
+
+    return <TextCell key={index} text={text} status={progressText} />;
   });
 };
 

--- a/apps/tangle-dapp/containers/ManageProfileModalContainer/Independent/IndependentAllocationStep.tsx
+++ b/apps/tangle-dapp/containers/ManageProfileModalContainer/Independent/IndependentAllocationStep.tsx
@@ -203,7 +203,7 @@ const IndependentAllocationStep: FC<IndependentAllocationStepProps> = ({
             Remaining:{' '}
             {amountRemaining !== null
               ? formatTokenBalance(amountRemaining, nativeTokenSymbol)
-              : '—'}
+              : '--'}
           </Typography>
 
           <div className="flex items-center gap-2">

--- a/apps/tangle-dapp/containers/ManageProfileModalContainer/Shared/SharedAllocationStep.tsx
+++ b/apps/tangle-dapp/containers/ManageProfileModalContainer/Shared/SharedAllocationStep.tsx
@@ -88,7 +88,7 @@ const SharedAllocationStep: FC<SharedAllocationStepProps> = ({
         Remaining:{' '}
         {remainingAmount !== null
           ? formatTokenBalance(remainingAmount, nativeTokenSymbol)
-          : '—'}
+          : '--'}
       </Typography>
     </AllocationStepContainer>
   );

--- a/apps/tangle-dapp/data/payouts/usePayoutsAvailability.ts
+++ b/apps/tangle-dapp/data/payouts/usePayoutsAvailability.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import useSubstrateAddress from '../hooks/useSubstrateAddress';
-import usePayouts from './DelegationsPayouts/usePayouts';
+import useSubstrateAddress from '../../hooks/useSubstrateAddress';
+import usePayouts from '../DelegationsPayouts/usePayouts';
 
 const usePayoutsAvailability = () => {
   const activeSubstrateAddress = useSubstrateAddress();

--- a/apps/tangle-dapp/data/usePayoutsAvailability.ts
+++ b/apps/tangle-dapp/data/usePayoutsAvailability.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import useSubstrateAddress from '../../hooks/useSubstrateAddress';
-import usePayouts from '../DelegationsPayouts/usePayouts';
+import useSubstrateAddress from '../hooks/useSubstrateAddress';
+import usePayouts from './DelegationsPayouts/usePayouts';
 
 const usePayoutsAvailability = () => {
   const activeSubstrateAddress = useSubstrateAddress();


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- [x] Added the `Remaining` column to the locked balances details, this shows information about the remaining vesting balance of vesting schedules.
- [x] Change `Total balance` to be `Free balance`
- [x] Fix bug where the transferrable/free balance is negative (can be replicated by having a vesting schedule with a large amount)
- [x] Move `Total balance` tooltip next to the amount, and use it to show the **entire** balance (with reasonable precision), since there's currently no way to see that because the balances are abbreviated
- [x] Remove the `Vest` buttons on the locked balance details table, keep it on the 'Vested balance' field and the Account summary card button
- [x] Change the `Vest` action's icon to be the Unlock icon for consistency with the other `Vest` buttons

_(Most of the changes above I actually added in another PR that's why you may not see them here)_

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes #2149

### Screen Recording

_If possible provide a screen recording of proposed change._

https://github.com/webb-tools/webb-dapp/assets/101931215/52b0a18b-1fc8-4c44-8b14-b4993c216c2a

---

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
