### PR TITLE
Show Network Dropdown, Key Stats and Validators Table even with no wallet connection

### DIFF
--- a/apps/tangle-dapp/components/NetworkSelector/NetworkSelectionButton.tsx
+++ b/apps/tangle-dapp/components/NetworkSelector/NetworkSelectionButton.tsx
@@ -49,7 +49,7 @@ const TriggerButton: FC<{ networkName: string }> = ({ networkName }) => {
     <button
       type="button"
       className={twMerge(
-        'rounded-lg border-2 p-2 pl-4',
+        'rounded-lg border-2 p-2',
         'bg-mono-0/10 border-mono-60',
         'hover:bg-mono-0/30',
         'dark:bg-mono-0/5 dark:border-mono-140',

--- a/apps/tangle-dapp/components/NetworkSelector/NetworkSelectionButton.tsx
+++ b/apps/tangle-dapp/components/NetworkSelector/NetworkSelectionButton.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useWebContext } from '@webb-tools/api-provider-environment/webb-context/webb-context';
 import { ChainIcon, ChevronDown } from '@webb-tools/icons';
 import {
   Dropdown,
@@ -19,7 +18,6 @@ import { NetworkSelectorDropdown } from './NetworkSelectorDropdown';
 export const TANGLE_TESTNET_NATIVE_CHAIN_NAME = 'Tangle Testnet Native';
 
 const NetworkSelectionButton: FC = () => {
-  const { activeChain } = useWebContext();
   const { network, setNetwork, isCustom } = useNetworkState();
 
   const switchToCustomNetwork = useCallback(
@@ -29,22 +27,20 @@ const NetworkSelectionButton: FC = () => {
   );
 
   return (
-    activeChain && (
-      <Dropdown>
-        <DropdownBasicButton>
-          <TriggerButton networkName={network?.name ?? 'Loading'} />
-        </DropdownBasicButton>
+    <Dropdown>
+      <DropdownBasicButton>
+        <TriggerButton networkName={network?.name ?? 'Loading'} />
+      </DropdownBasicButton>
 
-        <DropdownBody className="mt-1 bg-mono-0 dark:bg-mono-180">
-          <NetworkSelectorDropdown
-            isCustomEndpointSelected={isCustom}
-            selectedNetwork={network}
-            onSetCustomNetwork={switchToCustomNetwork}
-            onNetworkChange={(newNetwork) => setNetwork(newNetwork, false)}
-          />
-        </DropdownBody>
-      </Dropdown>
-    )
+      <DropdownBody className="mt-1 bg-mono-0 dark:bg-mono-180">
+        <NetworkSelectorDropdown
+          isCustomEndpointSelected={isCustom}
+          selectedNetwork={network}
+          onSetCustomNetwork={switchToCustomNetwork}
+          onNetworkChange={(newNetwork) => setNetwork(newNetwork, false)}
+        />
+      </DropdownBody>
+    </Dropdown>
   );
 };
 

--- a/apps/tangle-dapp/components/NetworkSelector/NetworkSelectionButton.tsx
+++ b/apps/tangle-dapp/components/NetworkSelector/NetworkSelectionButton.tsx
@@ -19,7 +19,7 @@ import { NetworkSelectorDropdown } from './NetworkSelectorDropdown';
 export const TANGLE_TESTNET_NATIVE_CHAIN_NAME = 'Tangle Testnet Native';
 
 const NetworkSelectionButton: FC = () => {
-  const { activeChain, activeAccount } = useWebContext();
+  const { activeChain } = useWebContext();
   const { network, setNetwork, isCustom } = useNetworkState();
 
   const switchToCustomNetwork = useCallback(
@@ -29,7 +29,6 @@ const NetworkSelectionButton: FC = () => {
   );
 
   return (
-    activeAccount &&
     activeChain && (
       <Dropdown>
         <DropdownBasicButton>

--- a/apps/tangle-dapp/containers/BalancesTableContainer/BalancesTableContainer.tsx
+++ b/apps/tangle-dapp/containers/BalancesTableContainer/BalancesTableContainer.tsx
@@ -40,7 +40,10 @@ const BalancesTableContainer: FC = () => {
 
   const { data: locks } = usePolkadotApiRx(
     useCallback(
-      (api) => api.query.balances.locks(activeSubstrateAddress ?? ''),
+      (api) => {
+        if (!activeSubstrateAddress) return null;
+        return api.query.balances.locks(activeSubstrateAddress);
+      },
       [activeSubstrateAddress]
     )
   );

--- a/apps/tangle-dapp/containers/BalancesTableContainer/BalancesTableContainer.tsx
+++ b/apps/tangle-dapp/containers/BalancesTableContainer/BalancesTableContainer.tsx
@@ -17,6 +17,7 @@ import useBalances from '../../data/balances/useBalances';
 import useVestingInfo from '../../data/vesting/useVestingInfo';
 import useLocalStorage, { LocalStorageKey } from '../../hooks/useLocalStorage';
 import usePolkadotApiRx from '../../hooks/usePolkadotApiRx';
+import useSubstrateAddress from '../../hooks/useSubstrateAddress';
 import { StaticSearchQueryPath } from '../../types';
 import TransferTxContainer from '../TransferTxContainer/TransferTxContainer';
 import BalanceAction from './BalanceAction';
@@ -27,6 +28,7 @@ import VestBalanceAction from './VestBalanceAction';
 
 const BalancesTableContainer: FC = () => {
   const { locked, transferrable } = useBalances();
+  const activeSubstrateAddress = useSubstrateAddress();
   const [isTransferModalOpen, setIsTransferModalOpen] = useState(false);
   const [isDetailsCollapsed, setIsDetailsCollapsed] = useState(false);
 
@@ -38,9 +40,8 @@ const BalancesTableContainer: FC = () => {
 
   const { data: locks } = usePolkadotApiRx(
     useCallback(
-      (api, activeSubstrateAddress) =>
-        api.query.balances.locks(activeSubstrateAddress),
-      []
+      (api) => api.query.balances.locks(activeSubstrateAddress ?? ''),
+      [activeSubstrateAddress]
     )
   );
 

--- a/apps/tangle-dapp/containers/KeyStatsContainer/KeyStatsContainer.tsx
+++ b/apps/tangle-dapp/containers/KeyStatsContainer/KeyStatsContainer.tsx
@@ -33,7 +33,6 @@ export const KeyStatsContainer = () => {
 
         <ActiveValidatorsKeyStat />
 
-        {/* TODO: check this */}
         <ActualStakedPercentageKeyStat />
 
         <IdealStakedPercentageKeyStat />

--- a/apps/tangle-dapp/containers/KeyStatsContainer/KeyStatsContainer.tsx
+++ b/apps/tangle-dapp/containers/KeyStatsContainer/KeyStatsContainer.tsx
@@ -33,6 +33,7 @@ export const KeyStatsContainer = () => {
 
         <ActiveValidatorsKeyStat />
 
+        {/* TODO: check this */}
         <ActualStakedPercentageKeyStat />
 
         <IdealStakedPercentageKeyStat />

--- a/apps/tangle-dapp/containers/ValidatorTablesContainer/ValidatorTablesContainer.tsx
+++ b/apps/tangle-dapp/containers/ValidatorTablesContainer/ValidatorTablesContainer.tsx
@@ -35,7 +35,7 @@ const ValidatorTablesContainer = () => {
             icon="⏳"
           />
         ) : isActiveValidatorsLoading ? (
-          <ContainerSkeleton numOfRows={5} />
+          <ContainerSkeleton />
         ) : (
           <ValidatorTableContainer data={activeValidatorsData} />
         )}

--- a/apps/tangle-dapp/containers/WalletAndChainContainer/WalletAndChainContainer.tsx
+++ b/apps/tangle-dapp/containers/WalletAndChainContainer/WalletAndChainContainer.tsx
@@ -11,10 +11,16 @@ import {
   Typography,
   useCheckMobile,
 } from '@webb-tools/webb-ui-components';
+import dynamic from 'next/dynamic';
 import { type FC } from 'react';
 
 import { WalletDropdown } from '../../components';
-import NetworkSelectionButton from '../../components/NetworkSelector/NetworkSelectionButton';
+// import NetworkSelectionButton from '../../components/NetworkSelector/NetworkSelectionButton';
+
+const NetworkSelectionButton = dynamic(
+  () => import('../../components/NetworkSelector/NetworkSelectionButton'),
+  { ssr: false }
+);
 
 const WalletAndChainContainer: FC = () => {
   const { activeAccount, activeWallet, loading, isConnecting } =

--- a/apps/tangle-dapp/containers/WalletAndChainContainer/WalletAndChainContainer.tsx
+++ b/apps/tangle-dapp/containers/WalletAndChainContainer/WalletAndChainContainer.tsx
@@ -15,7 +15,6 @@ import dynamic from 'next/dynamic';
 import { type FC } from 'react';
 
 import { WalletDropdown } from '../../components';
-// import NetworkSelectionButton from '../../components/NetworkSelector/NetworkSelectionButton';
 
 const NetworkSelectionButton = dynamic(
   () => import('../../components/NetworkSelector/NetworkSelectionButton'),

--- a/apps/tangle-dapp/data/balances/useBalances.ts
+++ b/apps/tangle-dapp/data/balances/useBalances.ts
@@ -38,8 +38,9 @@ const useBalances = (): AccountBalances => {
   const [balances, setBalances] = useState<AccountBalances | null>(null);
 
   const balancesFetcher = useCallback<ObservableFactory<AccountBalances>>(
-    (api) =>
-      api.query.system.account(activeSubstrateAddress ?? '').pipe(
+    (api) => {
+      if (!activeSubstrateAddress) return null;
+      return api.query.system.account(activeSubstrateAddress).pipe(
         map(({ data }) => {
           // Note that without the null/undefined check, an error
           // reports that `num` is undefined for some reason. Might be
@@ -63,7 +64,8 @@ const useBalances = (): AccountBalances => {
             locked: data.free.sub(transferrable),
           };
         })
-      ),
+      );
+    },
     [activeSubstrateAddress]
   );
 

--- a/apps/tangle-dapp/data/balances/useBalances.ts
+++ b/apps/tangle-dapp/data/balances/useBalances.ts
@@ -6,6 +6,7 @@ import { map } from 'rxjs/operators';
 import usePolkadotApiRx, {
   ObservableFactory,
 } from '../../hooks/usePolkadotApiRx';
+import useSubstrateAddress from '../../hooks/useSubstrateAddress';
 
 export type AccountBalances = {
   /**
@@ -33,11 +34,12 @@ export type AccountBalances = {
 
 const useBalances = (): AccountBalances => {
   const { activeAccount } = useWebContext();
+  const activeSubstrateAddress = useSubstrateAddress();
   const [balances, setBalances] = useState<AccountBalances | null>(null);
 
   const balancesFetcher = useCallback<ObservableFactory<AccountBalances>>(
-    (api, activeAccountAddress) =>
-      api.query.system.account(activeAccountAddress).pipe(
+    (api) =>
+      api.query.system.account(activeSubstrateAddress ?? '').pipe(
         map(({ data }) => {
           // Note that without the null/undefined check, an error
           // reports that `num` is undefined for some reason. Might be
@@ -62,7 +64,7 @@ const useBalances = (): AccountBalances => {
           };
         })
       ),
-    []
+    [activeSubstrateAddress]
   );
 
   const { data, isLoading } = usePolkadotApiRx(balancesFetcher);

--- a/apps/tangle-dapp/data/balances/useBalancesLock.ts
+++ b/apps/tangle-dapp/data/balances/useBalancesLock.ts
@@ -11,7 +11,10 @@ const useBalancesLock = (lockId: SubstrateLockId) => {
 
   const { data: locks } = usePolkadotApiRx(
     useCallback(
-      (api) => api.query.balances.locks(activeSubstrateAddress ?? ''),
+      (api) => {
+        if (!activeSubstrateAddress) return null;
+        return api.query.balances.locks(activeSubstrateAddress);
+      },
       [activeSubstrateAddress]
     )
   );

--- a/apps/tangle-dapp/data/balances/useBalancesLock.ts
+++ b/apps/tangle-dapp/data/balances/useBalancesLock.ts
@@ -3,14 +3,16 @@ import { useCallback, useMemo } from 'react';
 
 import { SubstrateLockId } from '../../constants';
 import usePolkadotApiRx from '../../hooks/usePolkadotApiRx';
+import useSubstrateAddress from '../../hooks/useSubstrateAddress';
 import getSubstrateLockId from '../../utils/getSubstrateLockId';
 
 const useBalancesLock = (lockId: SubstrateLockId) => {
+  const activeSubstrateAddress = useSubstrateAddress();
+
   const { data: locks } = usePolkadotApiRx(
     useCallback(
-      (api, activeSubstrateAddress) =>
-        api.query.balances.locks(activeSubstrateAddress),
-      []
+      (api) => api.query.balances.locks(activeSubstrateAddress ?? ''),
+      [activeSubstrateAddress]
     )
   );
 

--- a/apps/tangle-dapp/data/democracy/useDemocracy.ts
+++ b/apps/tangle-dapp/data/democracy/useDemocracy.ts
@@ -3,14 +3,16 @@ import { map } from 'rxjs';
 
 import { SubstrateLockId } from '../../constants';
 import usePolkadotApiRx from '../../hooks/usePolkadotApiRx';
+import useSubstrateAddress from '../../hooks/useSubstrateAddress';
 import useBalancesLock from '../balances/useBalancesLock';
 
 const useDemocracy = () => {
+  const activeSubstrateAddress = useSubstrateAddress();
+
   const { data: votes } = usePolkadotApiRx(
     useCallback(
-      (api, activeSubstrateAddress) =>
-        api.query.democracy.votingOf(activeSubstrateAddress),
-      []
+      (api) => api.query.democracy.votingOf(activeSubstrateAddress ?? ''),
+      [activeSubstrateAddress]
     )
   );
 

--- a/apps/tangle-dapp/data/democracy/useDemocracy.ts
+++ b/apps/tangle-dapp/data/democracy/useDemocracy.ts
@@ -11,7 +11,10 @@ const useDemocracy = () => {
 
   const { data: votes } = usePolkadotApiRx(
     useCallback(
-      (api) => api.query.democracy.votingOf(activeSubstrateAddress ?? ''),
+      (api) => {
+        if (!activeSubstrateAddress) return null;
+        return api.query.democracy.votingOf(activeSubstrateAddress);
+      },
       [activeSubstrateAddress]
     )
   );

--- a/apps/tangle-dapp/data/payouts/usePayouts2.ts
+++ b/apps/tangle-dapp/data/payouts/usePayouts2.ts
@@ -35,9 +35,8 @@ const usePayouts2 = () => {
 
   const { data: nominators } = usePolkadotApiRx(
     useCallback(
-      (api, activeSubstrateAddress) =>
-        api.query.staking.nominators(activeSubstrateAddress),
-      []
+      (api) => api.query.staking.nominators(activeSubstrateAddress ?? ''),
+      [activeSubstrateAddress]
     )
   );
 

--- a/apps/tangle-dapp/data/payouts/usePayouts2.ts
+++ b/apps/tangle-dapp/data/payouts/usePayouts2.ts
@@ -35,7 +35,10 @@ const usePayouts2 = () => {
 
   const { data: nominators } = usePolkadotApiRx(
     useCallback(
-      (api) => api.query.staking.nominators(activeSubstrateAddress ?? ''),
+      (api) => {
+        if (!activeSubstrateAddress) return null;
+        return api.query.staking.nominators(activeSubstrateAddress);
+      },
       [activeSubstrateAddress]
     )
   );

--- a/apps/tangle-dapp/data/vesting/useVestingInfo.ts
+++ b/apps/tangle-dapp/data/vesting/useVestingInfo.ts
@@ -56,7 +56,10 @@ const useVestingInfo = (): VestingInfo => {
 
   const { data: schedulesOpt } = usePolkadotApiRx(
     useCallback(
-      (api) => api.query.vesting.vesting(activeSubstrateAddress ?? ''),
+      (api) => {
+        if (!activeSubstrateAddress) return null;
+        return api.query.vesting.vesting(activeSubstrateAddress);
+      },
       [activeSubstrateAddress]
     )
   );

--- a/apps/tangle-dapp/data/vesting/useVestingInfo.ts
+++ b/apps/tangle-dapp/data/vesting/useVestingInfo.ts
@@ -5,6 +5,7 @@ import { useCallback, useMemo } from 'react';
 
 import { SubstrateLockId } from '../../constants/index';
 import usePolkadotApiRx from '../../hooks/usePolkadotApiRx';
+import useSubstrateAddress from '../../hooks/useSubstrateAddress';
 import useBalancesLock from '../balances/useBalancesLock';
 
 export type VestingInfo = {
@@ -51,11 +52,12 @@ export type VestingInfo = {
  * Substrate and EVM accounts.
  */
 const useVestingInfo = (): VestingInfo => {
+  const activeSubstrateAddress = useSubstrateAddress();
+
   const { data: schedulesOpt } = usePolkadotApiRx(
     useCallback(
-      (api, activeSubstrateAddress) =>
-        api.query.vesting.vesting(activeSubstrateAddress),
-      []
+      (api) => api.query.vesting.vesting(activeSubstrateAddress ?? ''),
+      [activeSubstrateAddress]
     )
   );
 

--- a/apps/tangle-dapp/hooks/useIsFirstTimeNominator.ts
+++ b/apps/tangle-dapp/hooks/useIsFirstTimeNominator.ts
@@ -13,7 +13,10 @@ const useIsFirstTimeNominator = () => {
     error: nominatorsError,
   } = usePolkadotApiRx(
     useCallback(
-      (api) => api.query.staking.nominators(activeSubstrateAddress ?? ''),
+      (api) => {
+        if (!activeSubstrateAddress) return null;
+        return api.query.staking.nominators(activeSubstrateAddress);
+      },
       [activeSubstrateAddress]
     )
   );
@@ -32,7 +35,10 @@ const useIsFirstTimeNominator = () => {
     error: bondedInfoError,
   } = usePolkadotApiRx(
     useCallback(
-      (api) => api.query.staking.bonded(activeSubstrateAddress ?? ''),
+      (api) => {
+        if (!activeSubstrateAddress) return null;
+        return api.query.staking.bonded(activeSubstrateAddress);
+      },
       [activeSubstrateAddress]
     )
   );

--- a/apps/tangle-dapp/hooks/useIsFirstTimeNominator.ts
+++ b/apps/tangle-dapp/hooks/useIsFirstTimeNominator.ts
@@ -2,17 +2,19 @@ import { useCallback } from 'react';
 
 import useErrorReporting from './useErrorReporting';
 import usePolkadotApiRx from './usePolkadotApiRx';
+import useSubstrateAddress from './useSubstrateAddress';
 
 const useIsFirstTimeNominator = () => {
+  const activeSubstrateAddress = useSubstrateAddress();
+
   const {
     data: nominators,
     isLoading: isLoadingNominators,
     error: nominatorsError,
   } = usePolkadotApiRx(
     useCallback(
-      (api, activeSubstrateAddress) =>
-        api.query.staking.nominators(activeSubstrateAddress),
-      []
+      (api) => api.query.staking.nominators(activeSubstrateAddress ?? ''),
+      [activeSubstrateAddress]
     )
   );
 
@@ -30,9 +32,8 @@ const useIsFirstTimeNominator = () => {
     error: bondedInfoError,
   } = usePolkadotApiRx(
     useCallback(
-      (api, activeSubstrateAddress) =>
-        api.query.staking.bonded(activeSubstrateAddress),
-      []
+      (api) => api.query.staking.bonded(activeSubstrateAddress ?? ''),
+      [activeSubstrateAddress]
     )
   );
 

--- a/apps/tangle-dapp/hooks/useStakingLedgerRx.ts
+++ b/apps/tangle-dapp/hooks/useStakingLedgerRx.ts
@@ -21,9 +21,10 @@ function useStakingLedgerRx<T>(fetcher: StakingLedgerFetcherRx<T>) {
   return usePolkadotApiRx(
     useCallback(
       (api) => {
+        if (!activeSubstrateAddress) return null;
         return (
           api.query.staking
-            .ledger(activeSubstrateAddress ?? '')
+            .ledger(activeSubstrateAddress)
             // TODO: Error handling. Under what circumstances would the ledger be `None`?
             .pipe(map((ledgerOpt) => fetcher(ledgerOpt.unwrap(), api)))
         );

--- a/apps/tangle-dapp/hooks/useStakingLedgerRx.ts
+++ b/apps/tangle-dapp/hooks/useStakingLedgerRx.ts
@@ -4,6 +4,7 @@ import { useCallback } from 'react';
 import { map } from 'rxjs';
 
 import usePolkadotApiRx from './usePolkadotApiRx';
+import useSubstrateAddress from './useSubstrateAddress';
 
 /**
  * A function provided by the consumer of the {@link useStakingLedgerRx}
@@ -15,17 +16,19 @@ export type StakingLedgerFetcherRx<T> = (
 ) => T;
 
 function useStakingLedgerRx<T>(fetcher: StakingLedgerFetcherRx<T>) {
+  const activeSubstrateAddress = useSubstrateAddress();
+
   return usePolkadotApiRx(
     useCallback(
-      (api, activeSubstrateAddress) => {
+      (api) => {
         return (
           api.query.staking
-            .ledger(activeSubstrateAddress)
+            .ledger(activeSubstrateAddress ?? '')
             // TODO: Error handling. Under what circumstances would the ledger be `None`?
             .pipe(map((ledgerOpt) => fetcher(ledgerOpt.unwrap(), api)))
         );
       },
-      [fetcher]
+      [fetcher, activeSubstrateAddress]
     )
   );
 }


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Update `usePolkadotApiRx` no longer depend on `activeSubstrateAddress`
- Show Network Dropdown even with no wallet connection
- Show Key Stats and Validators Table even with no wallet connection

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes #2180 

### Screen Recording

_If possible provide a screen recording of proposed change._

https://github.com/webb-tools/webb-dapp/assets/69841784/120ccd4e-7985-498e-ab58-02b486da6585

---

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
