### PR TITLE
chore(tangle-dapp): Hide Development Pages & Features

### DIFF
--- a/apps/tangle-dapp/components/DelegatorTable/DelegatorTable.tsx
+++ b/apps/tangle-dapp/components/DelegatorTable/DelegatorTable.tsx
@@ -33,7 +33,7 @@ const columns = [
       const identity = props.row.original.identity;
 
       return (
-        <div className="flex space-x-1 items-center">
+        <div className="flex items-center space-x-1">
           <Avatar sourceVariant="address" value={address} theme="substrate">
             {address}
           </Avatar>
@@ -116,7 +116,6 @@ const DelegatorTable: FC<DelegatorTableProps> = ({ data = [], pageSize }) => {
     <div className="overflow-hidden border rounded-lg bg-mono-0 dark:bg-mono-180 border-mono-40 dark:border-mono-160">
       <Table
         thClassName="border-t-0 bg-mono-0"
-        trClassName="cursor-pointer"
         paginationClassName="bg-mono-0 dark:bg-mono-180 pl-6"
         tableProps={table}
         isPaginated

--- a/apps/tangle-dapp/components/PayoutTable/PayoutTable.tsx
+++ b/apps/tangle-dapp/components/PayoutTable/PayoutTable.tsx
@@ -61,7 +61,7 @@ const PayoutTable: FC<PayoutTableProps> = ({
 
           return (
             <div
-              className="flex space-x-1 items-center justify-start"
+              className="flex items-center justify-start space-x-1"
               key={`${props.row.original.era}-${address}`}
             >
               <Avatar sourceVariant="address" value={address} theme="substrate">
@@ -175,7 +175,6 @@ const PayoutTable: FC<PayoutTableProps> = ({
       <div className="overflow-hidden border rounded-lg bg-mono-0 dark:bg-mono-180 border-mono-40 dark:border-mono-160">
         <Table
           thClassName="border-t-0 bg-mono-0"
-          trClassName="cursor-pointer"
           paginationClassName="bg-mono-0 dark:bg-mono-180 pl-6"
           tableProps={table}
           isPaginated

--- a/apps/tangle-dapp/components/Sidebar/Sidebar.tsx
+++ b/apps/tangle-dapp/components/Sidebar/Sidebar.tsx
@@ -18,11 +18,7 @@ const Sidebar: FC<SidebarProps> = ({ isExpandedAtDefault }) => {
 
   const sidebarProps = useMemo(
     () =>
-      getSidebarProps(
-        process.env.NODE_ENV === 'development',
-        network?.polkadotExplorerUrl,
-        network?.evmExplorerUrl
-      ),
+      getSidebarProps(network?.polkadotExplorerUrl, network?.evmExplorerUrl),
     [network]
   );
 

--- a/apps/tangle-dapp/components/Sidebar/SidebarMenu.tsx
+++ b/apps/tangle-dapp/components/Sidebar/SidebarMenu.tsx
@@ -13,11 +13,7 @@ const SidebarMenu: FC = () => {
 
   const sidebarProps = useMemo(
     () =>
-      getSidebarProps(
-        process.env.NODE_ENV === 'development',
-        network?.polkadotExplorerUrl,
-        network?.evmExplorerUrl
-      ),
+      getSidebarProps(network?.polkadotExplorerUrl, network?.evmExplorerUrl),
     [network?.evmExplorerUrl, network?.polkadotExplorerUrl]
   );
 

--- a/apps/tangle-dapp/components/Sidebar/sidebarProps.ts
+++ b/apps/tangle-dapp/components/Sidebar/sidebarProps.ts
@@ -1,3 +1,4 @@
+import { isAppEnvironmentType } from '@webb-tools/dapp-config/types';
 import {
   AppsLine,
   DocumentationIcon,
@@ -21,6 +22,8 @@ import {
 
 import { PagePath } from '../../types';
 
+// TODO: This entire system of handling sidebar props can be improved in a more React-compliant manner. For now, leaving as is since it is not necessary.
+// Only show the services dropdown if on development mode.
 const SIDEBAR_STATIC_ITEMS: SideBarItemProps[] = [
   {
     name: 'Account',
@@ -29,6 +32,28 @@ const SIDEBAR_STATIC_ITEMS: SideBarItemProps[] = [
     isNext: true,
     Icon: UserLineIcon,
     subItems: [],
+  },
+  {
+    name: 'Services',
+    href: '',
+    isInternal: true,
+    isNext: true,
+    Icon: GridFillIcon,
+    environments: ['development', 'staging', 'test'],
+    subItems: [
+      {
+        name: 'Overview',
+        href: PagePath.SERVICES_OVERVIEW,
+        isInternal: true,
+        isNext: true,
+      },
+      {
+        name: 'Restake',
+        href: PagePath.SERVICES_RESTAKE,
+        isInternal: true,
+        isNext: true,
+      },
+    ],
   },
   {
     name: 'Nomination',
@@ -57,40 +82,15 @@ const SIDEBAR_FOOTER: SideBarFooterType = {
 };
 
 export default function getSidebarProps(
-  isDevelopment: boolean,
   substratePortalHref?: string,
   evmExplorerHref?: string
 ): SidebarProps {
-  const staticItems = [...SIDEBAR_STATIC_ITEMS];
-
-  // TODO: This entire system of handling sidebar props can be improved in a more React-compliant manner. For now, leaving as is since it is not necessary.
-  // Only show the services dropdown if on development mode.
-  if (isDevelopment) {
-    staticItems.splice(1, 0, {
-      name: 'Services',
-      href: '',
-      isInternal: true,
-      isNext: true,
-      Icon: GridFillIcon,
-      subItems: [
-        {
-          name: 'Overview',
-          href: PagePath.SERVICES_OVERVIEW,
-          isInternal: true,
-          isNext: true,
-        },
-        {
-          name: 'Restake',
-          href: PagePath.SERVICES_RESTAKE,
-          isInternal: true,
-          isNext: true,
-        },
-      ],
-    });
-  }
+  const currentEnv = isAppEnvironmentType(process.env.NODE_ENV)
+    ? process.env.NODE_ENV
+    : 'development';
 
   const sideBarItems: SideBarItemProps[] = [
-    ...staticItems,
+    ...SIDEBAR_STATIC_ITEMS,
     ...(substratePortalHref
       ? [
           {
@@ -115,11 +115,19 @@ export default function getSidebarProps(
       : []),
   ];
 
+  // Filter the sidebar items based on the current environment
+  const items = sideBarItems.filter((item) => {
+    if (!item.environments) {
+      return true;
+    }
+    return item.environments.includes(currentEnv);
+  });
+
   return {
     ClosedLogo: SidebarTangleClosedIcon,
     Logo: TangleLogo,
     footer: SIDEBAR_FOOTER,
-    items: sideBarItems,
+    items,
     logoLink: TANGLE_MKT_URL,
   } satisfies SidebarProps;
 }

--- a/apps/tangle-dapp/components/ValidatorTable/ValidatorTable.tsx
+++ b/apps/tangle-dapp/components/ValidatorTable/ValidatorTable.tsx
@@ -34,7 +34,7 @@ const columns = [
       const identity = props.row.original.identityName;
 
       return (
-        <div className="flex space-x-1 items-center">
+        <div className="flex items-center space-x-1">
           <Avatar sourceVariant="address" value={address} theme="substrate">
             hello
           </Avatar>
@@ -88,6 +88,10 @@ const ValidatorTable: FC<ValidatorTableProps> = ({ data }) => {
 
   const onRowClick = useCallback(
     (row: Row<Validator>) => {
+      if (process.env.NODE_ENV === 'production') {
+        return;
+      }
+
       router.push(`${PagePath.NOMINATION}/${row.original.address}`);
     },
     [router]
@@ -110,7 +114,9 @@ const ValidatorTable: FC<ValidatorTableProps> = ({ data }) => {
     <div className="overflow-hidden border rounded-lg bg-mono-0 dark:bg-mono-180 border-mono-40 dark:border-mono-160">
       <Table
         thClassName="border-t-0 bg-mono-0"
-        trClassName="cursor-pointer"
+        trClassName={
+          process.env.NODE_ENV === 'production' ? '' : 'cursor-pointer'
+        }
         paginationClassName="bg-mono-0 dark:bg-mono-180 pl-6"
         tableProps={table}
         isPaginated

--- a/libs/webb-ui-components/src/components/SideBar/types.ts
+++ b/libs/webb-ui-components/src/components/SideBar/types.ts
@@ -1,7 +1,8 @@
-import type { IconBase } from '@webb-tools/icons/types';
-import type { LogoProps } from '../Logo/types';
+import type { AppEnvironment } from '@webb-tools/dapp-config/types';
 import type { DialogContentProps } from '@radix-ui/react-dialog';
+import type { IconBase } from '@webb-tools/icons/types';
 import { MouseEventHandler } from 'react';
+import type { LogoProps } from '../Logo/types';
 
 export type SideBarFooterType = {
   name: string;
@@ -43,16 +44,22 @@ export interface SideBarItemsProps {
 export type SideBarItemProps = {
   /** The item name */
   name: string;
+
   /** Indicate the item is next.js link */
   isNext?: boolean;
+
   /** If `true`, the item will be disabled */
   isDisabled?: boolean;
+
   /** Indicate the item is app internal link */
   isInternal: boolean;
+
   /** The item link */
   href: string;
+
   /** The item icon */
   Icon: (props: IconBase) => JSX.Element;
+
   /** The extra info tooltip for the item */
   info?: string | React.ReactElement;
 
@@ -63,6 +70,12 @@ export type SideBarItemProps = {
 
   /** The item sub items */
   subItems: SideBarSubItemProps[];
+
+  /**
+   * The environments the item is available in
+   * If not provided, the item is available in all environments
+   */
+  environments?: AppEnvironment[];
 };
 
 export type SideBarExtraItemProps = {
@@ -74,14 +87,19 @@ export type SideBarExtraItemProps = {
 export type SideBarSubItemProps = {
   /** Sub item name */
   name: string;
+
   /** Indicate the item is next.js link */
   isNext?: boolean;
+
   /** If `true`, the item will be disabled */
   isDisabled?: boolean;
+
   /** Indicate the item is app internal link */
   isInternal: boolean;
+
   /** The item link */
   href: string;
+
   /** The extra info tooltip for the item */
   info?: string | React.ReactElement;
 
@@ -89,6 +107,12 @@ export type SideBarSubItemProps = {
   onClick?: MouseEventHandler<HTMLAnchorElement>;
 
   pathnameOrHash?: string;
+
+  /**
+   * The environments the item is available in
+   * If not provided, the item is available in all environments
+   */
+  environments?: AppEnvironment[];
 };
 
 export type SideBarExtraSubItemProps = {

--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "@webb-tools/contracts": "0.5.47",
     "@webb-tools/interfaces": "0.5.47",
     "@webb-tools/sdk-core": "0.1.4-127",
-    "@webb-tools/tangle-substrate-types": "^0.5.4",
+    "@webb-tools/tangle-substrate-types": "^0.5.5",
     "@webb-tools/test-utils": "0.1.8",
     "@webb-tools/tokens": "1.0.8",
     "@webb-tools/utils": "1.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13475,10 +13475,10 @@
     ffjavascript "^0.2.57"
     snarkjs "^0.7.2"
 
-"@webb-tools/tangle-substrate-types@^0.5.4":
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/@webb-tools/tangle-substrate-types/-/tangle-substrate-types-0.5.4.tgz#793b69d0e85c18a8d627dfb77be19ea61926444b"
-  integrity sha512-8TEITXJrioETmJXVoePZXBYL+DZBMHHMycstDf7e5zU/V9f/nGFojXs6NK+i+fylwwTbgR8HXTCu7AywM+X7Cg==
+"@webb-tools/tangle-substrate-types@^0.5.5":
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/@webb-tools/tangle-substrate-types/-/tangle-substrate-types-0.5.5.tgz#03ee0e9380c3f9744b5ee210a97eaa0d92c97c37"
+  integrity sha512-fNCkugerqerFlF15DMPuVrHEQIacRajCqh5hHAihkB5wvKlEtWd6JivrrWihPqiQVX6OBnkE6SbEfqPvbBgrKw==
   dependencies:
     "@babel/cli" "^7.23.9"
     "@babel/core" "^7.24.0"


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Disabling the validator page on production.
- Adding environments property to sidebar item.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes https://github.com/webb-tools/webb-dapp/issues/2191

### Screen Recording

_If possible provide a screen recording of proposed change._

---


https://github.com/webb-tools/webb-dapp/assets/60747384/bd673794-3253-4f4d-a205-e25a0e4a47c8

