### PR TITLE
fix(tangle-dapp): Add mainnet network to network selector

### DIFF
--- a/apps/tangle-dapp/components/NetworkSelector/NetworkSelectorDropdown.tsx
+++ b/apps/tangle-dapp/components/NetworkSelector/NetworkSelectorDropdown.tsx
@@ -1,7 +1,6 @@
 import { ChainIcon } from '@webb-tools/icons';
 import { Typography } from '@webb-tools/webb-ui-components';
 import {
-  HAS_TANGLE_MAINNET_LAUNCHED,
   Network,
   TANGLE_LOCAL_DEV_NETWORK,
   TANGLE_MAINNET_NETWORK,
@@ -31,13 +30,11 @@ export const NetworkSelectorDropdown: FC<NetworkSelectorDropdownProps> = ({
   return (
     <div className="flex flex-col items-center justify-between gap-2 py-1">
       {/* Mainnet network */}
-      {HAS_TANGLE_MAINNET_LAUNCHED && (
-        <NetworkOption
-          isSelected={selectedNetwork?.name === TANGLE_MAINNET_NETWORK.name}
-          name={TANGLE_MAINNET_NETWORK.name}
-          onClick={() => onNetworkChange(TANGLE_MAINNET_NETWORK)}
-        />
-      )}
+      <NetworkOption
+        isSelected={selectedNetwork?.name === TANGLE_MAINNET_NETWORK.name}
+        name={TANGLE_MAINNET_NETWORK.name}
+        onClick={() => onNetworkChange(TANGLE_MAINNET_NETWORK)}
+      />
 
       {/* Testnet network */}
       <NetworkOption

--- a/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/LockedBalanceDetails.tsx
+++ b/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/LockedBalanceDetails.tsx
@@ -1,4 +1,4 @@
-import { formatDecimal } from '@polkadot/util';
+import { BN_ZERO, formatDecimal } from '@polkadot/util';
 import { ArrowRightUp } from '@webb-tools/icons';
 import { Chip, Typography } from '@webb-tools/webb-ui-components';
 import { FC } from 'react';
@@ -31,6 +31,9 @@ const LockedBalanceDetails: FC = () => {
     SubstrateLockId.STAKING
   );
 
+  const showNomination =
+    stakingLockedBalance !== null && stakingLockedBalance.gt(BN_ZERO);
+
   const visitNominationPageAction = (
     <BalanceAction
       Icon={ArrowRightUp}
@@ -62,7 +65,7 @@ const LockedBalanceDetails: FC = () => {
 
           {isInDemocracy && <LabelChip title="Democracy" />}
 
-          {stakingLockedBalance !== null && <LabelChip title="Nomination" />}
+          {showNomination && <LabelChip title="Nomination" />}
 
           {unbondingEntries !== null &&
             unbondingEntries.length > 0 &&
@@ -79,7 +82,7 @@ const LockedBalanceDetails: FC = () => {
 
           <DemocracyUnlockingAt />
 
-          {stakingLockedBalance !== null && <TextCell text="--" />}
+          {showNomination && <TextCell text="--" />}
 
           {currentEra !== null &&
             unbondingEntries !== null &&
@@ -109,9 +112,7 @@ const LockedBalanceDetails: FC = () => {
 
           <DemocracyBalance />
 
-          {stakingLockedBalance !== null && (
-            <BalanceCell amount={stakingLockedBalance} />
-          )}
+          {showNomination && <BalanceCell amount={stakingLockedBalance} />}
 
           {unbondingEntries !== null &&
             unbondingEntries.length > 0 &&
@@ -130,7 +131,7 @@ const LockedBalanceDetails: FC = () => {
             <DemocracyUnlockAction />
           </div>
 
-          {stakingLockedBalance !== null && (
+          {showNomination && (
             <div className="flex flex-row justify-between items-center">
               <TextCell text="--" />
 

--- a/libs/webb-ui-components/src/constants/networks.ts
+++ b/libs/webb-ui-components/src/constants/networks.ts
@@ -40,12 +40,6 @@ export type Network = {
   httpRpcEndpoint?: string;
 };
 
-/**
- * Easy toggle to show/hide the mainnet network option
- * on the network selector.
- */
-export const HAS_TANGLE_MAINNET_LAUNCHED = false;
-
 const TANGLE_MAINNET_WS_RPC_ENDPOINT = 'wss://rpc.tangle.tools';
 
 export const TANGLE_MAINNET_NETWORK: Network = {


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Add mainnet network to network selector
- Fixed `Nomination` row shown in locked balance details even when the user is not participating in staking or has zero staking lock balance.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes

### Screen Recording

_If possible provide a screen recording of proposed change._

https://github.com/webb-tools/webb-dapp/assets/101931215/c5a0572d-a770-47d9-837d-9a488e1351ed

---

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
