### PR TITLE
fix(tangle-dapp): Use proper balance for account summary card (#2209)

### DIFF
--- a/apps/tangle-dapp/components/account/Balance.tsx
+++ b/apps/tangle-dapp/components/account/Balance.tsx
@@ -12,7 +12,7 @@ import { formatTokenBalance } from '../../utils/polkadot';
 import { InfoIconWithTooltip } from '..';
 
 const Balance: FC = () => {
-  const { transferrable: balance } = useBalances();
+  const { free: balance } = useBalances();
   const { nativeTokenSymbol } = useNetworkStore();
 
   const formattedBalance =

--- a/apps/tangle-dapp/containers/BalancesTableContainer/BalancesTableContainer.tsx
+++ b/apps/tangle-dapp/containers/BalancesTableContainer/BalancesTableContainer.tsx
@@ -78,7 +78,7 @@ const BalancesTableContainer: FC = () => {
             <HeaderCell title="Asset" />
 
             <AssetCell
-              title="Free Balance"
+              title="Transferrable Balance"
               tooltip="The amount of tokens you can freely transfer right now. These tokens are not subject to any limitations."
             />
 


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Account summary card should be displaying `free` balance instead of `transferrable` balance.
- Transferrable balance is now shown under the `Manage balances` table.
- The user can now see their total balance (`free`) and how much they can transfer at the moment (`transferrable`).

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes

### Screen Recording

_If possible provide a screen recording of proposed change._

![image](https://github.com/webb-tools/webb-dapp/assets/101931215/a2758ba6-5a96-46f1-9b4e-1fc2f73a3177)

---

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)