### PR TITLE
feat(tangle-dapp): Sort vesting schedules in ascending order

### DIFF
--- a/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/VestingRemainingBalances.tsx
+++ b/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/VestingRemainingBalances.tsx
@@ -4,6 +4,7 @@ import { FC, useCallback } from 'react';
 import useVestingInfo from '../../../data/vesting/useVestingInfo';
 import usePolkadotApiRx from '../../../hooks/usePolkadotApiRx';
 import BalanceCell from '../BalanceCell';
+import { sortVestingSchedulesAscending } from './VestingScheduleBalances';
 
 const VestingRemainingBalances: FC = () => {
   const { schedulesOpt: vestingSchedulesOpt } = useVestingInfo();
@@ -16,22 +17,27 @@ const VestingRemainingBalances: FC = () => {
     return;
   }
 
-  return vestingSchedulesOpt.unwrap().map((schedule, index) => {
-    // Do not exceed the total locked amount in case that
-    // the ending block has already passed, and the difference
-    // between the current block number and the starting block
-    // number exceeds the total locked amount.
-    const amountAlreadyVested = currentBlockNumber?.gt(schedule.startingBlock)
-      ? BN.min(
-          schedule.locked,
-          currentBlockNumber.sub(schedule.startingBlock).mul(schedule.perBlock)
-        )
-      : BN_ZERO;
+  return vestingSchedulesOpt
+    .unwrap()
+    .toSorted(sortVestingSchedulesAscending)
+    .map((schedule, index) => {
+      // Do not exceed the total locked amount in case that
+      // the ending block has already passed, and the difference
+      // between the current block number and the starting block
+      // number exceeds the total locked amount.
+      const amountAlreadyVested = currentBlockNumber?.gt(schedule.startingBlock)
+        ? BN.min(
+            schedule.locked,
+            currentBlockNumber
+              .sub(schedule.startingBlock)
+              .mul(schedule.perBlock)
+          )
+        : BN_ZERO;
 
-    const remaining = schedule.locked.sub(amountAlreadyVested);
+      const remaining = schedule.locked.sub(amountAlreadyVested);
 
-    return <BalanceCell key={index} amount={remaining} />;
-  });
+      return <BalanceCell key={index} amount={remaining} />;
+    });
 };
 
 export default VestingRemainingBalances;

--- a/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/VestingScheduleBalances.tsx
+++ b/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/VestingScheduleBalances.tsx
@@ -1,3 +1,4 @@
+import { PalletVestingVestingInfo } from '@polkadot/types/lookup';
 import { BN, BN_ZERO, formatDecimal } from '@polkadot/util';
 import { FC, useCallback } from 'react';
 
@@ -5,6 +6,21 @@ import useVestingInfo from '../../../data/vesting/useVestingInfo';
 import usePolkadotApiRx from '../../../hooks/usePolkadotApiRx';
 import { formatTokenBalance } from '../../../utils/polkadot';
 import BalanceCell from '../BalanceCell';
+
+/**
+ * Sort by ending block number in ascending order. This will
+ * effectively show the vesting schedules that will end/unlock
+ * sooner first.
+ */
+export const sortVestingSchedulesAscending = (
+  a: PalletVestingVestingInfo,
+  b: PalletVestingVestingInfo
+): 0 | 1 | -1 => {
+  const endingBlockNumberOfA = a.startingBlock.add(a.locked.div(a.perBlock));
+  const endingBlockNumberOfB = b.startingBlock.add(b.locked.div(b.perBlock));
+
+  return endingBlockNumberOfA.cmp(endingBlockNumberOfB);
+};
 
 const VestingScheduleBalances: FC = () => {
   const { schedulesOpt: vestingSchedulesOpt } = useVestingInfo();
@@ -17,36 +33,43 @@ const VestingScheduleBalances: FC = () => {
     return;
   }
 
-  return vestingSchedulesOpt.unwrap().map((schedule, index) => {
-    // Do not exceed the total locked amount in case that
-    // the ending block has already passed, and the difference
-    // between the current block number and the starting block
-    // number exceeds the total locked amount.
-    const amountAlreadyVested = currentBlockNumber?.gt(schedule.startingBlock)
-      ? BN.min(
-          schedule.locked,
-          currentBlockNumber.sub(schedule.startingBlock).mul(schedule.perBlock)
-        )
-      : BN_ZERO;
+  return vestingSchedulesOpt
+    .unwrap()
+    .toSorted(sortVestingSchedulesAscending)
+    .map((schedule, index) => {
+      // Do not exceed the total locked amount in case that
+      // the ending block has already passed, and the difference
+      // between the current block number and the starting block
+      // number exceeds the total locked amount.
+      const amountAlreadyVested = currentBlockNumber?.gt(schedule.startingBlock)
+        ? BN.min(
+            schedule.locked,
+            currentBlockNumber
+              .sub(schedule.startingBlock)
+              .mul(schedule.perBlock)
+          )
+        : BN_ZERO;
 
-    const remaining = schedule.locked.sub(amountAlreadyVested);
-    const allVested = remaining.isZero();
+      const remaining = schedule.locked.sub(amountAlreadyVested);
+      const allVested = remaining.isZero();
 
-    // The unlock column already shows a status message about the
-    // tokens being fully vested, so don't repeat it here.
-    const status = allVested ? undefined : amountAlreadyVested.isZero() ? (
-      `No tokens have vested yet. This vesting schedule will start unlocking at block #${formatDecimal(
-        schedule.startingBlock.toString()
-      )}.`
-    ) : (
-      <>
-        <strong>{formatTokenBalance(amountAlreadyVested)}</strong> has vested,
-        with <strong>{formatTokenBalance(remaining)}</strong> remaining.
-      </>
-    );
+      // The unlock column already shows a status message about the
+      // tokens being fully vested, so don't repeat it here.
+      const status = allVested ? undefined : amountAlreadyVested.isZero() ? (
+        `No tokens have vested yet. This vesting schedule will start unlocking at block #${formatDecimal(
+          schedule.startingBlock.toString()
+        )}.`
+      ) : (
+        <>
+          <strong>{formatTokenBalance(amountAlreadyVested)}</strong> has vested,
+          with <strong>{formatTokenBalance(remaining)}</strong> remaining.
+        </>
+      );
 
-    return <BalanceCell key={index} amount={schedule.locked} status={status} />;
-  });
+      return (
+        <BalanceCell key={index} amount={schedule.locked} status={status} />
+      );
+    });
 };
 
 export default VestingScheduleBalances;

--- a/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/VestingSchedulesUnlockingAt.tsx
+++ b/apps/tangle-dapp/containers/BalancesTableContainer/LockedBalanceDetails/VestingSchedulesUnlockingAt.tsx
@@ -6,6 +6,7 @@ import usePolkadotApi from '../../../hooks/usePolkadotApi';
 import usePolkadotApiRx from '../../../hooks/usePolkadotApiRx';
 import calculateTimeRemaining from '../../../utils/calculateTimeRemaining';
 import TextCell from './TextCell';
+import { sortVestingSchedulesAscending } from './VestingScheduleBalances';
 
 const VestingSchedulesUnlockingAt: FC = () => {
   const { schedulesOpt: vestingSchedulesOpt } = useVestingInfo();
@@ -27,33 +28,36 @@ const VestingSchedulesUnlockingAt: FC = () => {
     return null;
   }
 
-  return vestingSchedulesOpt.unwrap().map((schedule, index) => {
-    const endingBlockNumber = schedule.startingBlock.add(
-      schedule.locked.div(schedule.perBlock)
-    );
+  return vestingSchedulesOpt
+    .unwrap()
+    .toSorted(sortVestingSchedulesAscending)
+    .map((schedule, index) => {
+      const endingBlockNumber = schedule.startingBlock.add(
+        schedule.locked.div(schedule.perBlock)
+      );
 
-    const timeRemaining = calculateTimeRemaining(
-      babeExpectedBlockTime,
-      currentBlockNumber,
-      endingBlockNumber
-    );
+      const timeRemaining = calculateTimeRemaining(
+        babeExpectedBlockTime,
+        currentBlockNumber,
+        endingBlockNumber
+      );
 
-    const isComplete = currentBlockNumber.gte(endingBlockNumber);
+      const isComplete = currentBlockNumber.gte(endingBlockNumber);
 
-    const progressText = isComplete
-      ? undefined
-      : `${timeRemaining} remaining. Currently at block #${formatDecimal(
-          currentBlockNumber.toString()
-        )}, with ${formatDecimal(
-          endingBlockNumber.sub(currentBlockNumber).toString()
-        )} blocks left until all vested tokens are available to claim.`;
+      const progressText = isComplete
+        ? undefined
+        : `${timeRemaining} remaining. Currently at block #${formatDecimal(
+            currentBlockNumber.toString()
+          )}, with ${formatDecimal(
+            endingBlockNumber.sub(currentBlockNumber).toString()
+          )} blocks left until all vested tokens are available to claim.`;
 
-    const text = isComplete
-      ? 'Fully vested'
-      : `Block #${formatDecimal(endingBlockNumber.toString())}`;
+      const text = isComplete
+        ? 'Fully vested'
+        : `Block #${formatDecimal(endingBlockNumber.toString())}`;
 
-    return <TextCell key={index} text={text} status={progressText} />;
-  });
+      return <TextCell key={index} text={text} status={progressText} />;
+    });
 };
 
 export default VestingSchedulesUnlockingAt;


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Vesting schedules are now sorted in ascending order, with the ones unlocking nearest shown first.
- This is more intuitive and easier on the eyes especially for users with multiple vesting schedules. 

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes #2217

### Screen Recording

_If possible provide a screen recording of proposed change._

![image](https://github.com/webb-tools/webb-dapp/assets/101931215/2e4129ff-9576-4de4-b216-60c99a73d13d)

---

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
