### PR TITLE
style(tangle-dapp): Post-launch visual improvements & fixes

### DIFF
--- a/apps/tangle-dapp/app/claim/EligibleSection.tsx
+++ b/apps/tangle-dapp/app/claim/EligibleSection.tsx
@@ -261,6 +261,7 @@ const EligibleSection: FC<Props> = ({
             }}
             wrapperClassName="pt-0.5"
           />
+
           <Typography variant="body1">
             {`I have read and understood the terms and conditions of the statement provided at `}
             <a

--- a/apps/tangle-dapp/app/page.tsx
+++ b/apps/tangle-dapp/app/page.tsx
@@ -34,7 +34,7 @@ const AccountPage: FC = () => {
       </div>
 
       <Typography variant="h4" fw="bold">
-        Manage Balances
+        Balances
       </Typography>
 
       <Suspense fallback={<SkeletonLoader className="rounded-2xl h-[190px]" />}>

--- a/apps/tangle-dapp/components/AmountInput/BaseInput.tsx
+++ b/apps/tangle-dapp/components/AmountInput/BaseInput.tsx
@@ -17,6 +17,7 @@ import { twMerge } from 'tailwind-merge';
 
 import InputAction from '../../containers/ManageProfileModalContainer/InputAction';
 import { useErrorCountContext } from '../../context/ErrorsContext';
+import { InfoIconWithTooltip } from '../InfoIconWithTooltip';
 
 export type BaseInputProps = {
   title: string;
@@ -35,6 +36,7 @@ export type BaseInputProps = {
   dropdownBodyClassName?: string;
   isFullWidth?: boolean;
   isDisabled?: boolean;
+  tooltip?: ReactNode;
 };
 
 const BaseInput: FC<BaseInputProps> = ({
@@ -54,6 +56,7 @@ const BaseInput: FC<BaseInputProps> = ({
   dropdownBodyClassName,
   isFullWidth = false,
   isDisabled = false,
+  tooltip,
 }) => {
   const { addError, removeError } = useErrorCountContext();
 
@@ -96,12 +99,16 @@ const BaseInput: FC<BaseInputProps> = ({
         )}
       >
         <div className="flex flex-col gap-1 w-full mr-auto">
-          <Label
-            className="text-mono-100 dark:text-mono-80 font-bold"
-            htmlFor={id}
-          >
-            {title}
-          </Label>
+          <div className="flex gap-1">
+            <Label
+              className="text-mono-100 dark:text-mono-80 font-bold"
+              htmlFor={id}
+            >
+              {title}
+            </Label>
+
+            {tooltip !== undefined && <InfoIconWithTooltip content={tooltip} />}
+          </div>
 
           <div className={bodyClassName}>{children}</div>
         </div>

--- a/apps/tangle-dapp/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/apps/tangle-dapp/components/Breadcrumbs/Breadcrumbs.tsx
@@ -24,6 +24,7 @@ import { FC, useMemo } from 'react';
 import { PagePath } from '../../types';
 import { BreadcrumbType } from './types';
 
+// TODO: Need to statically link the breadcrumb labels to the page path for better type safety and to enable fearless refactoring in the future.
 const BREADCRUMB_ICONS: Record<string, BreadcrumbType['icon']> = {
   claim: <GiftLineIcon className="w-4 h-4 lg:w-6 lg:h-6" />,
   services: <GridFillIcon className="w-4 h-4 lg:w-6 lg:h-6" />,
@@ -31,8 +32,10 @@ const BREADCRUMB_ICONS: Record<string, BreadcrumbType['icon']> = {
   nomination: <FundsLine className="w-4 h-4 lg:w-6 lg:h-6" />,
 };
 
+// TODO: Need to statically link the breadcrumb labels to the page path for better type safety and to enable fearless refactoring in the future.
 const BREADCRUMB_LABELS: Record<string, string> = {
   services: 'Service Overview',
+  claim: 'Claim Airdrop',
 };
 
 const getBreadcrumbLabel = (
@@ -71,6 +74,7 @@ const Breadcrumbs: FC<{ className?: string }> = ({ className }) => {
   const pathNames = fullPathname.split('/').filter((path) => path);
 
   const breadCrumbs = useMemo<BreadcrumbType[]>(() => {
+    // Special case for the home page; must specify the breadcrumb manually.
     if (pathNames.length === 0) {
       return [
         {

--- a/apps/tangle-dapp/components/InfoIconWithTooltip/InfoIconWithTooltip.tsx
+++ b/apps/tangle-dapp/components/InfoIconWithTooltip/InfoIconWithTooltip.tsx
@@ -14,10 +14,7 @@ export const InfoIconWithTooltip: FC<InfoIconWithTooltipProps> = ({
       icon={<InformationLine className="fill-mono-140 dark:fill-mono-40" />}
       content={content}
       overrideTooltipBodyProps={{
-        className: twMerge(
-          '!max-w-[185px] !break-normal text-center',
-          className
-        ),
+        className: twMerge('max-w-[350px]', className),
       }}
     />
   );

--- a/apps/tangle-dapp/components/KeyStatsItem/KeyStatsItem.tsx
+++ b/apps/tangle-dapp/components/KeyStatsItem/KeyStatsItem.tsx
@@ -50,9 +50,17 @@ const KeyStatsItem: FC<KeyStatsItemProps> = ({
   }, [error]);
 
   return (
-    <div className={twMerge('px-2 py-2 space-y-2 md:px-2 lg:px-4', className)}>
+    <div
+      className={twMerge(
+        'flex flex-col gap-2 justify-center px-2 py-2 md:px-2 lg:px-4',
+        className
+      )}
+    >
       <div className="flex items-center gap-0.5">
-        <Typography variant="body1" className="text-mono-140 dark:text-mono-40">
+        <Typography
+          variant="body1"
+          className="text-mono-140 dark:text-mono-40 break-all"
+        >
           {title}
         </Typography>
 

--- a/apps/tangle-dapp/components/NetworkSelector/NetworkSelectionButton.tsx
+++ b/apps/tangle-dapp/components/NetworkSelector/NetworkSelectionButton.tsx
@@ -15,13 +15,13 @@ import createCustomNetwork from '../../utils/createCustomNetwork';
 import { NetworkSelectorDropdown } from './NetworkSelectorDropdown';
 
 // TODO: Currently hard-coded, but shouldn't it always be the Tangle icon, since it's not switching chains but rather networks within Tangle? If so, find some constant somewhere instead of having it hard-coded here.
-export const TANGLE_TESTNET_NATIVE_CHAIN_NAME = 'Tangle Testnet Native';
+export const TANGLE_TESTNET_CHAIN_NAME = 'Tangle Testnet Native';
 
 const NetworkSelectionButton: FC = () => {
   const { network, setNetwork, isCustom } = useNetworkState();
 
   const switchToCustomNetwork = useCallback(
-    async (customRpcEndpoint: string) =>
+    (customRpcEndpoint: string) =>
       setNetwork(createCustomNetwork(customRpcEndpoint), true),
     [setNetwork]
   );
@@ -60,11 +60,15 @@ const TriggerButton: FC<{ networkName: string }> = ({ networkName }) => {
       <ChainIcon
         size="lg"
         className="shrink-0 grow-0"
-        name={TANGLE_TESTNET_NATIVE_CHAIN_NAME}
+        name={TANGLE_TESTNET_CHAIN_NAME}
       />
 
       <div className="flex items-center gap-0">
-        <Typography variant="body1" fw="bold" className="dark:text-mono-0">
+        <Typography
+          variant="body1"
+          fw="bold"
+          className="dark:text-mono-0 hidden sm:block"
+        >
           {networkName}
         </Typography>
 

--- a/apps/tangle-dapp/components/NetworkSelector/NetworkSelectionButton.tsx
+++ b/apps/tangle-dapp/components/NetworkSelector/NetworkSelectionButton.tsx
@@ -58,7 +58,6 @@ const TriggerButton: FC<{ networkName: string }> = ({ networkName }) => {
       )}
     >
       <ChainIcon
-        status="success"
         size="lg"
         className="shrink-0 grow-0"
         name={TANGLE_TESTNET_NATIVE_CHAIN_NAME}

--- a/apps/tangle-dapp/components/NetworkSelector/NetworkSelectorDropdown.tsx
+++ b/apps/tangle-dapp/components/NetworkSelector/NetworkSelectorDropdown.tsx
@@ -11,7 +11,7 @@ import { twMerge } from 'tailwind-merge';
 
 import { InfoIconWithTooltip } from '../InfoIconWithTooltip';
 import CustomRpcEndpointInput from './CustomRpcEndpointInput';
-import { TANGLE_TESTNET_NATIVE_CHAIN_NAME } from './NetworkSelectionButton';
+import { TANGLE_TESTNET_CHAIN_NAME } from './NetworkSelectionButton';
 
 export type NetworkSelectorDropdownProps = {
   selectedNetwork: Network | null;
@@ -52,6 +52,14 @@ export const NetworkSelectorDropdown: FC<NetworkSelectorDropdownProps> = ({
         isSelected={selectedNetwork?.name === TANGLE_LOCAL_DEV_NETWORK.name}
         name={TANGLE_LOCAL_DEV_NETWORK.name}
         onClick={() => onNetworkChange(TANGLE_LOCAL_DEV_NETWORK)}
+        tooltip={
+          <>
+            Use this network if you are running a local Tangle node for
+            development purposes. This will attempt to connect to the node
+            running at <strong>{TANGLE_LOCAL_DEV_NETWORK.wsRpcEndpoint}</strong>
+            .
+          </>
+        }
       />
 
       {/* Custom network */}
@@ -103,7 +111,7 @@ const NetworkOption: FC<NetworkOptionProps> = ({
         isSelected && 'bg-mono-20 dark:bg-mono-140 cursor-default'
       )}
     >
-      <ChainIcon size="lg" name={TANGLE_TESTNET_NATIVE_CHAIN_NAME} />
+      <ChainIcon size="lg" name={TANGLE_TESTNET_CHAIN_NAME} />
 
       <Typography variant="body1" fw="semibold" className="dark:text-mono-0">
         {name}

--- a/apps/tangle-dapp/components/NetworkSelector/NetworkSelectorDropdown.tsx
+++ b/apps/tangle-dapp/components/NetworkSelector/NetworkSelectorDropdown.tsx
@@ -6,7 +6,7 @@ import {
   TANGLE_MAINNET_NETWORK,
   TANGLE_TESTNET_NATIVE_NETWORK,
 } from '@webb-tools/webb-ui-components/constants/networks';
-import { FC, ReactNode } from 'react';
+import { FC, ReactNode, useCallback } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 import { InfoIconWithTooltip } from '../InfoIconWithTooltip';
@@ -85,13 +85,13 @@ const NetworkOption: FC<NetworkOptionProps> = ({
   tooltip,
   onClick,
 }) => {
-  const handleClick = () => {
+  const handleClick = useCallback(() => {
     if (isSelected || onClick === undefined) {
       return;
     }
 
     onClick();
-  };
+  }, [isSelected, onClick]);
 
   return (
     <div
@@ -109,12 +109,7 @@ const NetworkOption: FC<NetworkOptionProps> = ({
         {name}
       </Typography>
 
-      {tooltip !== undefined && (
-        <InfoIconWithTooltip
-          className="!max-w-[200px]"
-          content={<>{tooltip}</>}
-        />
-      )}
+      {tooltip !== undefined && <InfoIconWithTooltip content={tooltip} />}
     </div>
   );
 };

--- a/apps/tangle-dapp/components/Sidebar/Sidebar.tsx
+++ b/apps/tangle-dapp/components/Sidebar/Sidebar.tsx
@@ -28,7 +28,7 @@ const Sidebar: FC<SidebarProps> = ({ isExpandedAtDefault }) => {
       pathnameOrHash={pathname}
       className="hidden lg:block !z-0"
       isExpandedAtDefault={isExpandedAtDefault}
-      onSideBarToggle={() => setSidebarCookieOnToggle()}
+      onSideBarToggle={setSidebarCookieOnToggle}
     />
   );
 };

--- a/apps/tangle-dapp/containers/BalancesTableContainer/BalancesTableContainer.tsx
+++ b/apps/tangle-dapp/containers/BalancesTableContainer/BalancesTableContainer.tsx
@@ -183,9 +183,7 @@ const AssetCell: FC<{
           {title}
         </Typography>
 
-        {tooltip !== undefined && (
-          <InfoIconWithTooltip content={<>{tooltip}</>} />
-        )}
+        {tooltip !== undefined && <InfoIconWithTooltip content={tooltip} />}
       </div>
     </div>
   );

--- a/apps/tangle-dapp/containers/KeyStatsContainer/ActualStakedPercentageKeyStat.tsx
+++ b/apps/tangle-dapp/containers/KeyStatsContainer/ActualStakedPercentageKeyStat.tsx
@@ -11,7 +11,7 @@ const ActualStakedPercentageKeyStat: FC = () => {
   return (
     <KeyStatsItem
       title="Actual Staked"
-      tooltip="The % of all network tokens that have been staked in the current era."
+      tooltip="The actual percentage of all network tokens that have been staked in the current era."
       className="!border-r-0 lg:!border-r  lg:!border-b-0"
       suffix="%"
       isLoading={actualStakedPercentage === null}

--- a/apps/tangle-dapp/containers/KeyStatsContainer/IdealStakedPercentageKeyStat.tsx
+++ b/apps/tangle-dapp/containers/KeyStatsContainer/IdealStakedPercentageKeyStat.tsx
@@ -11,7 +11,7 @@ const IdealStakedPercentageKeyStat: FC = () => {
   return (
     <KeyStatsItem
       title="Ideal Staked"
-      tooltip="The ideal % of all network tokens that should be staked."
+      tooltip="Ideal proportion of tokens staked to secure the network and sustain active token trade and usage."
       className="!border-b-0"
       suffix="%"
       isLoading={isLoading}

--- a/apps/tangle-dapp/containers/KeyStatsContainer/InflationPercentageKeyStat.tsx
+++ b/apps/tangle-dapp/containers/KeyStatsContainer/InflationPercentageKeyStat.tsx
@@ -11,7 +11,7 @@ const InflationPercentageKeyStat: FC = () => {
   return (
     <KeyStatsItem
       title="Inflation"
-      tooltip="The yearly % increase in the network’s total token supply."
+      tooltip="The yearly percent increase in the network's total token supply."
       className="!border-b-0 !border-r-0"
       suffix="%"
       isLoading={isLoading}

--- a/apps/tangle-dapp/containers/Layout/FeedbackBanner.tsx
+++ b/apps/tangle-dapp/containers/Layout/FeedbackBanner.tsx
@@ -4,14 +4,40 @@ import { Transition } from '@headlessui/react';
 import { BoxLine } from '@webb-tools/icons';
 import { Banner } from '@webb-tools/webb-ui-components/components/Banner';
 import { GITHUB_BUG_REPORT_URL } from '@webb-tools/webb-ui-components/constants';
-import { FC, useState } from 'react';
+import { FC, useCallback, useEffect, useState } from 'react';
+
+import useLocalStorage, { LocalStorageKey } from '../../hooks/useLocalStorage';
 
 const FeedbackBanner: FC = () => {
-  const [showBanner, setShowBanner] = useState(true);
+  // Initially, the banner is hidden until the value is
+  // extracted from local storage.
+  const [showBanner, setShowBanner] = useState(false);
 
-  const onCloseHandler = () => {
+  const {
+    isSet: isBannerDismissalCacheSet,
+    get: getCachedWasBannerDismissed,
+    set: setCachedWasBannerDismissed,
+  } = useLocalStorage(LocalStorageKey.WAS_BANNER_DISMISSED);
+
+  // If there is no cache key, show the banner by default.
+  useEffect(() => {
+    if (!isBannerDismissalCacheSet()) {
+      setShowBanner(true);
+    }
+  }, [isBannerDismissalCacheSet, setShowBanner]);
+
+  // If the banner was dismissed, do not show it to prevent
+  // annoying the user.
+  useEffect(() => {
+    if (getCachedWasBannerDismissed() === true) {
+      setShowBanner(false);
+    }
+  }, [getCachedWasBannerDismissed]);
+
+  const onCloseHandler = useCallback(() => {
     setShowBanner(false);
-  };
+    setCachedWasBannerDismissed(true);
+  }, [setCachedWasBannerDismissed]);
 
   return (
     <Transition show={showBanner}>

--- a/apps/tangle-dapp/containers/ManageProfileModalContainer/InputAction.tsx
+++ b/apps/tangle-dapp/containers/ManageProfileModalContainer/InputAction.tsx
@@ -31,10 +31,8 @@ const InputAction: FC<InputActionProps> = ({
     icon
   ) : (
     <IconWithTooltip
-      overrideTooltipBodyProps={{
-        className: 'break-normal text-center max-w-[200px]',
-      }}
-      content={<>{tooltip}</>}
+      overrideTooltipBodyProps={{ className: 'max-w-[200px]' }}
+      content={tooltip}
       icon={icon}
     />
   );

--- a/apps/tangle-dapp/containers/NominationsPayoutsContainer/NominationsPayoutsContainer.tsx
+++ b/apps/tangle-dapp/containers/NominationsPayoutsContainer/NominationsPayoutsContainer.tsx
@@ -172,6 +172,7 @@ const DelegationsPayoutsContainer: FC = () => {
               <div>
                 <Button
                   variant="utility"
+                  size="sm"
                   isDisabled={payouts.length === 0}
                   onClick={() => setIsPayoutAllModalOpen(true)}
                 >

--- a/apps/tangle-dapp/containers/NominatorStatsContainer/NominatorStatsContainer.tsx
+++ b/apps/tangle-dapp/containers/NominatorStatsContainer/NominatorStatsContainer.tsx
@@ -119,7 +119,7 @@ const NominatorStatsContainer: FC = () => {
           <div className="grid grid-cols-2 gap-2">
             <NominatorStatsItem
               title={`Total Staked ${nativeTokenSymbol}`}
-              tooltip={`The total amount of tokens you have bonded for nominating.`}
+              tooltip="The total amount of tokens you have bonded for nominating."
               type="Total Staked"
               address={substrateAddress}
             />

--- a/apps/tangle-dapp/containers/RecentTxContainer/RecentTxContainer.tsx
+++ b/apps/tangle-dapp/containers/RecentTxContainer/RecentTxContainer.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { Button, Typography } from '@webb-tools/webb-ui-components';
+import { TANGLE_DOCS_URL } from '@webb-tools/webb-ui-components/constants';
+import Link from 'next/link';
 import { FC } from 'react';
 
 import GlassCard from '../../components/GlassCard/GlassCard';
@@ -12,8 +14,8 @@ const RecentTxContainer: FC = () => {
   const { isEvm } = useAgnosticAccountInfo();
 
   return (
-    <GlassCard className="space-y-4">
-      <div className="flex justify-end p-4">
+    <GlassCard className="flex flex-col gap-3 sm:gap-0">
+      <div className="flex justify-end">
         <Button
           size="sm"
           variant="utility"
@@ -26,11 +28,15 @@ const RecentTxContainer: FC = () => {
         </Button>
       </div>
 
-      <div className="flex flex-col gap-3 justify-center items-center h-full text-center">
+      <div className="flex flex-col gap-5 justify-center items-center h-full text-center">
         <Typography variant="body1" className="text-center max-w-lg">
-          Welcome to Tangle dApp – Your portal to managing Tangle Network assets
-          and upcoming Multi-Party Computation (MPC) services.
+          Welcome to Tangle dApp &mdash; Your portal to managing Tangle Network
+          assets and upcoming Multi-Party Computation (MPC) services.
         </Typography>
+
+        <Link href={TANGLE_DOCS_URL} target="_blank">
+          <Button isFullWidth>Learn More</Button>
+        </Link>
       </div>
     </GlassCard>
   );

--- a/apps/tangle-dapp/containers/TransferTxContainer/TransferTxContainer.tsx
+++ b/apps/tangle-dapp/containers/TransferTxContainer/TransferTxContainer.tsx
@@ -13,7 +13,7 @@ import {
 } from '@webb-tools/webb-ui-components';
 import { TANGLE_DOCS_URL } from '@webb-tools/webb-ui-components/constants';
 import Link from 'next/link';
-import { FC, useCallback, useEffect, useState } from 'react';
+import { FC, ReactNode, useCallback, useEffect, useState } from 'react';
 import { isHex } from 'viem';
 
 import AddressInput, {
@@ -127,6 +127,17 @@ const TransferTxContainer: FC<TransferTxContainerProps> = ({
   const isValidReceiverAddress =
     isAddress(receiverAddress) || isHex(receiverAddress);
 
+  const transferrableBalanceTooltip: ReactNode = transferrableBalance !==
+    null && (
+    <span>
+      You have{' '}
+      <strong>
+        {formatTokenBalance(transferrableBalance, nativeTokenSymbol)}
+      </strong>{' '}
+      available to transfer.
+    </span>
+  );
+
   return (
     <Modal>
       <ModalContent
@@ -166,7 +177,10 @@ const TransferTxContainer: FC<TransferTxContainerProps> = ({
               isDisabled={!isReady}
               amount={amount}
               setAmount={setAmount}
-              baseInputOverrides={{ isFullWidth: true }}
+              baseInputOverrides={{
+                isFullWidth: true,
+                tooltip: transferrableBalanceTooltip,
+              }}
               maxErrorMessage="Not enough available balance"
               setErrorMessage={handleSetErrorMessage}
             />

--- a/apps/tangle-dapp/containers/TransferTxContainer/TransferTxContainer.tsx
+++ b/apps/tangle-dapp/containers/TransferTxContainer/TransferTxContainer.tsx
@@ -194,6 +194,14 @@ const TransferTxContainer: FC<TransferTxContainerProps> = ({
 
         <ModalFooter className="flex items-center gap-2 px-8 py-6 space-y-0">
           <div className="flex-1">
+            <Link href={TANGLE_DOCS_URL} target="_blank" className="w-full">
+              <Button isFullWidth variant="secondary">
+                Learn More
+              </Button>
+            </Link>
+          </div>
+
+          <div className="flex-1">
             <Button
               isFullWidth
               isLoading={!isReady}
@@ -207,14 +215,6 @@ const TransferTxContainer: FC<TransferTxContainerProps> = ({
             >
               Send
             </Button>
-          </div>
-
-          <div className="flex-1">
-            <Link href={TANGLE_DOCS_URL} target="_blank" className="w-full">
-              <Button isFullWidth variant="secondary">
-                Learn More
-              </Button>
-            </Link>
           </div>
         </ModalFooter>
       </ModalContent>

--- a/apps/tangle-dapp/hooks/useLocalStorage.ts
+++ b/apps/tangle-dapp/hooks/useLocalStorage.ts
@@ -18,6 +18,7 @@ export enum LocalStorageKey {
   KNOWN_NETWORK_ID = 'knownNetworkId',
   NATIVE_TOKEN_SYMBOL = 'nativeTokenSymbol',
   VALIDATORS = 'validators',
+  WAS_BANNER_DISMISSED = 'wasBannerDismissed',
 }
 
 export type AirdropEligibilityCache = {
@@ -61,6 +62,8 @@ export type LocalStorageValueOf<T extends LocalStorageKey> =
     ? string
     : T extends LocalStorageKey.KNOWN_NETWORK_ID
     ? number
+    : T extends LocalStorageKey.WAS_BANNER_DISMISSED
+    ? boolean
     : never;
 
 export const extractFromLocalStorage = <Key extends LocalStorageKey>(

--- a/libs/webb-ui-components/src/components/ChainsRing/ChainsRing.tsx
+++ b/libs/webb-ui-components/src/components/ChainsRing/ChainsRing.tsx
@@ -39,7 +39,10 @@ const ChainsRing = forwardRef<HTMLDivElement, ChainsRingProps>(
           const chainName = chainsConfig[typedChainId].name;
 
           return (
-            <Tooltip key={typedChainId}>
+            // NOTE: Would ideally have the key be the chain id, but the edge
+            // case where the same chain is repeated (ex. transferring between
+            // the same chain) would cause issues.
+            <Tooltip key={idx}>
               <TooltipTrigger className="cursor-pointer" asChild>
                 <div
                   className={getChainIconClassNameByIdx(idx)}
@@ -48,6 +51,7 @@ const ChainsRing = forwardRef<HTMLDivElement, ChainsRingProps>(
                   <ChainIcon name={chainName} size="lg" />
                 </div>
               </TooltipTrigger>
+
               <TooltipBody className="z-20">{chainName}</TooltipBody>
             </Tooltip>
           );

--- a/libs/webb-ui-components/src/components/CheckBox/Checkbox.tsx
+++ b/libs/webb-ui-components/src/components/CheckBox/Checkbox.tsx
@@ -56,7 +56,11 @@ export const CheckBox: React.FC<CheckBoxProps> = (props) => {
   const inputDisabledClsx =
     'disabled:border-mono-60 disabled:cursor-not-allowed disabled:bg-mono-0 disabled:shadow-none dark:disabled:bg-mono-140 dark:disabled:border-mono-120';
 
+  const inputCursorClsx =
+    'cursor-pointer disabled:cursor-not-allowed peer-disabled:cursor-not-allowed';
+
   const mergedInputClsx = twMerge(
+    inputCursorClsx,
     inputClsx,
     inputHoverClsx,
     inputCheckedClsx,
@@ -70,6 +74,7 @@ export const CheckBox: React.FC<CheckBoxProps> = (props) => {
     labelVariant,
     spacingClassName
   );
+
   const mergedLabelClsx = twMerge(labelClsx, labelClsxProp);
 
   return (
@@ -83,6 +88,7 @@ export const CheckBox: React.FC<CheckBoxProps> = (props) => {
         disabled={isDisabled}
         {...inputProps}
       />
+
       {children && <label className={mergedLabelClsx}>{children}</label>}
 
       {info && (
@@ -92,6 +98,7 @@ export const CheckBox: React.FC<CheckBoxProps> = (props) => {
               <InformationLine className="!fill-current pointer-events-none" />
             </span>
           </TooltipTrigger>
+
           <TooltipBody
             title={info.title}
             className="max-w-[185px] break-normal"

--- a/libs/webb-ui-components/src/components/IconWithTooltip/IconWithTooltip.tsx
+++ b/libs/webb-ui-components/src/components/IconWithTooltip/IconWithTooltip.tsx
@@ -26,7 +26,9 @@ export const IconWithTooltip: FC<IconWithTooltipProp> = ({
 
       <TooltipBody {...overrideTooltipBodyProps}>
         {typeof content === 'string' || typeof content === 'number' ? (
-          <Typography variant="body3">{content}</Typography>
+          <Typography variant="body3" className="text-center break-normal">
+            {content}
+          </Typography>
         ) : (
           content
         )}

--- a/libs/webb-ui-components/src/components/IconWithTooltip/IconWithTooltip.tsx
+++ b/libs/webb-ui-components/src/components/IconWithTooltip/IconWithTooltip.tsx
@@ -25,13 +25,9 @@ export const IconWithTooltip: FC<IconWithTooltipProp> = ({
       </TooltipTrigger>
 
       <TooltipBody {...overrideTooltipBodyProps}>
-        {typeof content === 'string' || typeof content === 'number' ? (
-          <Typography variant="body3" className="text-center break-normal">
-            {content}
-          </Typography>
-        ) : (
-          content
-        )}
+        <Typography variant="body3" className="text-center break-normal">
+          {content}
+        </Typography>
       </TooltipBody>
     </Tooltip>
   );

--- a/libs/webb-ui-components/src/components/SideBar/Item.tsx
+++ b/libs/webb-ui-components/src/components/SideBar/Item.tsx
@@ -92,16 +92,16 @@ const SideBarItem: FC<SideBarItemProps & SideBarExtraItemProps> = ({
             <div
               className={twMerge(
                 'group select-none rounded-full',
-                isDisabled ? 'pointer-events-none' : '',
+                isDisabled && 'pointer-events-none',
                 !isExpanded ? 'px-3 py-2' : 'flex items-center',
                 isActive && (subItems.length === 0 || !isExpanded)
                   ? 'text-mono-200 dark:text-mono-0'
                   : 'text-mono-100 dark:text-mono-100',
-                isExpanded ? 'hover:bg-mono-20 dark:hover:bg-mono-160' : '',
-                isExpanded ? 'justify-between px-1 py-3' : 'justify-center',
-                isActive && (subItems.length === 0 || !isExpanded)
-                  ? 'bg-mono-20 dark:bg-mono-160'
-                  : ''
+                isExpanded && 'hover:bg-mono-20 dark:hover:bg-mono-160',
+                isExpanded ? 'justify-between px-4 py-3' : 'justify-center',
+                isActive &&
+                  (subItems.length === 0 || !isExpanded) &&
+                  'bg-mono-20 dark:bg-mono-160'
               )}
             >
               <div

--- a/libs/webb-ui-components/src/constants/networks.ts
+++ b/libs/webb-ui-components/src/constants/networks.ts
@@ -56,7 +56,7 @@ export const TANGLE_MAINNET_NETWORK: Network = {
 export const TANGLE_TESTNET_NATIVE_NETWORK: Network = {
   id: NetworkId.TANGLE_TESTNET,
   chainId: 3799,
-  name: 'Tangle Testnet Native',
+  name: 'Tangle Testnet',
   nodeType: 'standalone',
   subqueryEndpoint: SUBQUERY_ENDPOINT,
   httpRpcEndpoint: 'https://testnet-rpc.tangle.tools',
@@ -71,7 +71,7 @@ export const TANGLE_TESTNET_NATIVE_NETWORK: Network = {
 export const TANGLE_LOCAL_DEV_NETWORK: Network = {
   id: NetworkId.TANGLE_LOCAL_DEV,
   chainId: 3799,
-  name: 'Local endpoint (127.0.0.1)',
+  name: 'Local endpoint',
   nodeType: 'standalone',
   subqueryEndpoint: 'http://localhost:4000/graphql',
   wsRpcEndpoint: 'ws://127.0.0.1:9944',


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- [x] Show available balance for transferring on the Transfer modal
- [x] Show what the RPC URL is for the local network selector option, since right now the users don't have any way of knowing
- [x] Hide the selected network's name on the network selector on MOBILE view, since it is taking huge amount of space and breaks the design:
  ![image](https://github.com/webb-tools/webb-dapp/assets/101931215/7edf7f85-a24d-41a1-a64e-b09368b62020)
- [x] Improve text copy for tooltips, make them more useful. Right now, they are a bit vague; for example, look at Ideal Staked's tooltip: It just mentions 'the % of tokens that should be staked' but no further reason as to WHY.
- [x] Tooltips look strange being left-aligned, they should be center-aligned instead. Ideally, make this change across all tooltips for consistency: 
  ![image](https://github.com/webb-tools/webb-dapp/assets/101931215/a46f4313-6f09-4139-a909-d3b98f8847bb)
- [x] If the user closes the banner, it may be a good idea to remember that via a local storage entry, to avoid annoyance:
  ![image](https://github.com/webb-tools/webb-dapp/assets/101931215/f4a80456-1a63-4029-969c-2bdad4dd18ed)
- [x] `Claim Airdrop` page's breadcrumb should reflect the same label as the navbar for consistency:
  ![image](https://github.com/webb-tools/webb-dapp/assets/101931215/1a83096e-29e6-448d-b1ba-df4cdc993da3)
- [x] Sidebar items' horizontal padding should be adjusted, as currently it is tight and looks strange:
  ![image](https://github.com/webb-tools/webb-dapp/assets/101931215/a9847ffd-0a06-49b2-8e05-d0162762abf1)
- [x] `Recent Transactions` container on the account page has a lot of empty whitespace and could use an improved design or content (cc @monaiuu):
  ![image](https://github.com/webb-tools/webb-dapp/assets/101931215/a4b0636f-07cb-41c7-a113-a86b66d9d47b)
- [x] On the account page -> Transfer modal, the buttons' order is unintuitive and inconsistent with other modals, it may be better to place `Send` on the right:
  ![image](https://github.com/webb-tools/webb-dapp/assets/101931215/f57866ab-c88c-4d81-b47b-44b7b19627d4)
- [x] On network selector, the active network displays a green status indicator, but that status indicator is hard-coded and serves no purpose, which may be misleading to the users:
  ![image](https://github.com/webb-tools/webb-dapp/assets/101931215/da453323-1e46-4035-9432-ea8a4347fbb0)
- [x] Checkboxes do not currently show a hand cursor to indicate that they are clickable:
  ![image](https://github.com/webb-tools/webb-dapp/assets/101931215/3743bb53-505a-4569-a626-243326ce8baf)

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes #2208

### Screen Recording

https://github.com/webb-tools/webb-dapp/assets/101931215/894d71c9-389c-4852-9634-31cd27491bbe

_If possible provide a screen recording of proposed change._

---

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
