### PR TITLE
Update Explorer links on Tangle Dapp + getUrlExplorer + Chains Config

### DIFF
--- a/apps/bridge-dapp/src/components/Header/Header.tsx
+++ b/apps/bridge-dapp/src/components/Header/Header.tsx
@@ -2,6 +2,7 @@ import {
   useWebContext,
   useConnectWallet,
 } from '@webb-tools/api-provider-environment';
+import { TANGLE_TESTNET_NATIVE_EXPLORER_URL } from '@webb-tools/dapp-config/constants/tangle';
 import { WebbLogoIcon } from '@webb-tools/icons';
 import {
   Breadcrumbs,
@@ -20,7 +21,6 @@ import {
 import {
   GITHUB_REQUEST_FEATURE_URL,
   SOCIAL_URLS_RECORD,
-  TANGLE_TESTNET_NATIVE_EXPLORER_URL,
   WEBB_DOCS_URL,
   WEBB_FAUCET_URL,
   WEBB_MKT_URL,

--- a/apps/faucet/src/components/Header.tsx
+++ b/apps/faucet/src/components/Header.tsx
@@ -1,3 +1,4 @@
+import { TANGLE_TESTNET_NATIVE_EXPLORER_URL } from '@webb-tools/dapp-config/constants/tangle';
 import { FaucetIcon, TangleIcon } from '@webb-tools/icons';
 import {
   Breadcrumbs,
@@ -14,7 +15,6 @@ import {
   GITHUB_REQUEST_FEATURE_URL,
   SOCIAL_URLS_RECORD,
   TANGLE_MKT_URL,
-  TANGLE_TESTNET_NATIVE_EXPLORER_URL,
 } from '@webb-tools/webb-ui-components/constants';
 import Link from 'next/link';
 import { type FC } from 'react';

--- a/apps/faucet/src/constants/sidebar.ts
+++ b/apps/faucet/src/constants/sidebar.ts
@@ -1,4 +1,8 @@
 import {
+  TANGLE_TESTNET_EVM_EXPLORER_URL,
+  TANGLE_TESTNET_NATIVE_EXPLORER_URL,
+} from '@webb-tools/dapp-config/constants/tangle';
+import {
   AppsLine,
   DocumentationIcon,
   FaucetIcon,
@@ -18,8 +22,6 @@ import {
   DKG_STATS_PROPOSALS_URL,
   TANGLE_DOCS_URL,
   TANGLE_MKT_URL,
-  TANGLE_TESTNET_EVM_EXPLORER_URL,
-  TANGLE_TESTNET_NATIVE_EXPLORER_URL,
 } from '@webb-tools/webb-ui-components/constants';
 
 const items: SideBarItemProps[] = [

--- a/apps/hubble-stats/containers/Layout/Header.tsx
+++ b/apps/hubble-stats/containers/Layout/Header.tsx
@@ -8,6 +8,7 @@ import {
   NavigationMenuTrigger,
   Logo,
 } from '@webb-tools/webb-ui-components';
+import { TANGLE_TESTNET_NATIVE_EXPLORER_URL } from '@webb-tools/dapp-config/constants/tangle';
 import { WebbLogoIcon } from '@webb-tools/icons';
 import { Breadcrumbs, SideBarMenu } from '../../components';
 import {
@@ -16,7 +17,6 @@ import {
   GITHUB_REQUEST_FEATURE_URL,
   SOCIAL_URLS_RECORD,
   TANGLE_MKT_URL,
-  TANGLE_TESTNET_NATIVE_EXPLORER_URL,
 } from '@webb-tools/webb-ui-components/constants';
 
 const Header: FC = () => {

--- a/apps/stats-dapp/src/containers/KeyDetail/KeyDetail.tsx
+++ b/apps/stats-dapp/src/containers/KeyDetail/KeyDetail.tsx
@@ -28,7 +28,7 @@ import {
   TitleWithInfo,
 } from '@webb-tools/webb-ui-components/components';
 import { fuzzyFilter } from '@webb-tools/webb-ui-components/components/Filter/utils';
-import { POLKADOT_EXPLORER_URL } from '@webb-tools/webb-ui-components/constants';
+import { POLKADOT_JS_EXPLORER_URL } from '@webb-tools/webb-ui-components/constants';
 import { Typography } from '@webb-tools/webb-ui-components/typography';
 import cx from 'classnames';
 import getUnicodeFlagIcon from 'country-flag-icons/unicode';
@@ -250,7 +250,7 @@ export const KeyDetail = forwardRef<HTMLDivElement, KeyDetailProps>(
                       title={status}
                       time={at}
                       blockHash={hash}
-                      externalUrl={POLKADOT_EXPLORER_URL + hash}
+                      externalUrl={POLKADOT_JS_EXPLORER_URL + hash}
                     />
                   );
                 }
@@ -262,7 +262,7 @@ export const KeyDetail = forwardRef<HTMLDivElement, KeyDetailProps>(
                       title={status}
                       time={at}
                       blockHash={hash}
-                      externalUrl={POLKADOT_EXPLORER_URL + hash}
+                      externalUrl={POLKADOT_JS_EXPLORER_URL + hash}
                     />
                   );
                 }
@@ -274,7 +274,7 @@ export const KeyDetail = forwardRef<HTMLDivElement, KeyDetailProps>(
                       title={status}
                       time={at}
                       blockHash={hash}
-                      externalUrl={POLKADOT_EXPLORER_URL + hash}
+                      externalUrl={POLKADOT_JS_EXPLORER_URL + hash}
                     />
                   );
                 }

--- a/apps/tangle-dapp/app/claim/success/SuccessClient.tsx
+++ b/apps/tangle-dapp/app/claim/success/SuccessClient.tsx
@@ -8,12 +8,12 @@ import { AppTemplate } from '@webb-tools/webb-ui-components/containers/AppTempla
 import { Typography } from '@webb-tools/webb-ui-components/typography/Typography';
 import { type FC } from 'react';
 
-import useExplorerUrl from '../../../hooks/useExplorerUrl';
+import useTxExplorerUrl from '../../../hooks/useTxExplorerUrl';
 import { ExplorerType } from '../../../types';
 
 const SuccessClient: FC<{ blockHash: HexString }> = ({ blockHash }) => {
-  const getExplorerUrl = useExplorerUrl();
-  const txExplorerUrl = getExplorerUrl(blockHash, ExplorerType.Substrate);
+  const getTxExplorerUrl = useTxExplorerUrl();
+  const txExplorerUrl = getTxExplorerUrl(blockHash, ExplorerType.Substrate);
 
   return (
     <AppTemplate.Content>

--- a/apps/tangle-dapp/app/claim/success/SuccessClient.tsx
+++ b/apps/tangle-dapp/app/claim/success/SuccessClient.tsx
@@ -8,7 +8,8 @@ import { AppTemplate } from '@webb-tools/webb-ui-components/containers/AppTempla
 import { Typography } from '@webb-tools/webb-ui-components/typography/Typography';
 import { type FC } from 'react';
 
-import useExplorerUrl, { ExplorerType } from '../../../hooks/useExplorerUrl';
+import useExplorerUrl from '../../../hooks/useExplorerUrl';
+import { ExplorerType } from '../../../types';
 
 const SuccessClient: FC<{ blockHash: HexString }> = ({ blockHash }) => {
   const getExplorerUrl = useExplorerUrl();

--- a/apps/tangle-dapp/app/services/[serviceId]/JobsListTable.tsx
+++ b/apps/tangle-dapp/app/services/[serviceId]/JobsListTable.tsx
@@ -46,7 +46,7 @@ const columns = [
     cell: (props) => {
       const txHash = props.getValue();
 
-      // TODO: This should be based off the active network, cannot assume it is always the testnet!
+      // TODO: get the network from store, move this into the component
       const txExplorerURI = TANGLE_BLOCK_EXPLORER
         ? getExplorerURI(
             TANGLE_BLOCK_EXPLORER,

--- a/apps/tangle-dapp/components/KeyStatsItem/KeyStatsItem.tsx
+++ b/apps/tangle-dapp/components/KeyStatsItem/KeyStatsItem.tsx
@@ -59,7 +59,7 @@ const KeyStatsItem: FC<KeyStatsItemProps> = ({
       <div className="flex items-center gap-0.5">
         <Typography
           variant="body1"
-          className="text-mono-140 dark:text-mono-40 break-all"
+          className="text-mono-140 dark:text-mono-40 break-all xl:whitespace-nowrap"
         >
           {title}
         </Typography>

--- a/apps/tangle-dapp/components/TxConfirmationModal/TxConfirmationModal.tsx
+++ b/apps/tangle-dapp/components/TxConfirmationModal/TxConfirmationModal.tsx
@@ -16,7 +16,7 @@ import {
 import { KeyValueWithButton } from '@webb-tools/webb-ui-components/components/KeyValueWithButton';
 import { FC, useCallback } from 'react';
 
-import useExplorerUrl from '../../hooks/useExplorerUrl';
+import useTxExplorerUrl from '../../hooks/useTxExplorerUrl';
 import { ExplorerType } from '../../types';
 import { TxConfirmationModalProps } from './types';
 
@@ -27,9 +27,9 @@ export const TxConfirmationModal: FC<TxConfirmationModalProps> = ({
   txHash,
   txType,
 }) => {
-  const getExplorerUrl = useExplorerUrl();
+  const getTxExplorerUrl = useTxExplorerUrl();
 
-  const txExplorerUrl = getExplorerUrl(
+  const txExplorerUrl = getTxExplorerUrl(
     txHash,
     txType === 'evm' ? ExplorerType.EVM : ExplorerType.Substrate
   );

--- a/apps/tangle-dapp/components/TxConfirmationModal/TxConfirmationModal.tsx
+++ b/apps/tangle-dapp/components/TxConfirmationModal/TxConfirmationModal.tsx
@@ -16,7 +16,8 @@ import {
 import { KeyValueWithButton } from '@webb-tools/webb-ui-components/components/KeyValueWithButton';
 import { FC, useCallback } from 'react';
 
-import useExplorerUrl, { ExplorerType } from '../../hooks/useExplorerUrl';
+import useExplorerUrl from '../../hooks/useExplorerUrl';
+import { ExplorerType } from '../../types';
 import { TxConfirmationModalProps } from './types';
 
 export const TxConfirmationModal: FC<TxConfirmationModalProps> = ({

--- a/apps/tangle-dapp/containers/RecentTxContainer/RecentTxContainer.tsx
+++ b/apps/tangle-dapp/containers/RecentTxContainer/RecentTxContainer.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { getExplorerURI } from '@webb-tools/api-provider-environment/transaction/utils';
 import { Button, Typography } from '@webb-tools/webb-ui-components';
 import { TANGLE_DOCS_URL } from '@webb-tools/webb-ui-components/constants';
 import Link from 'next/link';
@@ -11,7 +12,14 @@ import useAgnosticAccountInfo from '../../hooks/useAgnosticAccountInfo';
 
 const RecentTxContainer: FC = () => {
   const { network } = useNetworkStore();
-  const { isEvm } = useAgnosticAccountInfo();
+  const { isEvm, substrateAddress, evmAddress } = useAgnosticAccountInfo();
+
+  const accountExplorerUrl = getExplorerURI(
+    isEvm ? network.evmExplorerUrl : network.polkadotExplorerUrl,
+    (isEvm ? evmAddress : substrateAddress) ?? '',
+    'address',
+    isEvm ? 'web3' : 'polkadot'
+  ).toString();
 
   return (
     <GlassCard className="flex flex-col gap-3 sm:gap-0">
@@ -22,7 +30,7 @@ const RecentTxContainer: FC = () => {
           color="primary"
           className="uppercase"
           target="_blank"
-          href={isEvm ? network.evmExplorerUrl : network.polkadotExplorerUrl}
+          href={accountExplorerUrl}
         >
           Open Explorer
         </Button>

--- a/apps/tangle-dapp/containers/RecentTxContainer/RecentTxContainer.tsx
+++ b/apps/tangle-dapp/containers/RecentTxContainer/RecentTxContainer.tsx
@@ -9,6 +9,7 @@ import { FC } from 'react';
 import GlassCard from '../../components/GlassCard/GlassCard';
 import useNetworkStore from '../../context/useNetworkStore';
 import useAgnosticAccountInfo from '../../hooks/useAgnosticAccountInfo';
+import { ExplorerType } from '../../types';
 
 const RecentTxContainer: FC = () => {
   const { network } = useNetworkStore();
@@ -18,7 +19,7 @@ const RecentTxContainer: FC = () => {
     isEvm ? network.evmExplorerUrl : network.polkadotExplorerUrl,
     (isEvm ? evmAddress : substrateAddress) ?? '',
     'address',
-    isEvm ? 'web3' : 'polkadot'
+    isEvm ? ExplorerType.EVM : ExplorerType.Substrate
   ).toString();
 
   return (

--- a/apps/tangle-dapp/containers/RecentTxContainer/RecentTxContainer.tsx
+++ b/apps/tangle-dapp/containers/RecentTxContainer/RecentTxContainer.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { isEthereumAddress } from '@polkadot/util-crypto';
 import { getExplorerURI } from '@webb-tools/api-provider-environment/transaction/utils';
 import { Button, Typography } from '@webb-tools/webb-ui-components';
 import { TANGLE_DOCS_URL } from '@webb-tools/webb-ui-components/constants';
@@ -8,19 +9,26 @@ import { FC } from 'react';
 
 import GlassCard from '../../components/GlassCard/GlassCard';
 import useNetworkStore from '../../context/useNetworkStore';
-import useAgnosticAccountInfo from '../../hooks/useAgnosticAccountInfo';
+import useActiveAccountAddress from '../../hooks/useActiveAccountAddress';
 import { ExplorerType } from '../../types';
 
 const RecentTxContainer: FC = () => {
   const { network } = useNetworkStore();
-  const { isEvm, substrateAddress, evmAddress } = useAgnosticAccountInfo();
+  const activeAccountAddress = useActiveAccountAddress();
 
-  const accountExplorerUrl = getExplorerURI(
-    isEvm ? network.evmExplorerUrl : network.polkadotExplorerUrl,
-    (isEvm ? evmAddress : substrateAddress) ?? '',
-    'address',
-    isEvm ? ExplorerType.EVM : ExplorerType.Substrate
-  ).toString();
+  const isEvm =
+    activeAccountAddress === null
+      ? null
+      : isEthereumAddress(activeAccountAddress);
+
+  const accountExplorerUrl = activeAccountAddress
+    ? getExplorerURI(
+        isEvm ? network.evmExplorerUrl : network.polkadotExplorerUrl,
+        activeAccountAddress,
+        'address',
+        isEvm ? ExplorerType.EVM : ExplorerType.Substrate
+      ).toString()
+    : undefined;
 
   return (
     <GlassCard className="flex flex-col gap-3 sm:gap-0">
@@ -32,6 +40,7 @@ const RecentTxContainer: FC = () => {
           className="uppercase"
           target="_blank"
           href={accountExplorerUrl}
+          isDisabled={!accountExplorerUrl}
         >
           Open Explorer
         </Button>

--- a/apps/tangle-dapp/hooks/useExecuteTxWithNotification.tsx
+++ b/apps/tangle-dapp/hooks/useExecuteTxWithNotification.tsx
@@ -7,11 +7,11 @@ import { useCallback } from 'react';
 import { ExplorerType } from '../types';
 import ensureError from '../utils/ensureError';
 import { evmPublicClient } from '../utils/evm';
-import useExplorerUrl from './useExplorerUrl';
+import useTxExplorerUrl from './useTxExplorerUrl';
 
 const useExecuteTxWithNotification = () => {
   const { activeWallet } = useWebContext();
-  const getExplorerUrl = useExplorerUrl();
+  const getTxExplorerUrl = useTxExplorerUrl();
   const { enqueueSnackbar: enqueueNotifications } = useSnackbar();
 
   /**
@@ -52,8 +52,7 @@ const useExecuteTxWithNotification = () => {
           throw new Error(errorMessage);
         }
 
-        // TODO: tx explorer url is incorrect
-        const txExplorerUrl = getExplorerUrl(
+        const txExplorerUrl = getTxExplorerUrl(
           txHash,
           activeWallet?.platform === 'EVM'
             ? ExplorerType.EVM
@@ -105,7 +104,7 @@ const useExecuteTxWithNotification = () => {
         throw error;
       }
     },
-    [activeWallet?.platform, getExplorerUrl, enqueueNotifications]
+    [activeWallet?.platform, getTxExplorerUrl, enqueueNotifications]
   );
 
   return executeTx;

--- a/apps/tangle-dapp/hooks/useExecuteTxWithNotification.tsx
+++ b/apps/tangle-dapp/hooks/useExecuteTxWithNotification.tsx
@@ -4,9 +4,10 @@ import { Button, Typography } from '@webb-tools/webb-ui-components';
 import { useSnackbar } from 'notistack';
 import { useCallback } from 'react';
 
+import { ExplorerType } from '../types';
 import ensureError from '../utils/ensureError';
 import { evmPublicClient } from '../utils/evm';
-import useExplorerUrl, { ExplorerType } from './useExplorerUrl';
+import useExplorerUrl from './useExplorerUrl';
 
 const useExecuteTxWithNotification = () => {
   const { activeWallet } = useWebContext();

--- a/apps/tangle-dapp/hooks/useExplorerUrl.ts
+++ b/apps/tangle-dapp/hooks/useExplorerUrl.ts
@@ -2,11 +2,7 @@ import { getExplorerURI } from '@webb-tools/api-provider-environment/transaction
 import { useCallback } from 'react';
 
 import useNetworkStore from '../context/useNetworkStore';
-
-export enum ExplorerType {
-  Substrate = 'polkadot',
-  EVM = 'web3',
-}
+import { ExplorerType } from '../types';
 
 // TODO: change name to useTxExplorerUrl
 const useExplorerUrl = () => {

--- a/apps/tangle-dapp/hooks/useExplorerUrl.ts
+++ b/apps/tangle-dapp/hooks/useExplorerUrl.ts
@@ -8,6 +8,7 @@ export enum ExplorerType {
   EVM = 'web3',
 }
 
+// TODO: change name to useTxExplorerUrl
 const useExplorerUrl = () => {
   const { network } = useNetworkStore();
 

--- a/apps/tangle-dapp/hooks/useTxExplorerUrl.ts
+++ b/apps/tangle-dapp/hooks/useTxExplorerUrl.ts
@@ -4,12 +4,11 @@ import { useCallback } from 'react';
 import useNetworkStore from '../context/useNetworkStore';
 import { ExplorerType } from '../types';
 
-// TODO: change name to useTxExplorerUrl
-const useExplorerUrl = () => {
+const useTxExplorerUrl = () => {
   const { network } = useNetworkStore();
 
   return useCallback(
-    (transactionOrBlockHash: string, type: ExplorerType): URL | null => {
+    (txHash: string, type: ExplorerType): URL | null => {
       const explorerUrl =
         type === ExplorerType.Substrate
           ? network.polkadotExplorerUrl
@@ -19,10 +18,10 @@ const useExplorerUrl = () => {
         return null;
       }
 
-      return getExplorerURI(explorerUrl, transactionOrBlockHash, 'tx', type);
+      return getExplorerURI(explorerUrl, txHash, 'tx', type);
     },
     [network.evmExplorerUrl, network.polkadotExplorerUrl]
   );
 };
 
-export default useExplorerUrl;
+export default useTxExplorerUrl;

--- a/apps/tangle-dapp/types/index.ts
+++ b/apps/tangle-dapp/types/index.ts
@@ -197,3 +197,8 @@ export type ServiceParticipant = {
 export enum NetworkFeature {
   Faucet,
 }
+
+export enum ExplorerType {
+  Substrate = 'polkadot',
+  EVM = 'web3',
+}

--- a/apps/testnet-leaderboard/components/Navbar.tsx
+++ b/apps/testnet-leaderboard/components/Navbar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { AccordionTrigger } from '@radix-ui/react-accordion';
+import { TANGLE_TESTNET_NATIVE_EXPLORER_URL } from '@webb-tools/dapp-config/constants/tangle';
 import { ArrowRight, ChevronDown, Menu } from '@webb-tools/icons';
 import {
   Accordion,
@@ -16,7 +17,6 @@ import {
 import { MenuItem } from '@webb-tools/webb-ui-components/components/MenuItem';
 import {
   TANGLE_MKT_URL,
-  TANGLE_TESTNET_NATIVE_EXPLORER_URL,
   WEBB_BLOG_URL,
 } from '@webb-tools/webb-ui-components/constants';
 import { Typography } from '@webb-tools/webb-ui-components/typography/Typography';

--- a/libs/api-provider-environment/src/transaction/utils/getExplorerURI.ts
+++ b/libs/api-provider-environment/src/transaction/utils/getExplorerURI.ts
@@ -1,4 +1,16 @@
+import { encodeAddress } from '@polkadot/util-crypto';
 import { WebbProviderType } from '@webb-tools/abstract-api-provider/types';
+import { chainsConfig as substrateChainsConfig } from '@webb-tools/dapp-config/chains/substrate';
+
+const substrateExplorerAndChainIdMap = Object.keys(
+  substrateChainsConfig
+).reduce((acc, key) => {
+  const url = substrateChainsConfig[Number(key)].blockExplorers?.default.url;
+  if (url) {
+    acc[url] = substrateChainsConfig[Number(key)].id;
+  }
+  return acc;
+}, {} as Record<string, number>);
 
 export const getExplorerURI = (
   explorerUri: string,
@@ -11,7 +23,17 @@ export const getExplorerURI = (
       return new URL(`${variant}/${addOrTxHash}`, explorerUri);
 
     case 'polkadot': {
-      const path = variant === 'tx' ? `#/explorer/query/${addOrTxHash}` : '';
+      const path =
+        variant === 'tx'
+          ? `#/extrinsics/${addOrTxHash}`
+          : `#/accounts/${
+            typeof substrateExplorerAndChainIdMap[explorerUri] === 'number'
+              ? encodeAddress(
+                  addOrTxHash,
+                  substrateExplorerAndChainIdMap[explorerUri]
+                )
+              : addOrTxHash
+          }`;
       return new URL(`${path}`, explorerUri);
     }
 

--- a/libs/api-provider-environment/src/transaction/utils/getExplorerURI.ts
+++ b/libs/api-provider-environment/src/transaction/utils/getExplorerURI.ts
@@ -27,6 +27,7 @@ export const getExplorerURI = (
         variant === 'tx'
           ? `#/extrinsics/${addOrTxHash}`
           : `#/accounts/${
+            // encode address for all available substrate chains
             typeof substrateExplorerAndChainIdMap[explorerUri] === 'number'
               ? encodeAddress(
                   addOrTxHash,

--- a/libs/api-provider-environment/src/transaction/utils/getExplorerURI.ts
+++ b/libs/api-provider-environment/src/transaction/utils/getExplorerURI.ts
@@ -27,14 +27,14 @@ export const getExplorerURI = (
         variant === 'tx'
           ? `#/extrinsics/${addOrTxHash}`
           : `#/accounts/${
-            // encode address for all available substrate chains
-            typeof substrateExplorerAndChainIdMap[explorerUri] === 'number'
-              ? encodeAddress(
-                  addOrTxHash,
-                  substrateExplorerAndChainIdMap[explorerUri]
-                )
-              : addOrTxHash
-          }`;
+              // encode address for all available substrate chains
+              typeof substrateExplorerAndChainIdMap[explorerUri] === 'number'
+                ? encodeAddress(
+                    addOrTxHash,
+                    substrateExplorerAndChainIdMap[explorerUri]
+                  )
+                : addOrTxHash
+            }`;
       return new URL(`${path}`, explorerUri);
     }
 

--- a/libs/dapp-config/src/chains/evm/index.tsx
+++ b/libs/dapp-config/src/chains/evm/index.tsx
@@ -17,6 +17,13 @@ import {
   sepolia,
   type Chain,
 } from 'viem/chains';
+import {
+  TANGLE_MAINNET_HTTP_RPC_ENDPOINT,
+  TANGLE_MAINNET_EVM_EXPLORER_URL,
+  TANGLE_TESTNET_HTTP_RPC_ENDPOINT,
+  TANGLE_TESTNET_EVM_EXPLORER_URL,
+  TANGLE_LOCAL_HTTP_RPC_ENDPOINT,
+} from '../../constants/tangle';
 import { DEFAULT_EVM_CURRENCY } from '../../currencies';
 import type { ChainConfig, WebbExtendedChain } from '../chain-config.interface';
 
@@ -195,15 +202,15 @@ export const chainsConfig: Record<number, ChainConfig> = {
     blockExplorers: {
       default: {
         name: 'Tangle Mainnet EVM Explorer',
-        url: 'https://explorer.tangle.tools/',
+        url: TANGLE_MAINNET_EVM_EXPLORER_URL,
       },
     },
     rpcUrls: {
       default: {
-        http: ['https://rpc.tangle.tools'],
+        http: [TANGLE_MAINNET_HTTP_RPC_ENDPOINT],
       },
       public: {
-        http: ['https://rpc.tangle.tools'],
+        http: [TANGLE_MAINNET_HTTP_RPC_ENDPOINT],
       },
     },
   } satisfies ChainConfig,
@@ -223,20 +230,20 @@ export const chainsConfig: Record<number, ChainConfig> = {
       ? {
           default: {
             name: 'Tangle Testnet EVM Explorer',
-            url: 'https://testnet-explorer.tangle.tools/',
+            url: TANGLE_TESTNET_EVM_EXPLORER_URL,
           },
         }
       : undefined,
     rpcUrls: {
       default: {
         http: process.env['USING_LOCAL_TANGLE']
-          ? ['http://localhost:9944']
-          : ['https://testnet-rpc.tangle.tools'],
+          ? [TANGLE_LOCAL_HTTP_RPC_ENDPOINT]
+          : [TANGLE_TESTNET_HTTP_RPC_ENDPOINT],
       },
       public: {
         http: process.env['USING_LOCAL_TANGLE']
-          ? ['http://localhost:9944']
-          : ['https://testnet-rpc.tangle.tools'],
+          ? [TANGLE_LOCAL_HTTP_RPC_ENDPOINT]
+          : [TANGLE_TESTNET_HTTP_RPC_ENDPOINT],
       },
     },
   } satisfies ChainConfig,

--- a/libs/dapp-config/src/chains/substrate/index.tsx
+++ b/libs/dapp-config/src/chains/substrate/index.tsx
@@ -2,17 +2,6 @@ import { PresetTypedChainId, SubstrateChainId } from '@webb-tools/dapp-types';
 import { ChainType } from '@webb-tools/sdk-core/typed-chain-id';
 import { ChainConfig } from '../chain-config.interface';
 
-function populateBlockExplorerStub(connString: string): string {
-  const params = new URLSearchParams({
-    rpc: connString,
-  });
-  const url = new URL(
-    `?${params.toString()}`,
-    'https://polkadot.js.org/apps/'
-  ).toString();
-  return url;
-}
-
 // All substrate chains temporary use in `development` environment now
 export const chainsConfig: Record<number, ChainConfig> = {
   [PresetTypedChainId.TangleMainnetNative]: {
@@ -29,7 +18,7 @@ export const chainsConfig: Record<number, ChainConfig> = {
     blockExplorers: {
       default: {
         name: 'Tangle Explorer',
-        url: populateBlockExplorerStub('wss://rpc.tangle.tools'),
+        url: 'https://tangle.statescan.io/',
       },
     },
     rpcUrls: {
@@ -59,8 +48,8 @@ export const chainsConfig: Record<number, ChainConfig> = {
       default: {
         name: 'Tangle Explorer',
         url: process.env['USING_LOCAL_TANGLE']
-          ? populateBlockExplorerStub('ws://127.0.0.1:9944')
-          : populateBlockExplorerStub('wss://testnet-rpc.tangle.tools'),
+          ? 'https://polkadot.js.org/apps/?rpc=ws://127.0.0.1:9944#/explorer'
+          : 'https://tangle-testnet.statescan.io/',
       },
     },
     rpcUrls: {
@@ -94,7 +83,7 @@ export const chainsConfig: Record<number, ChainConfig> = {
     blockExplorers: {
       default: {
         name: 'Kusama Explorer',
-        url: populateBlockExplorerStub('wss://kusama-rpc.polkadot.io'),
+        url: 'https://kusama.statescan.io/',
       },
     },
     rpcUrls: {
@@ -123,8 +112,8 @@ export const chainsConfig: Record<number, ChainConfig> = {
     },
     blockExplorers: {
       default: {
-        name: 'Kusama Explorer',
-        url: populateBlockExplorerStub('wss://rpc.polkadot.io'),
+        name: 'Polkadot Explorer',
+        url: 'https://polkadot.statescan.io/',
       },
     },
     rpcUrls: {
@@ -140,3 +129,4 @@ export const chainsConfig: Record<number, ChainConfig> = {
     env: ['development'],
   },
 };
+

--- a/libs/dapp-config/src/chains/substrate/index.tsx
+++ b/libs/dapp-config/src/chains/substrate/index.tsx
@@ -1,5 +1,12 @@
 import { PresetTypedChainId, SubstrateChainId } from '@webb-tools/dapp-types';
 import { ChainType } from '@webb-tools/sdk-core/typed-chain-id';
+import {
+  TANGLE_MAINNET_WS_RPC_ENDPOINT,
+  TANGLE_MAINNET_NATIVE_EXPLORER_URL,
+  TANGLE_TESTNET_WS_RPC_ENDPOINT,
+  TANGLE_TESTNET_NATIVE_EXPLORER_URL,
+  TANGLE_LOCAL_WS_RPC_ENDPOINT,
+} from '../../constants/tangle';
 import { ChainConfig } from '../chain-config.interface';
 
 // All substrate chains temporary use in `development` environment now
@@ -18,17 +25,17 @@ export const chainsConfig: Record<number, ChainConfig> = {
     blockExplorers: {
       default: {
         name: 'Tangle Explorer',
-        url: 'https://tangle.statescan.io/',
+        url: TANGLE_MAINNET_NATIVE_EXPLORER_URL,
       },
     },
     rpcUrls: {
       default: {
         http: [],
-        webSocket: ['wss://rpc.tangle.tools'],
+        webSocket: [TANGLE_MAINNET_WS_RPC_ENDPOINT],
       },
       public: {
         http: [],
-        webSocket: ['wss://rpc.tangle.tools'],
+        webSocket: [TANGLE_MAINNET_WS_RPC_ENDPOINT],
       },
     },
   },
@@ -48,22 +55,22 @@ export const chainsConfig: Record<number, ChainConfig> = {
       default: {
         name: 'Tangle Explorer',
         url: process.env['USING_LOCAL_TANGLE']
-          ? 'https://polkadot.js.org/apps/?rpc=ws://127.0.0.1:9944#/explorer'
-          : 'https://tangle-testnet.statescan.io/',
+          ? 'https://polkadot.js.org/apps/?rpc=ws://127.0.0.1:9944#/explorer/'
+          : TANGLE_TESTNET_NATIVE_EXPLORER_URL,
       },
     },
     rpcUrls: {
       default: {
         http: [],
         webSocket: process.env['USING_LOCAL_TANGLE']
-          ? ['ws://127.0.0.1:9944']
-          : ['wss://testnet-rpc.tangle.tools'],
+          ? [TANGLE_LOCAL_WS_RPC_ENDPOINT]
+          : [TANGLE_TESTNET_WS_RPC_ENDPOINT],
       },
       public: {
         http: [],
         webSocket: process.env['USING_LOCAL_TANGLE']
-          ? ['ws://127.0.0.1:9944']
-          : ['wss://testnet-rpc.tangle.tools'],
+          ? [TANGLE_LOCAL_WS_RPC_ENDPOINT]
+          : [TANGLE_TESTNET_WS_RPC_ENDPOINT],
       },
     },
     env: ['development'],
@@ -129,4 +136,3 @@ export const chainsConfig: Record<number, ChainConfig> = {
     env: ['development'],
   },
 };
-

--- a/libs/dapp-config/src/constants/index.ts
+++ b/libs/dapp-config/src/constants/index.ts
@@ -6,3 +6,5 @@ export const DEFAULT_DECIMALS = 18;
 
 /** Big int zero */
 export const ZERO_BIG_INT = BigInt(0);
+
+export * from './tangle';

--- a/libs/dapp-config/src/constants/tangle.ts
+++ b/libs/dapp-config/src/constants/tangle.ts
@@ -1,0 +1,21 @@
+// MAINNET
+export const TANGLE_MAINNET_WS_RPC_ENDPOINT = 'wss://rpc.tangle.tools';
+export const TANGLE_MAINNET_HTTP_RPC_ENDPOINT = 'https://rpc.tangle.tools';
+export const TANGLE_MAINNET_NATIVE_EXPLORER_URL =
+  'https://tangle.statescan.io/';
+export const TANGLE_MAINNET_EVM_EXPLORER_URL = 'https://explorer.tangle.tools/';
+
+// TESTNET
+export const TANGLE_TESTNET_WS_RPC_ENDPOINT = 'wss://testnet-rpc.tangle.tools';
+export const TANGLE_TESTNET_HTTP_RPC_ENDPOINT =
+  'https://testnet-rpc.tangle.tools';
+export const TANGLE_TESTNET_NATIVE_EXPLORER_URL =
+  'https://tangle-testnet.statescan.io/';
+export const TANGLE_TESTNET_EVM_EXPLORER_URL =
+  'https://testnet-explorer.tangle.tools';
+
+// LOCAL
+export const TANGLE_LOCAL_WS_RPC_ENDPOINT = 'ws://127.0.0.1:9944';
+export const TANGLE_LOCAL_HTTP_RPC_ENDPOINT = 'http://127.0.0.1:9944';
+// Note: there is no official explorer for the local dev network, using Polkadot.{js} dashboard
+export const TANGLE_LOCAL_NATIVE_EXPLORER_URL = `https://polkadot.js.org/apps/?rpc=${TANGLE_TESTNET_WS_RPC_ENDPOINT}#/explorer`;

--- a/libs/webb-ui-components/src/constants/index.ts
+++ b/libs/webb-ui-components/src/constants/index.ts
@@ -1,4 +1,8 @@
 import {
+  TANGLE_MAINNET_NATIVE_EXPLORER_URL,
+  TANGLE_MAINNET_EVM_EXPLORER_URL,
+} from '@webb-tools/dapp-config/constants/tangle';
+import {
   Common2Icon,
   DiscordFill,
   GithubFill,
@@ -49,17 +53,6 @@ export const TANGLE_WHITEPAPER_URL =
 
 export const WEBB_CAREERS_URL = 'https://wellfound.com/company/webb-4/jobs';
 
-export const TANGLE_TESTNET_EVM_EXPLORER_URL =
-  'https://testnet-explorer.tangle.tools';
-
-export const TANGLE_MAINNET_EVM_EXPLORER_URL = 'https://explorer.tangle.tools/';
-
-export const TANGLE_TESTNET_NATIVE_EXPLORER_URL =
-  'https://tangle-testnet.statescan.io/';
-
-export const TANGLE_MAINNET_NATIVE_EXPLORER_URL =
-  'https://tangle.statescan.io/';
-
 export const WEBB_DAPP_NEW_ISSUE_URL =
   'https://github.com/webb-tools/webb-dapp/issues/new/choose';
 export const WEBB_FAUCET_URL = 'https://faucet.tangle.tools';
@@ -72,7 +65,8 @@ export const GITHUB_REQUEST_FEATURE_URL =
 export const GITHUB_BUG_REPORT_URL =
   'https://github.com/webb-tools/webb-dapp/issues/new?assignees=&labels=bug+%F0%9F%AA%B2&projects=&template=BUG_REPORT.yml&title=%5BBUG%5D+%3Ctitle%3E';
 
-export const POLKADOT_EXPLORER_URL =
+// TODO: remove this, only use in the old stats dapp
+export const POLKADOT_JS_EXPLORER_URL =
   'https://polkadot.js.org/apps/?rpc=wss://testnet-rpc.tangle.tools#/explorer/query';
 
 export const FOLLOW_WEBB_TWITTER_URL =
@@ -83,9 +77,6 @@ export const TANGLE_TWITTER_URL = 'https://twitter.com/tangle_network';
 export const DKG_STATS_KEYS_URL = `${DKG_STATS_URL}/#/keys`;
 export const DKG_STATS_AUTHORITIES_URL = `${DKG_STATS_URL}/#/authorities`;
 export const DKG_STATS_PROPOSALS_URL = `${DKG_STATS_URL}/#/proposals`;
-
-export const TANGLE_TESTNET_RPC_ENDPOINT = 'wss://testnet-rpc.tangle.tools';
-export const TANGLE_MAINNET_RPC_ENDPOINT = 'wss://rpc.tangle.tools';
 
 export const SUBQUERY_ENDPOINT =
   'https://standalone-subql.tangle.tools/graphql';
@@ -247,13 +238,13 @@ export const footerNavs: FooterNavsType = {
   ],
   network: [
     {
-      name: 'Block Explorer',
-      href: TANGLE_TESTNET_EVM_EXPLORER_URL,
+      name: 'Tangle EVM Explorer',
+      href: TANGLE_MAINNET_EVM_EXPLORER_URL,
       ...commonExternalProps,
     },
     {
-      name: 'polkadot explorer',
-      href: TANGLE_TESTNET_NATIVE_EXPLORER_URL,
+      name: 'Tangle Native explorer',
+      href: TANGLE_MAINNET_NATIVE_EXPLORER_URL,
       ...commonExternalProps,
     },
   ],

--- a/libs/webb-ui-components/src/constants/index.ts
+++ b/libs/webb-ui-components/src/constants/index.ts
@@ -52,8 +52,13 @@ export const WEBB_CAREERS_URL = 'https://wellfound.com/company/webb-4/jobs';
 export const TANGLE_TESTNET_EVM_EXPLORER_URL =
   'https://testnet-explorer.tangle.tools';
 
+export const TANGLE_MAINNET_EVM_EXPLORER_URL = 'https://explorer.tangle.tools/';
+
 export const TANGLE_TESTNET_NATIVE_EXPLORER_URL =
-  'https://polkadot.js.org/apps/?rpc=wss://testnet-rpc.tangle.tools#/explorer';
+  'https://tangle-testnet.statescan.io/';
+
+export const TANGLE_MAINNET_NATIVE_EXPLORER_URL =
+  'https://tangle.statescan.io/';
 
 export const WEBB_DAPP_NEW_ISSUE_URL =
   'https://github.com/webb-tools/webb-dapp/issues/new/choose';
@@ -79,7 +84,9 @@ export const DKG_STATS_KEYS_URL = `${DKG_STATS_URL}/#/keys`;
 export const DKG_STATS_AUTHORITIES_URL = `${DKG_STATS_URL}/#/authorities`;
 export const DKG_STATS_PROPOSALS_URL = `${DKG_STATS_URL}/#/proposals`;
 
-export const TANGLE_RPC_ENDPOINT = 'wss://testnet-rpc.tangle.tools';
+export const TANGLE_TESTNET_RPC_ENDPOINT = 'wss://testnet-rpc.tangle.tools';
+export const TANGLE_MAINNET_RPC_ENDPOINT = 'wss://rpc.tangle.tools';
+
 export const SUBQUERY_ENDPOINT =
   'https://standalone-subql.tangle.tools/graphql';
 

--- a/libs/webb-ui-components/src/constants/networks.ts
+++ b/libs/webb-ui-components/src/constants/networks.ts
@@ -1,6 +1,9 @@
 import {
   SUBQUERY_ENDPOINT,
-  TANGLE_RPC_ENDPOINT,
+  TANGLE_MAINNET_RPC_ENDPOINT,
+  TANGLE_MAINNET_EVM_EXPLORER_URL,
+  TANGLE_MAINNET_NATIVE_EXPLORER_URL,
+  TANGLE_TESTNET_RPC_ENDPOINT,
   TANGLE_TESTNET_EVM_EXPLORER_URL,
   TANGLE_TESTNET_NATIVE_EXPLORER_URL,
 } from '.';
@@ -40,17 +43,15 @@ export type Network = {
   httpRpcEndpoint?: string;
 };
 
-const TANGLE_MAINNET_WS_RPC_ENDPOINT = 'wss://rpc.tangle.tools';
-
 export const TANGLE_MAINNET_NETWORK: Network = {
   id: NetworkId.TANGLE_MAINNET,
   chainId: 5845,
   name: 'Tangle Mainnet',
   nodeType: 'standalone',
-  wsRpcEndpoint: TANGLE_MAINNET_WS_RPC_ENDPOINT,
+  wsRpcEndpoint: TANGLE_MAINNET_RPC_ENDPOINT,
   httpRpcEndpoint: 'https://rpc.tangle.tools',
-  polkadotExplorerUrl: `https://polkadot.js.org/apps/?rpc=${TANGLE_MAINNET_WS_RPC_ENDPOINT}#/explorer`,
-  evmExplorerUrl: 'https://explorer.tangle.tools/',
+  polkadotExplorerUrl: TANGLE_MAINNET_NATIVE_EXPLORER_URL,
+  evmExplorerUrl: TANGLE_MAINNET_EVM_EXPLORER_URL,
 };
 
 export const TANGLE_TESTNET_NATIVE_NETWORK: Network = {
@@ -60,7 +61,7 @@ export const TANGLE_TESTNET_NATIVE_NETWORK: Network = {
   nodeType: 'standalone',
   subqueryEndpoint: SUBQUERY_ENDPOINT,
   httpRpcEndpoint: 'https://testnet-rpc.tangle.tools',
-  wsRpcEndpoint: TANGLE_RPC_ENDPOINT,
+  wsRpcEndpoint: TANGLE_TESTNET_RPC_ENDPOINT,
   polkadotExplorerUrl: TANGLE_TESTNET_NATIVE_EXPLORER_URL,
   evmExplorerUrl: TANGLE_TESTNET_EVM_EXPLORER_URL,
 };
@@ -76,10 +77,11 @@ export const TANGLE_LOCAL_DEV_NETWORK: Network = {
   subqueryEndpoint: 'http://localhost:4000/graphql',
   wsRpcEndpoint: 'ws://127.0.0.1:9944',
   httpRpcEndpoint: 'http://127.0.0.1:9944',
+  // TODO: there is no official explorer for the local dev network, using Polkadot.{js} dashboard
   polkadotExplorerUrl:
     'https://polkadot.js.org/apps/?rpc=ws://127.0.0.1:9944#/explorer',
   // TODO: Use a generic EVM block explorer that supports passing in an RPC url. For now, this isn't a priority since this is the case only for the local development network, and this URL is only used for convenience.
-  evmExplorerUrl: `https://polkadot.js.org/apps/?rpc=${TANGLE_MAINNET_WS_RPC_ENDPOINT}#/explorer`,
+  evmExplorerUrl: `https://polkadot.js.org/apps/?rpc=${TANGLE_MAINNET_RPC_ENDPOINT}#/explorer`,
 };
 
 export const NETWORK_MAP: Partial<Record<NetworkId, Network>> = {

--- a/libs/webb-ui-components/src/constants/networks.ts
+++ b/libs/webb-ui-components/src/constants/networks.ts
@@ -1,12 +1,19 @@
+import { SubstrateChainId } from '@webb-tools/dapp-types';
 import {
-  SUBQUERY_ENDPOINT,
-  TANGLE_MAINNET_RPC_ENDPOINT,
-  TANGLE_MAINNET_EVM_EXPLORER_URL,
+  TANGLE_MAINNET_WS_RPC_ENDPOINT,
+  TANGLE_MAINNET_HTTP_RPC_ENDPOINT,
   TANGLE_MAINNET_NATIVE_EXPLORER_URL,
-  TANGLE_TESTNET_RPC_ENDPOINT,
-  TANGLE_TESTNET_EVM_EXPLORER_URL,
+  TANGLE_MAINNET_EVM_EXPLORER_URL,
+  TANGLE_TESTNET_WS_RPC_ENDPOINT,
+  TANGLE_TESTNET_HTTP_RPC_ENDPOINT,
   TANGLE_TESTNET_NATIVE_EXPLORER_URL,
-} from '.';
+  TANGLE_TESTNET_EVM_EXPLORER_URL,
+  TANGLE_LOCAL_WS_RPC_ENDPOINT,
+  TANGLE_LOCAL_HTTP_RPC_ENDPOINT,
+  TANGLE_LOCAL_NATIVE_EXPLORER_URL,
+} from '@webb-tools/dapp-config/constants/tangle';
+
+import { SUBQUERY_ENDPOINT } from '.';
 
 export type NetworkNodeType = 'parachain' | 'standalone';
 
@@ -45,23 +52,23 @@ export type Network = {
 
 export const TANGLE_MAINNET_NETWORK: Network = {
   id: NetworkId.TANGLE_MAINNET,
-  chainId: 5845,
+  chainId: SubstrateChainId.TangleMainnetNative,
   name: 'Tangle Mainnet',
   nodeType: 'standalone',
-  wsRpcEndpoint: TANGLE_MAINNET_RPC_ENDPOINT,
-  httpRpcEndpoint: 'https://rpc.tangle.tools',
+  wsRpcEndpoint: TANGLE_MAINNET_WS_RPC_ENDPOINT,
+  httpRpcEndpoint: TANGLE_MAINNET_HTTP_RPC_ENDPOINT,
   polkadotExplorerUrl: TANGLE_MAINNET_NATIVE_EXPLORER_URL,
   evmExplorerUrl: TANGLE_MAINNET_EVM_EXPLORER_URL,
 };
 
 export const TANGLE_TESTNET_NATIVE_NETWORK: Network = {
   id: NetworkId.TANGLE_TESTNET,
-  chainId: 3799,
+  chainId: SubstrateChainId.TangleTestnetNative,
   name: 'Tangle Testnet',
   nodeType: 'standalone',
   subqueryEndpoint: SUBQUERY_ENDPOINT,
-  httpRpcEndpoint: 'https://testnet-rpc.tangle.tools',
-  wsRpcEndpoint: TANGLE_TESTNET_RPC_ENDPOINT,
+  httpRpcEndpoint: TANGLE_TESTNET_HTTP_RPC_ENDPOINT,
+  wsRpcEndpoint: TANGLE_TESTNET_WS_RPC_ENDPOINT,
   polkadotExplorerUrl: TANGLE_TESTNET_NATIVE_EXPLORER_URL,
   evmExplorerUrl: TANGLE_TESTNET_EVM_EXPLORER_URL,
 };
@@ -71,17 +78,15 @@ export const TANGLE_TESTNET_NATIVE_NETWORK: Network = {
  */
 export const TANGLE_LOCAL_DEV_NETWORK: Network = {
   id: NetworkId.TANGLE_LOCAL_DEV,
-  chainId: 3799,
+  chainId: SubstrateChainId.TangleTestnetNative,
   name: 'Local endpoint',
   nodeType: 'standalone',
   subqueryEndpoint: 'http://localhost:4000/graphql',
-  wsRpcEndpoint: 'ws://127.0.0.1:9944',
-  httpRpcEndpoint: 'http://127.0.0.1:9944',
-  // TODO: there is no official explorer for the local dev network, using Polkadot.{js} dashboard
-  polkadotExplorerUrl:
-    'https://polkadot.js.org/apps/?rpc=ws://127.0.0.1:9944#/explorer',
+  wsRpcEndpoint: TANGLE_LOCAL_WS_RPC_ENDPOINT,
+  httpRpcEndpoint: TANGLE_LOCAL_HTTP_RPC_ENDPOINT,
+  polkadotExplorerUrl: TANGLE_LOCAL_NATIVE_EXPLORER_URL,
   // TODO: Use a generic EVM block explorer that supports passing in an RPC url. For now, this isn't a priority since this is the case only for the local development network, and this URL is only used for convenience.
-  evmExplorerUrl: `https://polkadot.js.org/apps/?rpc=${TANGLE_MAINNET_RPC_ENDPOINT}#/explorer`,
+  evmExplorerUrl: TANGLE_LOCAL_NATIVE_EXPLORER_URL,
 };
 
 export const NETWORK_MAP: Partial<Record<NetworkId, Network>> = {


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Navigate users to correct tx and account page on block explorer (both EVM & Substrate)
- Update chains-config in `dapp-config`
- Update `getUrlExplorer` function that handle substrate case successfully
- Unify constants related to `Tangle` inside `dapp-config`

### Proposed area of change

_Put an `x` in the boxes that apply._

- [x] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [x] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes #2224

### Screen Recording

_If possible provide a screen recording of proposed change._

https://github.com/webb-tools/webb-dapp/assets/69841784/5594d467-75ff-4b28-8842-1ada33e9a2b6

---

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
