### PR TITLE
UI improvements on Tangle Dapp (Key Stats Item + Fix Footer bottom bound + Static Tangle Icon)

### DIFF
--- a/apps/tangle-dapp/app/nomination/loading.tsx
+++ b/apps/tangle-dapp/app/nomination/loading.tsx
@@ -8,7 +8,7 @@ export default function Loading() {
         Overview
       </Typography>
 
-      <SkeletonLoader className="h-[84px]" />
+      <SkeletonLoader className="h-[157px]" />
 
       <div className="flex flex-col md:flex-row gap-4 w-full">
         <SkeletonLoader className="rounded-2xl h-[204px]" />

--- a/apps/tangle-dapp/components/KeyStatsItem/KeyStatsItem.tsx
+++ b/apps/tangle-dapp/components/KeyStatsItem/KeyStatsItem.tsx
@@ -59,7 +59,7 @@ const KeyStatsItem: FC<KeyStatsItemProps> = ({
       <div className="flex items-center gap-0.5">
         <Typography
           variant="body1"
-          className="text-mono-140 dark:text-mono-40 break-all xl:whitespace-nowrap"
+          className="text-mono-140 dark:text-mono-40 whitespace-nowrap"
         >
           {title}
         </Typography>
@@ -70,7 +70,7 @@ const KeyStatsItem: FC<KeyStatsItemProps> = ({
       <div className="flex flex-col gap-1 sm:flex-row sm:items-center">
         <div className="flex items-center gap-0.5">
           {isLoading ? (
-            <SkeletonLoader className="w-[80px]" size="lg" />
+            <SkeletonLoader className="w-20 h-8" />
           ) : error !== null ? (
             'Error'
           ) : children === null ? null : (

--- a/apps/tangle-dapp/components/TangleTokenIcon.tsx
+++ b/apps/tangle-dapp/components/TangleTokenIcon.tsx
@@ -1,0 +1,44 @@
+import TangleTokenLogo from '@webb-tools/icons/tokens/tnt.svg';
+import { IconSize } from '@webb-tools/icons/types';
+import Image from 'next/image';
+import { FC } from 'react';
+
+interface TangleTokenIconProps {
+  size: IconSize;
+}
+
+const TangleTokenIcon: FC<TangleTokenIconProps> = ({ size: size }) => {
+  const sizeInPx = getIconSize(size);
+
+  return (
+    <Image
+      src={TangleTokenLogo}
+      alt="Tangle Token Icon"
+      width={sizeInPx}
+      height={sizeInPx}
+    />
+  );
+};
+
+export default TangleTokenIcon;
+
+/* @internal */
+function getIconSize(size: IconSize) {
+  switch (size) {
+    case 'xl': {
+      return 48;
+    }
+
+    case 'lg': {
+      return 24;
+    }
+
+    case 'md': {
+      return 16;
+    }
+
+    default: {
+      throw new Error('Unknown icon size');
+    }
+  }
+}

--- a/apps/tangle-dapp/containers/BalancesTableContainer/BalancesTableContainer.tsx
+++ b/apps/tangle-dapp/containers/BalancesTableContainer/BalancesTableContainer.tsx
@@ -5,13 +5,13 @@ import {
   ChevronUp,
   CoinsStackedLineIcon,
   SendPlanLineIcon,
-  TokenIcon,
 } from '@webb-tools/icons';
 import { Typography } from '@webb-tools/webb-ui-components';
 import { FC, useCallback, useEffect, useState } from 'react';
 
 import { InfoIconWithTooltip } from '../../components';
 import GlassCard from '../../components/GlassCard/GlassCard';
+import TangleTokenIcon from '../../components/TangleTokenIcon';
 import useNetworkStore from '../../context/useNetworkStore';
 import useBalances from '../../data/balances/useBalances';
 import useVestingInfo from '../../data/vesting/useVestingInfo';
@@ -171,7 +171,7 @@ const AssetCell: FC<{
   return (
     <div className="flex px-3 py-3 gap-6">
       <div className="flex flex-row items-center gap-1">
-        <TokenIcon name={nativeTokenSymbol} size="lg" />
+        <TangleTokenIcon size="lg" />
 
         <Typography variant="body1" fw="semibold" className="dark:text-mono-0">
           {nativeTokenSymbol}

--- a/apps/tangle-dapp/containers/KeyStatsContainer/ActiveValidatorsKeyStat.tsx
+++ b/apps/tangle-dapp/containers/KeyStatsContainer/ActiveValidatorsKeyStat.tsx
@@ -13,7 +13,6 @@ const ActiveValidatorsKeyStat: FC = () => {
       title="Active/Nomination"
       tooltip="Current active nominators out of the total possible."
       isLoading={isLoading}
-      className="lg:!border-b-0"
       error={error}
     >
       {data?.value1}/{data?.value2}

--- a/apps/tangle-dapp/containers/KeyStatsContainer/KeyStatsContainer.tsx
+++ b/apps/tangle-dapp/containers/KeyStatsContainer/KeyStatsContainer.tsx
@@ -1,4 +1,4 @@
-import cx from 'classnames';
+import { twMerge } from 'tailwind-merge';
 
 import ActiveValidatorsKeyStat from './ActiveValidatorsKeyStat';
 import ActualStakedPercentageKeyStat from './ActualStakedPercentageKeyStat';
@@ -10,21 +10,19 @@ import WaitingValidatorsKeyStat from './WaitingValidatorsKeyStat';
 export const KeyStatsContainer = () => {
   return (
     <div
-      className={cx(
+      className={twMerge(
         'w-full rounded-lg overflow-hidden',
         'bg-glass dark:bg-glass_dark',
         'border-2 border-mono-0 dark:border-mono-160'
       )}
     >
       <div
-        className={cx(
-          'grid lg:gap-1 grid-cols-2 lg:grid-cols-6',
+        className={twMerge(
+          'grid grid-cols-2 lg:grid-cols-3',
           '[&>div]:border-r [&>div]:border-r-mono-40 [&>div]:dark:border-r-mono-160',
-          '[&>div]:even:border-none',
-          'lg:[&>div]:even:border-r',
-          '[&>div]:border-b [&>div]:border-b-mono-40 [&>div]:dark:border-b-mono-160',
-          'lg:[&>div]:nth-last-child(-n+5):border-b-0',
-          '[&>div]:nth-last-child(-n+2):border-b-0'
+          '[&>div]:even:border-none lg:[&>div]:even:border-r',
+          'lg:[&>div]:inline-block lg:[&>div]:basis-0 lg:[&>div]:grow',
+          '[&>div]:border-b [&>div]:border-b-mono-40 [&>div]:dark:border-b-mono-160'
         )}
       >
         <ValidatorCountKeyStat />

--- a/apps/tangle-dapp/containers/KeyStatsContainer/ValidatorCountKeyStat.tsx
+++ b/apps/tangle-dapp/containers/KeyStatsContainer/ValidatorCountKeyStat.tsx
@@ -16,7 +16,6 @@ const ValidatorCountKeyStat: FC = () => {
     <KeyStatsItem
       title="Validators"
       tooltip="Current number of active validators out of the total allowed."
-      className="lg:!border-b-0"
       error={validatorCountError}
       isLoading={isValidatorCountLoading}
     >

--- a/apps/tangle-dapp/containers/KeyStatsContainer/WaitingValidatorsKeyStat.tsx
+++ b/apps/tangle-dapp/containers/KeyStatsContainer/WaitingValidatorsKeyStat.tsx
@@ -12,7 +12,7 @@ const WaitingValidatorsKeyStat: FC = () => {
     <KeyStatsItem
       title="Waiting"
       tooltip="Nodes waiting in line to become active validators."
-      className="!border-r-0 lg:!border-r lg:!border-b-0"
+      className="!border-r-0 lg:!border-r"
       error={error}
       isLoading={isLoading}
     >

--- a/apps/tangle-dapp/containers/Layout/Layout.tsx
+++ b/apps/tangle-dapp/containers/Layout/Layout.tsx
@@ -43,7 +43,7 @@ const Layout: FC<PropsWithChildren> = ({ children }) => {
 
       <main className="flex-1 h-full overflow-y-auto scrollbar-hide">
         <FeedbackBanner />
-        <div className="max-w-[1448px] lg:px-12 md:px-8 px-4 m-auto flex flex-col justify-between">
+        <div className="h-full max-w-[1448px] lg:px-12 md:px-8 px-4 m-auto flex flex-col justify-between">
           <div className="flex flex-col justify-between space-y-5">
             <div className="flex items-center justify-between py-6">
               <div className="flex items-center space-x-4 lg:space-x-0">


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Update Key Stats Container to have 3 columns in the desktop display for less clutter display
- Fix Footer not bottom bound
- Add static icon for Tangle Token

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes #2244 
- Closes #2246 
- Closes #2252

### Screen Recording

_If possible provide a screen recording of proposed change._

#### New display for Key Stats items
https://github.com/webb-tools/webb-dapp/assets/69841784/0e9db169-1553-4a32-b018-1500a70c55f2

#### Footer Bottom bound
![CleanShot 2024-04-19 at 09 25 51@2x](https://github.com/webb-tools/webb-dapp/assets/69841784/00f2ece4-6e30-453b-a733-6d98557d8835)

---

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
