### PR TITLE
fix(tangle-dapp): Improve Balance Display

### DIFF
--- a/apps/tangle-dapp/components/account/Balance.tsx
+++ b/apps/tangle-dapp/components/account/Balance.tsx
@@ -7,7 +7,6 @@ import { FC, useMemo } from 'react';
 
 import useNetworkStore from '../../context/useNetworkStore';
 import useBalances from '../../data/balances/useBalances';
-import formatBnToDisplayAmount from '../../utils/formatBnToDisplayAmount';
 import { formatTokenBalance } from '../../utils/polkadot';
 import { InfoIconWithTooltip } from '..';
 
@@ -27,14 +26,9 @@ const Balance: FC = () => {
       return null;
     }
 
-    const amount = formatBnToDisplayAmount(balance, {
-      // Show up to 4 decimal places.
-      fractionLength: 4,
-      includeCommas: true,
-      padZerosInFraction: true,
+    return formatTokenBalance(balance, nativeTokenSymbol, {
+      withAll: true,
     });
-
-    return `${amount} ${nativeTokenSymbol}`;
   }, [balance, nativeTokenSymbol]);
 
   return (

--- a/apps/tangle-dapp/utils/polkadot/tokens.ts
+++ b/apps/tangle-dapp/utils/polkadot/tokens.ts
@@ -5,12 +5,15 @@ import { getPolkadotApiPromise } from './api';
 
 export const formatTokenBalance = (
   balance: BN | bigint,
-  tokenSymbol?: string
+  tokenSymbol?: string,
+  options: Parameters<typeof formatBalance>[1] = {}
 ): string => {
   return formatBalance(balance, {
     decimals: TANGLE_TOKEN_DECIMALS,
     withZero: false,
+    forceUnit: '-',
     withUnit: tokenSymbol ?? false,
+    ...options,
   });
 };
 


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Enhance the balance display to show the full amount, thus reducing confusion for users.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes https://github.com/webb-tools/webb-dapp/issues/2280

### Screen Recording

_If possible provide a screen recording of proposed change._

**_Before_**

https://github.com/webb-tools/webb-dapp/assets/60747384/5a158e7f-3a0b-4fcc-949f-695cc650467a

**_After_**

https://github.com/webb-tools/webb-dapp/assets/60747384/b3442519-3d81-45d8-98f8-de57a6212051