### PR TITLE
fix(tangle-dapp): Resolve Maximum Nomination Amount Error

### DIFF
--- a/apps/tangle-dapp/app/nomination/layout.tsx
+++ b/apps/tangle-dapp/app/nomination/layout.tsx
@@ -1,0 +1,7 @@
+import { PropsWithChildren } from 'react';
+
+import { BalancesProvider } from '../../context/BalancesContext';
+
+export default function Layout({ children }: PropsWithChildren) {
+  return <BalancesProvider>{children}</BalancesProvider>;
+}

--- a/apps/tangle-dapp/components/NominatorStatsItem/NominatorStatsItemText.tsx
+++ b/apps/tangle-dapp/components/NominatorStatsItem/NominatorStatsItemText.tsx
@@ -10,11 +10,11 @@ import { formatTokenBalance } from '../../utils/polkadot';
 import dataHooks from './dataHooks';
 import type { NominatorStatsItemProps } from './types';
 
-type Props = Pick<NominatorStatsItemProps, 'address' | 'type'>;
+type Props = Pick<NominatorStatsItemProps, 'type'>;
 
-const NominatorStatsItemText = ({ address, type }: Props) => {
+const NominatorStatsItemText = ({ type }: Props) => {
   const { nativeTokenSymbol } = useNetworkStore();
-  const { isLoading, error, data } = dataHooks[type](address);
+  const { isLoading, error, data } = dataHooks[type]();
 
   useEffect(() => {
     if (error) {

--- a/apps/tangle-dapp/components/NominatorStatsItem/types.ts
+++ b/apps/tangle-dapp/components/NominatorStatsItem/types.ts
@@ -6,6 +6,5 @@ export interface NominatorStatsItemProps {
   title: string;
   type: StatsType;
   tooltip?: string | React.ReactNode;
-  address: string;
   className?: string;
 }

--- a/apps/tangle-dapp/components/UnbondingStatsItem/UnbondingStatsItem.tsx
+++ b/apps/tangle-dapp/components/UnbondingStatsItem/UnbondingStatsItem.tsx
@@ -3,12 +3,14 @@
 import { notificationApi } from '@webb-tools/webb-ui-components';
 import { type FC, Fragment, useMemo } from 'react';
 
+import useActiveAccountAddress from '../..//hooks/useActiveAccountAddress';
 import useNetworkStore from '../../context/useNetworkStore';
 import useUnbondingRemainingErasSubscription from '../../data/NominatorStats/useUnbondingRemainingErasSubscription';
 import { formatTokenBalance } from '../../utils/polkadot';
 import { NominatorStatsItem } from '../NominatorStatsItem';
 
-const UnbondingStatsItem: FC<{ address: string }> = ({ address }) => {
+const UnbondingStatsItem: FC = () => {
+  const address = useActiveAccountAddress<string>('');
   const { nativeTokenSymbol } = useNetworkStore();
 
   const {
@@ -33,7 +35,7 @@ const UnbondingStatsItem: FC<{ address: string }> = ({ address }) => {
     const elements = unbondingRemainingErasData.value1.map((era, index) => {
       return (
         <Fragment key={index}>
-          <div className="text-center mb-2">
+          <div className="mb-2 text-center">
             <p>
               {era.remainingEras > 0 ? 'Unbonding' : 'Unbonded'}{' '}
               {formatTokenBalance(era.amount, nativeTokenSymbol)}
@@ -56,7 +58,6 @@ const UnbondingStatsItem: FC<{ address: string }> = ({ address }) => {
       title={`Unbonding ${nativeTokenSymbol}`}
       tooltip={unbondingRemainingErasTooltip}
       type="Unbonding Amount"
-      address={address}
     />
   );
 };

--- a/apps/tangle-dapp/containers/NominatorStatsContainer/NominatorStatsContainer.tsx
+++ b/apps/tangle-dapp/containers/NominatorStatsContainer/NominatorStatsContainer.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useWebContext } from '@webb-tools/api-provider-environment';
-import { isSubstrateAddress } from '@webb-tools/dapp-types';
 import { Button, Divider } from '@webb-tools/webb-ui-components';
 import {
   SOCIAL_URLS_RECORD,
@@ -10,15 +9,13 @@ import {
 } from '@webb-tools/webb-ui-components/constants';
 import cx from 'classnames';
 import Link from 'next/link';
-import { type FC, useMemo, useState } from 'react';
-import React from 'react';
+import { type FC, useState } from 'react';
 
 import { NominatorStatsItem, UnbondingStatsItem } from '../../components';
 import useNetworkStore from '../../context/useNetworkStore';
 import useIsFirstTimeNominator from '../../hooks/useIsFirstTimeNominator';
 import useNetworkFeatures from '../../hooks/useNetworkFeatures';
 import { NetworkFeature, PagePath } from '../../types';
-import { evmToSubstrateAddress } from '../../utils';
 import { BondMoreTxContainer } from '../BondMoreTxContainer';
 import { DelegateTxContainer } from '../DelegateTxContainer';
 import { RebondTxContainer } from '../RebondTxContainer';
@@ -28,29 +25,15 @@ import { WithdrawUnbondedTxContainer } from '../WithdrawUnbondedTxContainer';
 const NominatorStatsContainer: FC = () => {
   const { activeAccount, loading: isActiveAccountLoading } = useWebContext();
   const { nativeTokenSymbol } = useNetworkStore();
+  const networkFeatures = useNetworkFeatures();
+
   const [isDelegateModalOpen, setIsDelegateModalOpen] = useState(false);
   const [isBondMoreModalOpen, setIsBondMoreModalOpen] = useState(false);
   const [isUnbondModalOpen, setIsUnbondModalOpen] = useState(false);
   const [isRebondModalOpen, setIsRebondModalOpen] = useState(false);
-  const networkFeatures = useNetworkFeatures();
 
   const [isWithdrawUnbondedModalOpen, setIsWithdrawUnbondedModalOpen] =
     useState(false);
-
-  const walletAddress = useMemo(() => {
-    if (!activeAccount?.address) return '0x0';
-
-    return activeAccount.address;
-  }, [activeAccount?.address]);
-
-  const substrateAddress = useMemo(() => {
-    if (!activeAccount?.address) return '';
-
-    if (isSubstrateAddress(activeAccount?.address))
-      return activeAccount.address;
-
-    return evmToSubstrateAddress(activeAccount.address);
-  }, [activeAccount?.address]);
 
   const {
     isFirstTimeNominator,
@@ -60,7 +43,7 @@ const NominatorStatsContainer: FC = () => {
 
   return (
     <>
-      <div className="flex flex-col md:flex-row gap-4 w-full">
+      <div className="flex flex-col w-full gap-4 md:flex-row">
         <div
           className={cx(
             'w-full rounded-2xl overflow-hidden h-min-[204px] p-4',
@@ -68,15 +51,11 @@ const NominatorStatsContainer: FC = () => {
             'border-2 border-mono-0 dark:border-mono-160'
           )}
         >
-          <NominatorStatsItem
-            title={`Free Balance`}
-            type="Wallet Balance"
-            address={walletAddress}
-          />
+          <NominatorStatsItem title={`Free Balance`} type="Wallet Balance" />
 
           <Divider className="my-6 bg-mono-0 dark:bg-mono-160" />
 
-          <div className="flex items-center gap-2 flex-wrap">
+          <div className="flex flex-wrap items-center gap-2">
             {networkFeatures.includes(NetworkFeature.Faucet) &&
               !isActiveAccountLoading && (
                 <Link href={WEBB_DISCORD_CHANNEL_URL} target="_blank">
@@ -121,10 +100,9 @@ const NominatorStatsContainer: FC = () => {
               title={`Total Staked ${nativeTokenSymbol}`}
               tooltip="The total amount of tokens you have bonded for nominating."
               type="Total Staked"
-              address={substrateAddress}
             />
 
-            <UnbondingStatsItem address={substrateAddress} />
+            <UnbondingStatsItem />
           </div>
 
           <Divider className="my-6 bg-mono-0 dark:bg-mono-160" />
@@ -132,7 +110,7 @@ const NominatorStatsContainer: FC = () => {
           <div className="grid grid-cols-2 gap-2">
             {!isFirstTimeNominator ? (
               <>
-                <div className="flex items-center gap-2 flex-wrap">
+                <div className="flex flex-wrap items-center gap-2">
                   <Button
                     variant="utility"
                     className="!min-w-[100px]"
@@ -152,7 +130,7 @@ const NominatorStatsContainer: FC = () => {
                   </Button>
                 </div>
 
-                <div className="flex items-center gap-2 flex-wrap">
+                <div className="flex flex-wrap items-center gap-2">
                   <Button
                     variant="utility"
                     className="!min-w-[100px]"

--- a/apps/tangle-dapp/context/BalancesContext.tsx
+++ b/apps/tangle-dapp/context/BalancesContext.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { createContext, FC, PropsWithChildren, useContext } from 'react';
+
+import useBalances from '../data/balances/useBalances';
+
+const BalanceContext = createContext<ReturnType<typeof useBalances>>({
+  free: null,
+  transferable: null,
+  locked: null,
+  isLoading: false,
+  error: null,
+});
+
+export const useBalancesContext = () => useContext(BalanceContext);
+
+export const BalancesProvider: FC<PropsWithChildren> = ({ children }) => {
+  const balances = useBalances();
+
+  return (
+    <BalanceContext.Provider value={balances}>
+      {children}
+    </BalanceContext.Provider>
+  );
+};

--- a/apps/tangle-dapp/data/NominatorStats/useTokenWalletFreeBalance.ts
+++ b/apps/tangle-dapp/data/NominatorStats/useTokenWalletFreeBalance.ts
@@ -1,71 +1,18 @@
 'use client';
 
 import { BN } from '@polkadot/util';
-import { WebbError, WebbErrorCodes } from '@webb-tools/dapp-types/WebbError';
-import { useEffect, useState } from 'react';
-import { type Subscription } from 'rxjs';
 
-import useNetworkStore from '../../context/useNetworkStore';
+import { useBalancesContext } from '../../context/BalancesContext';
 import useFormatReturnType from '../../hooks/useFormatReturnType';
-import { evmToSubstrateAddress } from '../../utils/evmToSubstrateAddress';
-import { getPolkadotApiRx } from '../../utils/polkadot';
 
 export default function useTokenWalletFreeBalance(
-  address: string,
   defaultValue: { value1: BN | null } = { value1: null }
 ) {
-  const [value1, setValue1] = useState(defaultValue.value1);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-  const { rpcEndpoint } = useNetworkStore();
+  const { free, isLoading, error } = useBalancesContext();
 
-  useEffect(() => {
-    let isMounted = true;
-    let sub: Subscription | null = null;
-
-    const fetchData = async () => {
-      if (!address || address === '0x0') {
-        setValue1(null);
-        setIsLoading(false);
-        return;
-      }
-
-      try {
-        const api = await getPolkadotApiRx(rpcEndpoint);
-        if (!api) {
-          throw WebbError.from(WebbErrorCodes.ApiNotReady);
-        }
-
-        const substrateAddress = evmToSubstrateAddress(address);
-
-        sub = api.query.system
-          .account(substrateAddress)
-          .subscribe(async (accData) => {
-            if (isMounted) {
-              const freeBalance = accData.data.free;
-              setValue1(freeBalance);
-              setIsLoading(false);
-            }
-          });
-      } catch (error) {
-        if (isMounted) {
-          setError(
-            error instanceof Error
-              ? error
-              : WebbError.from(WebbErrorCodes.UnknownError)
-          );
-          setIsLoading(false);
-        }
-      }
-    };
-
-    fetchData();
-
-    return () => {
-      isMounted = false;
-      sub?.unsubscribe();
-    };
-  }, [address, rpcEndpoint]);
-
-  return useFormatReturnType({ isLoading, error, data: { value1 } });
+  return useFormatReturnType({
+    isLoading,
+    error,
+    data: { value1: free ?? defaultValue.value1 },
+  });
 }

--- a/apps/tangle-dapp/data/NominatorStats/useTotalStakedAmountSubscription.ts
+++ b/apps/tangle-dapp/data/NominatorStats/useTotalStakedAmountSubscription.ts
@@ -8,16 +8,18 @@ import { type Subscription } from 'rxjs';
 
 import useNetworkStore from '../../context/useNetworkStore';
 import useFormatReturnType from '../../hooks/useFormatReturnType';
+import useSubstrateAddress from '../../hooks/useSubstrateAddress';
 import { getPolkadotApiRx } from '../../utils/polkadot';
 
 export default function useTotalStakedAmountSubscription(
-  address: string,
   defaultValue: { value1: BN | null } = { value1: null }
 ) {
   const [value1, setValue1] = useState(defaultValue.value1);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+
   const { rpcEndpoint, nativeTokenSymbol } = useNetworkStore();
+  const address = useSubstrateAddress();
 
   useEffect(() => {
     let isMounted = true;

--- a/apps/tangle-dapp/data/NominatorStats/useUnbondingAmountSubscription.ts
+++ b/apps/tangle-dapp/data/NominatorStats/useUnbondingAmountSubscription.ts
@@ -7,10 +7,10 @@ import { type Subscription } from 'rxjs';
 
 import useNetworkStore from '../../context/useNetworkStore';
 import useFormatReturnType from '../../hooks/useFormatReturnType';
+import useSubstrateAddress from '../../hooks/useSubstrateAddress';
 import { getPolkadotApiRx } from '../../utils/polkadot';
 
 export default function useUnbondingAmountSubscription(
-  address: string,
   defaultValue: { value1: BN | null } = {
     value1: null,
   }
@@ -18,7 +18,9 @@ export default function useUnbondingAmountSubscription(
   const [value1, setValue1] = useState(defaultValue.value1);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+
   const { rpcEndpoint, nativeTokenSymbol } = useNetworkStore();
+  const address = useSubstrateAddress();
 
   useEffect(() => {
     let isMounted = true;

--- a/apps/tangle-dapp/hooks/useActiveAccountAddress.ts
+++ b/apps/tangle-dapp/hooks/useActiveAccountAddress.ts
@@ -1,9 +1,15 @@
 import { useActiveAccount } from '@webb-tools/api-provider-environment/WebbProvider/subjects';
 
-const useActiveAccountAddress = () => {
-  const activeAccount = useActiveAccount();
+const useActiveAccountAddress = <DefaultValue extends string | null>(
+  defaultValue: DefaultValue = null as DefaultValue
+): DefaultValue => {
+  const [activeAccount] = useActiveAccount();
 
-  return activeAccount[0]?.address ?? null;
+  if (activeAccount === null) {
+    return defaultValue;
+  }
+
+  return activeAccount.address as DefaultValue;
 };
 
 export default useActiveAccountAddress;

--- a/apps/tangle-dapp/utils/formatBnToDisplayAmount.ts
+++ b/apps/tangle-dapp/utils/formatBnToDisplayAmount.ts
@@ -36,8 +36,25 @@ function formatBnToDisplayAmount(
   const divided = amount.div(divisor);
   const remainder = amount.mod(divisor);
 
+  let integerPart = divided.toString(10);
+
   // Convert remainder to a string and pad with zeros if necessary.
   let remainderString = remainder.toString(10);
+
+  // There is a case when the decimals part has leading 0s, so that the remainer
+  // string can missing those 0s when we use `mod` method.
+  // Solution: Try to construct the string again and check the length,
+  // if the length is not the same, we can say that the remainder string is missing
+  // leading 0s, so we try to prepend those 0s to the remainder string
+  if (amount.toString().length !== (integerPart + remainderString).length) {
+    const missing0sCount =
+      amount.toString().length - (integerPart + remainderString).length;
+
+    remainderString =
+      Array.from({ length: missing0sCount })
+        .map(() => '0')
+        .join('') + remainderString;
+  }
 
   if (finalOptions.padZerosInFraction) {
     remainderString = remainderString.padStart(TANGLE_TOKEN_DECIMALS, '0');
@@ -49,8 +66,6 @@ function formatBnToDisplayAmount(
   while (remainderString.endsWith('0')) {
     remainderString = remainderString.substring(0, remainderString.length - 1);
   }
-
-  let integerPart = divided.toString(10);
 
   // Insert commas in the integer part if requested.
   if (finalOptions.includeCommas) {


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Implemented a `BalancesContext` to facilitate the sharing of the active account's balance state among components, eliminating redundant data fetching.
- Rectified an edge case within `formatBnToDisplayAmount` where the presence of leading `0`s in the decimal or remainder part resulted in an incorrect formatted amount compared to the input.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes https://github.com/webb-tools/webb-dapp/issues/2288

### Screen Recording

_If possible provide a screen recording of proposed change._

https://github.com/webb-tools/webb-dapp/assets/60747384/0c1d3535-12aa-4c7e-a110-82ccb6d05bd8