### PR TITLE
perf(tangle-dapp): Optimize `usePayouts` hook

### DIFF
--- a/apps/tangle-dapp/containers/NominationsPayoutsContainer/NominationsPayoutsContainer.tsx
+++ b/apps/tangle-dapp/containers/NominationsPayoutsContainer/NominationsPayoutsContainer.tsx
@@ -59,7 +59,7 @@ function assertTab(tab: string): NominationsAndPayoutsTab {
 
 const DelegationsPayoutsContainer: FC = () => {
   const tableRef = useRef<HTMLDivElement>(null);
-  const { activeAccount, loading } = useWebContext();
+  const { activeAccount, loading, isConnecting } = useWebContext();
   const [payouts, setPayouts] = useState<Payout[]>([]);
   const [updatedPayouts, setUpdatedPayouts] = useState<Payout[]>([]);
   const [isDelegateModalOpen, setIsDelegateModalOpen] = useState(false);
@@ -194,9 +194,9 @@ const DelegationsPayoutsContainer: FC = () => {
               description="Connect your wallet to view and manage your staking details."
               buttonText="Connect"
               buttonProps={{
-                isLoading: loading,
+                isLoading: loading || isConnecting,
                 isDisabled: isMobile,
-                loadingText: 'Connecting...',
+                loadingText: isConnecting ? 'Connecting...' : 'Loading...',
                 onClick: () => toggleModal(true),
               }}
               icon="🔗"
@@ -229,9 +229,9 @@ const DelegationsPayoutsContainer: FC = () => {
               description="Connect your wallet to view and manage your staking details."
               buttonText="Connect"
               buttonProps={{
-                isLoading: loading,
+                isLoading: loading || isConnecting,
                 isDisabled: isMobile,
-                loadingText: 'Connecting...',
+                loadingText: isConnecting ? 'Connecting...' : 'Loading...',
                 onClick: () => toggleModal(true),
               }}
               icon="🔗"

--- a/apps/tangle-dapp/data/payouts/store.ts
+++ b/apps/tangle-dapp/data/payouts/store.ts
@@ -1,0 +1,20 @@
+import type { Prettify } from 'viem/chains';
+import { create } from 'zustand';
+
+import type { Payout } from '../../types';
+
+type State = {
+  isLoading: boolean;
+  data: Payout[];
+};
+
+export const usePayoutsStore = create<Prettify<State>>(() => ({
+  isLoading: false,
+  data: [],
+}));
+
+export const setIsLoading = (isLoading: State['isLoading']) =>
+  usePayoutsStore.setState({ isLoading });
+
+export const setPayouts = (data: State['data']) =>
+  usePayoutsStore.setState({ data });

--- a/apps/tangle-dapp/data/payouts/useClaimedRewards.ts
+++ b/apps/tangle-dapp/data/payouts/useClaimedRewards.ts
@@ -1,0 +1,62 @@
+import type { ApiRx } from '@polkadot/api';
+import type { u32, Vec } from '@polkadot/types';
+import type { AccountId32 } from '@polkadot/types/interfaces';
+import { map } from 'rxjs';
+
+import useApiRx from '../../hooks/useApiRx';
+
+/**
+ * Get all claimed rewards in the storage,
+ * and store them in a map for easy access.
+ * @returns keyed by era and validator stash
+ * which maps to the set of page indexes which have been claimed.
+ */
+const useClaimedRewards = () => {
+  const { result, ...rest } = useApiRx(claimedRewardsFetcher);
+
+  return {
+    result: result ?? new Map<number, Map<string, Set<number>>>(),
+    ...rest,
+  };
+};
+
+export default useClaimedRewards;
+
+const claimedRewardsFetcher = (api: ApiRx) =>
+  // For some reason, the type of this query is not correct,
+  // so we need to manually specify the correct type
+  api.query.staking.claimedRewards.entries<Vec<u32>, [u32, AccountId32]>().pipe(
+    map((entries) =>
+      entries.reduce((claimedRewardsMap, [key, value]) => {
+        const era = key.args[0].toNumber();
+        const validatorAddress = key.args[1].toString();
+
+        const pageIndexes = value
+          .slice()
+          .reduce(
+            (pageIdxes, idx) => pageIdxes.add(idx.toNumber()),
+            new Set<number>(),
+          );
+
+        let validatorMap = claimedRewardsMap.get(era);
+
+        if (validatorMap === undefined) {
+          validatorMap = new Map<string, Set<number>>();
+          claimedRewardsMap.set(era, validatorMap);
+        }
+
+        const validatorClaimedPageIdxes = validatorMap.get(validatorAddress);
+
+        if (validatorClaimedPageIdxes === undefined) {
+          validatorMap.set(validatorAddress, pageIndexes);
+        } else {
+          validatorMap.set(
+            validatorAddress,
+            new Set([...validatorClaimedPageIdxes, ...pageIndexes]),
+          );
+        }
+
+        return claimedRewardsMap;
+      }, new Map<number, Map<string, Set<number>>>()),
+    ),
+  );

--- a/apps/tangle-dapp/data/payouts/useErasRewardsPoints.ts
+++ b/apps/tangle-dapp/data/payouts/useErasRewardsPoints.ts
@@ -1,0 +1,34 @@
+import type { ApiRx } from '@polkadot/api';
+import { map } from 'rxjs';
+
+import useApiRx from '../../hooks/useApiRx';
+
+/**
+ * Get all the entries of the staking.erasRewardPoints storage
+ * key is the era number and value is an object with total and individual reward points
+ * @returns the result of the query staking.erasRewardPoints.entries()
+ */
+const useErasRewardsPoints = () => useApiRx(erasRewardsPointsFetcher);
+
+export default useErasRewardsPoints;
+
+const erasRewardsPointsFetcher = (api: ApiRx) =>
+  api.query.staking.erasRewardPoints.entries().pipe(
+    map((entries) =>
+      entries.map(
+        ([key, value]) =>
+          [
+            key.args[0].toNumber(),
+            {
+              total: value.total.toNumber(),
+              individual: new Map(
+                Array.from(value.individual.entries()).map(([key, value]) => [
+                  key.toString(),
+                  value.toNumber(),
+                ]),
+              ),
+            },
+          ] as const,
+      ),
+    ),
+  );

--- a/apps/tangle-dapp/data/payouts/useNominationsUnclaimedRewards.ts
+++ b/apps/tangle-dapp/data/payouts/useNominationsUnclaimedRewards.ts
@@ -1,0 +1,61 @@
+import { useCallback } from 'react';
+import { map } from 'rxjs';
+
+import useApiRx from '../../hooks/useApiRx';
+import useSubstrateAddress from '../../hooks/useSubstrateAddress';
+import { ValidatorReward } from '../types';
+import useClaimedRewards from './useClaimedRewards';
+import useErasRewardsPoints from './useErasRewardsPoints';
+
+/**
+ * Get all unclaimed rewards of the active account's nominations
+ */
+export default function useNominationsUnclaimedRewards() {
+  const activeSubstrateAddress = useSubstrateAddress();
+
+  // Retrieve all validators that the account has nominated
+  const { result: validators } = useApiRx(
+    useCallback(
+      (api) => {
+        if (!activeSubstrateAddress) {
+          return null;
+        }
+
+        return api.query.staking
+          .nominators(activeSubstrateAddress)
+          .pipe(
+            map((nominators) =>
+              nominators.isNone
+                ? null
+                : nominators
+                    .unwrap()
+                    .targets.map((target) => target.toString()),
+            ),
+          );
+      },
+      [activeSubstrateAddress],
+    ),
+  );
+
+  const { result: claimedRewards } = useClaimedRewards();
+
+  const { result: erasRewardsPoints } = useErasRewardsPoints();
+
+  return (validators ?? []).reduce((unclaimedRewards, validator) => {
+    (erasRewardsPoints ?? []).forEach(([era, reward]) => {
+      const hasClaimed = claimedRewards.get(era)?.get(validator)?.size !== 0;
+
+      // If the reward has claimed, do nothing
+      if (hasClaimed) return;
+
+      unclaimedRewards.concat({
+        era,
+        eraTotalRewardPoints: reward.total,
+        validatorAddress: validator,
+        validatorRewardPoints: reward.individual.get(validator) ?? 0,
+      });
+    });
+
+    return unclaimedRewards;
+  }, [] as ValidatorReward[]);
+}

--- a/apps/tangle-dapp/data/types.ts
+++ b/apps/tangle-dapp/data/types.ts
@@ -1,0 +1,6 @@
+export type ValidatorReward = {
+  validatorAddress: string;
+  era: number;
+  eraTotalRewardPoints: number;
+  validatorRewardPoints: number;
+};

--- a/libs/api-provider-environment/src/WebbProvider/index.tsx
+++ b/libs/api-provider-environment/src/WebbProvider/index.tsx
@@ -98,7 +98,7 @@ const WebbProviderInner: FC<WebbProviderProps> = ({
   const [activeApi, setActiveApi] =
     useState<Maybe<WebbApiProvider<unknown>>>(undefined);
 
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
 
   const [accounts, setAccounts] = useState<Array<Account>>([]);
 


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Optimized `usePayouts` hook.
- Display the loading state on the nomination and payout tables.
- Loading should be `false` by default on `WebbProvider`.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes https://github.com/webb-tools/webb-dapp/issues/2327

### Screen Recording

_If possible provide a screen recording of proposed change._

---

_Before_

![CleanShot 2024-06-03 at 08 51 49@2x](https://github.com/webb-tools/webb-dapp/assets/60747384/42b35a60-ef5c-4f28-8dc4-d798306aaa26)

_After_

![CleanShot 2024-06-04 at 01 06 41@2x](https://github.com/webb-tools/webb-dapp/assets/60747384/40dea93f-0d8b-4505-9102-1fe41145d526)
