### PR TITLE
fix(tangle-dapp): Fixing Infinite `useEffect` Calls

### DIFF
--- a/apps/tangle-dapp/data/NominationsPayouts/usePayouts.ts
+++ b/apps/tangle-dapp/data/NominationsPayouts/usePayouts.ts
@@ -8,40 +8,45 @@ import {
 } from '@polkadot/types/lookup';
 import { BN_ZERO } from '@polkadot/util';
 import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 import useNetworkStore from '../../context/useNetworkStore';
 import useApiRx from '../../hooks/useApiRx';
 import useLocalStorage, { LocalStorageKey } from '../../hooks/useLocalStorage';
 import useSubstrateAddress from '../../hooks/useSubstrateAddress';
 import { Payout } from '../../types';
-import {
-  getApiPromise as getPolkadotApiPromise,
-  getValidatorIdentityName,
-} from '../../utils/polkadot';
-import { setIsLoading, setPayouts, usePayoutsStore } from '../payouts/store';
+import { getApiPromise as getPolkadotApiPromise } from '../../utils/polkadot';
+import { usePayoutsStore } from '../payouts/store';
 import useEraTotalRewards from '../payouts/useEraTotalRewards';
 import useNominationsUnclaimedRewards from '../payouts/useNominationsUnclaimedRewards';
 import type { ValidatorReward } from '../types';
+import useValidatorIdentityNames from '../ValidatorTables/useValidatorIdentityNames';
 
-type PayoutData = {
-  data: Payout[];
+type UsePayoutsReturnType = {
   isLoading: boolean;
+  data: Payout[];
 };
 
-export default function usePayouts(): PayoutData {
-  const { isLoading, data: payouts } = usePayoutsStore();
+export default function usePayouts(): UsePayoutsReturnType {
+  const { setIsLoading, setPayouts, isLoading, data } = usePayoutsStore();
+
   const { setWithPreviousValue: setCachedPayouts } = useLocalStorage(
     LocalStorageKey.PAYOUTS,
     true,
   );
+
   const { rpcEndpoint, network } = useNetworkStore();
   const activeSubstrateAddress = useSubstrateAddress();
 
   const { data: eraTotalRewards } = useEraTotalRewards();
+  const { result: validatorIdentityNamesMap } = useValidatorIdentityNames();
+
+  const unclaimedRewards = useNominationsUnclaimedRewards();
+
   const { result: validators } = useApiRx(
     useCallback((api) => api.query.staking.validators.entries(), []),
   );
+
   const mappedValidatorInfo = useMemo(() => {
     const map = new Map<string, PalletStakingValidatorPrefs>();
     validators?.forEach(([storageKey, validatorInfo]) => {
@@ -49,64 +54,77 @@ export default function usePayouts(): PayoutData {
     });
     return map;
   }, [validators]);
-  const unclaimedRewards = useNominationsUnclaimedRewards();
-  const hasComputedPayoutsRef = useRef(false);
 
-  useEffect(() => {
-    // Make sure all data is available before computing payouts
-    if (
-      activeSubstrateAddress === null ||
-      unclaimedRewards.length === 0 ||
-      eraTotalRewards === null ||
-      eraTotalRewards.size === 0 ||
-      mappedValidatorInfo.size === 0 ||
-      hasComputedPayoutsRef.current ||
-      isLoading
-    )
-      return;
+  useEffect(
+    () => {
+      // Make sure all data is available before computing payouts
+      if (
+        activeSubstrateAddress === null ||
+        unclaimedRewards.length === 0 ||
+        eraTotalRewards === null ||
+        eraTotalRewards.size === 0 ||
+        mappedValidatorInfo.size === 0 ||
+        validatorIdentityNamesMap === null ||
+        validatorIdentityNamesMap.size === 0 ||
+        data.length > 0
+      )
+        return;
 
-    const computePayouts = async () => {
-      setIsLoading(true);
+      const abortController = new AbortController();
 
-      const payouts = await fetchPayouts(
-        rpcEndpoint,
-        activeSubstrateAddress,
-        unclaimedRewards,
-        eraTotalRewards,
-        mappedValidatorInfo,
-        network.ss58Prefix,
-      );
+      const computePayouts = async () => {
+        try {
+          setIsLoading(true);
 
-      const sortedPayout = payouts.sort((a, b) => a.era - b.era);
+          const payouts = await fetchPayouts(
+            rpcEndpoint,
+            activeSubstrateAddress,
+            unclaimedRewards,
+            eraTotalRewards,
+            mappedValidatorInfo,
+            validatorIdentityNamesMap,
+            network.ss58Prefix,
+            abortController.signal,
+          );
 
-      setPayouts(sortedPayout);
-      setCachedPayouts((previous) => ({
-        ...previous?.value,
-        [rpcEndpoint]: {
-          ...previous?.value?.[rpcEndpoint],
-          [activeSubstrateAddress]: sortedPayout,
-        },
-      }));
+          abortController.signal.throwIfAborted();
+          const sortedPayout = payouts.sort((a, b) => a.era - b.era);
 
-      hasComputedPayoutsRef.current = true; // Mark payouts as computed
-      setIsLoading(false);
-    };
+          abortController.signal.throwIfAborted();
+          setPayouts(sortedPayout);
+          setCachedPayouts((previous) => ({
+            ...previous?.value,
+            [rpcEndpoint]: {
+              ...previous?.value?.[rpcEndpoint],
+              [activeSubstrateAddress]: sortedPayout,
+            },
+          }));
+        } catch (error) {
+          // Ignore if it is the AbortError
+          if ((error as Error).name === 'AbortError') {
+            setIsLoading(false);
+            return;
+          }
 
-    computePayouts();
-  }, [
-    activeSubstrateAddress,
-    eraTotalRewards,
-    mappedValidatorInfo,
-    network.ss58Prefix,
-    rpcEndpoint,
-    setCachedPayouts,
-    unclaimedRewards,
-    isLoading,
-  ]);
+          console.error('[usePayouts] Error fetching payouts', error);
+        } finally {
+          setIsLoading(false);
+        }
+      };
+
+      computePayouts();
+
+      return () => {
+        abortController.abort();
+      };
+    },
+    // prettier-ignore
+    [activeSubstrateAddress, data.length, eraTotalRewards, mappedValidatorInfo, network.ss58Prefix, rpcEndpoint, setCachedPayouts, setIsLoading, setPayouts, unclaimedRewards, validatorIdentityNamesMap],
+  );
 
   return {
-    data: payouts,
     isLoading,
+    data,
   };
 }
 
@@ -116,12 +134,15 @@ const fetchPayouts = async (
   unclaimedRewards: ValidatorReward[],
   eraTotalRewards: Map<number, Option<u128>>,
   mappedValidatorInfo: Map<string, PalletStakingValidatorPrefs>,
+  validatorIdentityNamesMap: Map<string, string | null>,
   ss58Prefix?: number,
+  abortSignal?: AbortSignal,
 ): Promise<Payout[]> => {
   const publicKey = decodeAddress(activeSubstrateAddress);
   const activeSubstrateAddressEncoded = encodeAddress(publicKey, ss58Prefix);
   const apiPromise = await getPolkadotApiPromise(rpcEndpoint);
 
+  abortSignal?.throwIfAborted();
   const payoutsWithNull = await Promise.all(
     unclaimedRewards.map(async (reward) => {
       const eraTotalRewardOpt = eraTotalRewards.get(reward.era);
@@ -139,6 +160,7 @@ const fetchPayouts = async (
         return null;
       }
 
+      abortSignal?.throwIfAborted();
       const erasStakersOverview =
         await apiPromise.query.staking.erasStakersOverview<
           Option<SpStakingPagedExposureMetadata>
@@ -156,6 +178,7 @@ const fetchPayouts = async (
         return null;
       }
 
+      abortSignal?.throwIfAborted();
       const eraStakerPaged = await apiPromise.query.staking.erasStakersPaged<
         Option<SpStakingExposurePage>
       >(reward.era, reward.validatorAddress, 0);
@@ -187,25 +210,20 @@ const fetchPayouts = async (
         return null;
       }
 
-      const validatorIdentityName = await getValidatorIdentityName(
-        rpcEndpoint,
-        reward.validatorAddress,
-      );
+      const validatorIdentityName =
+        validatorIdentityNamesMap.get(reward.validatorAddress) ?? '';
 
-      const validatorNominators = await Promise.all(
-        individualExposures.map(async (nominator) => {
-          const nominatorIdentity = await getValidatorIdentityName(
-            rpcEndpoint,
-            nominator.who.toString(),
-          );
+      const validatorNominators = individualExposures.map((nominator) => {
+        const nominatorIdentity =
+          validatorIdentityNamesMap.get(nominator.who.toString()) ?? '';
 
-          return {
-            address: nominator.who.toString(),
-            identity: nominatorIdentity ?? '',
-          };
-        }),
-      );
+        return {
+          address: nominator.who.toString(),
+          identity: nominatorIdentity,
+        };
+      });
 
+      abortSignal?.throwIfAborted();
       const stakerEraReward = await apiPromise.derive.staking.stakerRewards(
         activeSubstrateAddressEncoded,
       );
@@ -229,7 +247,7 @@ const fetchPayouts = async (
           era: reward.era,
           validator: {
             address: reward.validatorAddress,
-            identity: validatorIdentityName ?? '',
+            identity: validatorIdentityName,
           },
           validatorTotalStake: validatorTotalStake,
           nominators: validatorNominators,

--- a/apps/tangle-dapp/data/NominationsPayouts/usePayouts.ts
+++ b/apps/tangle-dapp/data/NominationsPayouts/usePayouts.ts
@@ -30,8 +30,6 @@ type UsePayoutsReturnType = {
 export default function usePayouts(): UsePayoutsReturnType {
   const { setIsLoading, setPayouts, isLoading, data } = usePayoutsStore();
 
-  console.debug('usePayouts', data);
-
   const { setWithPreviousValue: setCachedPayouts } = useLocalStorage(
     LocalStorageKey.PAYOUTS,
     true,

--- a/apps/tangle-dapp/data/NominationsPayouts/usePayouts.ts
+++ b/apps/tangle-dapp/data/NominationsPayouts/usePayouts.ts
@@ -30,6 +30,8 @@ type UsePayoutsReturnType = {
 export default function usePayouts(): UsePayoutsReturnType {
   const { setIsLoading, setPayouts, isLoading, data } = usePayoutsStore();
 
+  console.debug('usePayouts', data);
+
   const { setWithPreviousValue: setCachedPayouts } = useLocalStorage(
     LocalStorageKey.PAYOUTS,
     true,

--- a/apps/tangle-dapp/data/ValidatorTables/useValidatorIdentityNames.ts
+++ b/apps/tangle-dapp/data/ValidatorTables/useValidatorIdentityNames.ts
@@ -38,7 +38,10 @@ const useValidatorIdentityNames = () => {
     ),
   );
 
-  const nameMap = useEntryMap(identityNames, (key) => key);
+  const nameMap = useEntryMap(
+    identityNames,
+    useCallback((key) => key, []),
+  );
 
   return { result: nameMap, ...other };
 };

--- a/apps/tangle-dapp/data/payouts/store.ts
+++ b/apps/tangle-dapp/data/payouts/store.ts
@@ -1,4 +1,3 @@
-import type { Prettify } from 'viem/chains';
 import { create } from 'zustand';
 
 import type { Payout } from '../../types';
@@ -9,13 +8,15 @@ type State = {
 };
 
 type Actions = {
-  setIsLoading: (isLoading: State['isLoading']) => void;
-  setPayouts: (data: State['data']) => void;
+  setIsLoading: (isLoading: boolean) => void;
+  setPayouts: (data: Payout[]) => void;
 };
 
-export const usePayoutsStore = create<Prettify<State & Actions>>(() => ({
+type Store = State & Actions;
+
+export const usePayoutsStore = create<Store>((set) => ({
   isLoading: false,
   data: [],
-  setIsLoading: (isLoading: State['isLoading']) => ({ isLoading }),
-  setPayouts: (data: State['data']) => ({ data }),
+  setIsLoading: (isLoading) => set((state) => ({ ...state, isLoading })),
+  setPayouts: (data) => set((state) => ({ ...state, data })),
 }));

--- a/apps/tangle-dapp/data/payouts/store.ts
+++ b/apps/tangle-dapp/data/payouts/store.ts
@@ -8,13 +8,14 @@ type State = {
   data: Payout[];
 };
 
-export const usePayoutsStore = create<Prettify<State>>(() => ({
+type Actions = {
+  setIsLoading: (isLoading: State['isLoading']) => void;
+  setPayouts: (data: State['data']) => void;
+};
+
+export const usePayoutsStore = create<Prettify<State & Actions>>(() => ({
   isLoading: false,
   data: [],
+  setIsLoading: (isLoading: State['isLoading']) => ({ isLoading }),
+  setPayouts: (data: State['data']) => ({ data }),
 }));
-
-export const setIsLoading = (isLoading: State['isLoading']) =>
-  usePayoutsStore.setState({ isLoading });
-
-export const setPayouts = (data: State['data']) =>
-  usePayoutsStore.setState({ data });

--- a/apps/tangle-dapp/data/payouts/store.ts
+++ b/apps/tangle-dapp/data/payouts/store.ts
@@ -8,8 +8,8 @@ type State = {
 };
 
 type Actions = {
-  setIsLoading: (isLoading: boolean) => void;
-  setPayouts: (data: Payout[]) => void;
+  setIsLoading: (isLoading: State['isLoading']) => void;
+  setPayouts: (data: State['data']) => void;
 };
 
 type Store = State & Actions;
@@ -17,6 +17,6 @@ type Store = State & Actions;
 export const usePayoutsStore = create<Store>((set) => ({
   isLoading: false,
   data: [],
-  setIsLoading: (isLoading) => set((state) => ({ ...state, isLoading })),
-  setPayouts: (data) => set((state) => ({ ...state, data })),
+  setIsLoading: (isLoading) => set({ isLoading }),
+  setPayouts: (data) => set({ data }),
 }));

--- a/apps/tangle-dapp/data/payouts/useClaimedRewards.ts
+++ b/apps/tangle-dapp/data/payouts/useClaimedRewards.ts
@@ -11,14 +11,7 @@ import useApiRx from '../../hooks/useApiRx';
  * @returns keyed by era and validator stash
  * which maps to the set of page indexes which have been claimed.
  */
-const useClaimedRewards = () => {
-  const { result, ...rest } = useApiRx(claimedRewardsFetcher);
-
-  return {
-    result: result ?? new Map<number, Map<string, Set<number>>>(),
-    ...rest,
-  };
-};
+const useClaimedRewards = () => useApiRx(claimedRewardsFetcher);
 
 export default useClaimedRewards;
 

--- a/apps/tangle-dapp/data/payouts/useEraTotalRewards.ts
+++ b/apps/tangle-dapp/data/payouts/useEraTotalRewards.ts
@@ -8,10 +8,15 @@ const useEraTotalRewards = () => {
     useCallback((api) => api.query.staking.erasValidatorReward.entries(), []),
   );
 
-  const erasValidatorRewardsMap = useEntryMap(erasValidatorRewards, (key) =>
-    // It's fine to convert `u32` to a JavaScript number, it'll
-    // always be within the safe range.
-    key.args[0].toNumber(),
+  const erasValidatorRewardsMap = useEntryMap(
+    erasValidatorRewards,
+    useCallback(
+      (key) =>
+        // It's fine to convert `u32` to a JavaScript number, it'll
+        // always be within the safe range.
+        key.args[0].toNumber(),
+      [],
+    ),
   );
 
   return { data: erasValidatorRewardsMap, ...other };

--- a/apps/tangle-dapp/data/payouts/useNominationsUnclaimedRewards.ts
+++ b/apps/tangle-dapp/data/payouts/useNominationsUnclaimedRewards.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { map } from 'rxjs';
 
 import useApiRx from '../../hooks/useApiRx';
@@ -6,6 +6,13 @@ import useSubstrateAddress from '../../hooks/useSubstrateAddress';
 import { ValidatorReward } from '../types';
 import useClaimedRewards from './useClaimedRewards';
 import useErasRewardsPoints from './useErasRewardsPoints';
+
+/**
+ * Defined constant empty array to return on every render
+ * to make sure it's always the same reference
+ * and avoid unnecessary re-renders
+ */
+const EMPTY_ARRAY: ValidatorReward[] = [];
 
 /**
  * Get all unclaimed rewards of the active account's nominations
@@ -41,22 +48,36 @@ export default function useNominationsUnclaimedRewards() {
 
   const { result: erasRewardsPoints } = useErasRewardsPoints();
 
-  return (validators ?? []).reduce((unclaimedRewards, validator) => {
-    (erasRewardsPoints ?? []).forEach(([era, reward]) => {
-      const claimedErasLength = claimedRewards.get(era)?.get(validator)?.size;
-      const hasClaimed = claimedErasLength ? claimedErasLength >= 1 : false;
+  return useMemo(() => {
+    // Returned empty array if the data is not ready
+    if (
+      validators === null ||
+      validators.length === 0 ||
+      erasRewardsPoints === null ||
+      erasRewardsPoints.length === 0 ||
+      claimedRewards === null ||
+      claimedRewards.size === 0
+    ) {
+      return EMPTY_ARRAY;
+    }
 
-      // If the reward has claimed, do nothing
-      if (hasClaimed) return;
+    return validators.reduce((unclaimedRewards, validator) => {
+      erasRewardsPoints.forEach(([era, reward]) => {
+        const claimedErasLength = claimedRewards.get(era)?.get(validator)?.size;
+        const hasClaimed = claimedErasLength ? claimedErasLength >= 1 : false;
 
-      unclaimedRewards.push({
-        era,
-        eraTotalRewardPoints: reward.total,
-        validatorAddress: validator,
-        validatorRewardPoints: reward.individual.get(validator) ?? 0,
+        // If the reward has claimed, do nothing
+        if (hasClaimed) return;
+
+        unclaimedRewards.push({
+          era,
+          eraTotalRewardPoints: reward.total,
+          validatorAddress: validator,
+          validatorRewardPoints: reward.individual.get(validator) ?? 0,
+        });
       });
-    });
 
-    return unclaimedRewards;
-  }, [] as ValidatorReward[]);
+      return unclaimedRewards;
+    }, [] as ValidatorReward[]);
+  }, [claimedRewards, erasRewardsPoints, validators]);
 }


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Memorized calculations & functions to avoid unnecessary re-renders.
- Added an abort signal to cancel the previous call.
- Added an identity map to avoid multiple requests for validators' identities.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes `NaN`

### Screen Recording (# of requests benchmarking)

_If possible provide a screen recording of proposed change._

![CleanShot 2024-06-04 at 18 22 51@2x](https://github.com/webb-tools/webb-dapp/assets/60747384/2c0f8b61-945d-4619-9161-d48cbc7b4ca1)