### PR TITLE
fix(tangle-dapp): Fix Amount Input

### DIFF
--- a/apps/tangle-dapp/hooks/useInputAmount.ts
+++ b/apps/tangle-dapp/hooks/useInputAmount.ts
@@ -1,5 +1,5 @@
 import { BN } from '@polkadot/util';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import formatBn, { FormatOptions } from '../utils/formatBn';
 import parseChainUnits, {
@@ -64,12 +64,8 @@ const useInputAmount = ({
   decimals,
 }: Options) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [hasPeriodAtTheEnd, setHasPeriodAtTheEnd] = useState(false);
-
-  const displayAmount = useMemo(
-    () =>
-      `${amount !== null ? formatBn(amount, decimals, INPUT_AMOUNT_FORMAT) : ''}${amount !== null && hasPeriodAtTheEnd ? '.' : ''}`,
-    [amount, decimals, hasPeriodAtTheEnd],
+  const [displayAmount, setDisplayAmount] = useState(
+    amount !== null ? formatBn(amount, decimals, INPUT_AMOUNT_FORMAT) : '',
   );
 
   const handleChange = useCallback(
@@ -90,15 +86,7 @@ const useInputAmount = ({
         })
         .join('');
 
-      if (cleanAmountString !== newAmountString) {
-        return;
-      }
-
-      if (newAmountString.endsWith('.')) {
-        setHasPeriodAtTheEnd(true);
-      } else {
-        setHasPeriodAtTheEnd(false);
-      }
+      setDisplayAmount(cleanAmountString);
 
       const amountOrError = safeParseInputAmount({
         amountString: newAmountString,
@@ -131,6 +119,15 @@ const useInputAmount = ({
       setAmount,
     ],
   );
+
+  useEffect(() => {
+    // If the amount is null, then the display amount should always be empty.
+    // This handle the case where the amount is set to null after submitting a tx
+    // but the display amount is not updated
+    if (!amount) {
+      setDisplayAmount('');
+    }
+  }, [amount]);
 
   return {
     displayAmount,


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Fix the bug that the input amount does not allow 0.0, 10.00, etc.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes #2412 

### Screen Recording

https://github.com/webb-tools/webb-dapp/assets/69841784/448f1059-bb61-4eba-9e81-68b3e27ca442

---

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
