### PR TITLE
fix(tangle-dapp): Fix `useEffect` cycle in `usePayouts` hook

### DIFF
--- a/apps/tangle-dapp/data/NominationsPayouts/usePayouts.ts
+++ b/apps/tangle-dapp/data/NominationsPayouts/usePayouts.ts
@@ -72,6 +72,10 @@ export default function usePayouts(): UsePayoutsReturnType {
     resetPayouts();
   }, [activeAccount?.address, resetPayouts, setPayouts]);
 
+  // Keep this check outside to prevent cycle by the `data` dependency.
+  const doesDataAtMaxErasExist =
+    data[maxEras] !== undefined && data[maxEras].length > 0;
+
   useEffect(
     () => {
       // Make sure all data is available before computing payouts
@@ -83,7 +87,7 @@ export default function usePayouts(): UsePayoutsReturnType {
         mappedValidatorInfo.size === 0 ||
         validatorIdentityNamesMap === null ||
         validatorIdentityNamesMap.size === 0 ||
-        (data[maxEras] !== undefined && data[maxEras].length > 0)
+        doesDataAtMaxErasExist
       ) {
         return;
       }
@@ -138,7 +142,7 @@ export default function usePayouts(): UsePayoutsReturnType {
       };
     },
     // prettier-ignore
-    [activeSubstrateAddress, data, eraTotalRewards, mappedValidatorInfo, maxEras, network.ss58Prefix, rpcEndpoint, setCachedPayouts, setIsLoading, setPayouts, unclaimedRewards, validatorIdentityNamesMap],
+    [activeSubstrateAddress, doesDataAtMaxErasExist, eraTotalRewards, mappedValidatorInfo, maxEras, network.ss58Prefix, rpcEndpoint, setCachedPayouts, setIsLoading, setPayouts, unclaimedRewards, validatorIdentityNamesMap],
   );
 
   return {

--- a/apps/tangle-dapp/data/NominationsPayouts/usePayouts.ts
+++ b/apps/tangle-dapp/data/NominationsPayouts/usePayouts.ts
@@ -78,7 +78,7 @@ export default function usePayouts(): UsePayoutsReturnType {
 
   useEffect(
     () => {
-      // Make sure all data is available before computing payouts
+      // Make sure all data is available before computing payouts.
       if (
         activeSubstrateAddress === null ||
         unclaimedRewards.length === 0 ||


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- `data` is changed when `setPayouts` is called, yet `data` is a dependency of the `useEffect`, thus leading to a cycle.
- Fixed by taking the condition check outside of the `useEffect`.
- Bug seems to appear only when there are **no** available payouts in the user's account.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes

### Screen Recording

_If possible provide a screen recording of proposed change._

---

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
