### PR TITLE
fix(tangle-dapp): Fix Search not working on Validator Selection Table on Tangle dApp

### DIFF
--- a/apps/tangle-dapp/components/ValidatorSelectionTable/ValidatorSelectionTable.tsx
+++ b/apps/tangle-dapp/components/ValidatorSelectionTable/ValidatorSelectionTable.tsx
@@ -130,6 +130,13 @@ const ValidatorSelectionTable: FC<ValidatorSelectionTableProps> = ({
             sortAddressOrIdentityForNomineeOrValidator,
             isDesc,
           ),
+        filterFn: (row, _, filterValue) => {
+          const { address, identityName } = row.original;
+          return (
+            address.toLowerCase().includes(filterValue.toLowerCase()) ||
+            identityName.toLowerCase().includes(filterValue.toLowerCase())
+          );
+        },
       }),
       columnHelper.accessor('totalStakeAmount', {
         header: () => (
@@ -213,12 +220,14 @@ const ValidatorSelectionTable: FC<ValidatorSelectionTableProps> = ({
         },
         sorting,
         rowSelection,
-        globalFilter: searchValue,
+        columnFilters: [
+          {
+            id: 'address',
+            value: searchValue,
+          },
+        ],
       },
       enableRowSelection: true,
-      onGlobalFilterChange: (props) => {
-        setSearchValue(props);
-      },
       onRowSelectionChange: (props) => {
         toggleSortSelectionHandlerRef.current?.(false);
         setRowSelection(props);
@@ -253,6 +262,7 @@ const ValidatorSelectionTable: FC<ValidatorSelectionTableProps> = ({
           value={searchValue}
           onChange={(val) => setSearchValue(val)}
           className="mb-1"
+          isControlled
         />
 
         {allValidators.length === 0 ? (


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Fix searching not working
- User can search by identity and address of validators

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/bridge-dapp`
- [ ] `apps/hubble-stats`
- [ ] `apps/stats-dapp`
- [x] `apps/tangle-dapp`
- [ ] `apps/testnet-leaderboard`
- [ ] `apps/faucet`
- [ ] `apps/zk-explorer`
- [ ] `libs/webb-ui-components`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes #2431 

### Screen Recording

_If possible provide a screen recording of proposed change._

https://github.com/user-attachments/assets/bb9c0133-1934-4691-b1cc-9f8bd9967c1b

---

### Code Checklist

_Please be sure to add .stories documentation if any additions are made to `libs/webb-ui-components`._

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
