### PR TITLE
feat(tangle-cloud): runtime permitted callers management

### DIFF
--- a/apps/tangle-cloud/src/pages/instances/Instances/RunningInstanceTable.tsx
+++ b/apps/tangle-cloud/src/pages/instances/Instances/RunningInstanceTable.tsx
@@ -234,7 +234,7 @@ export const RunningInstanceTable: FC<RunningInstanceTableProps> = () => {
                     variant="utility"
                     className="uppercase body4 bg-blue-10 dark:bg-blue-120 text-blue-70 dark:text-blue-40 hover:bg-blue-20 dark:hover:bg-blue-110 border border-blue-30 dark:border-blue-100 transition-all duration-200"
                   >
-                    View
+                    Blueprint
                   </Button>
                 </Link>
 

--- a/apps/tangle-cloud/src/pages/instances/Instances/RunningInstanceTable.tsx
+++ b/apps/tangle-cloud/src/pages/instances/Instances/RunningInstanceTable.tsx
@@ -1,11 +1,4 @@
-import {
-  useMemo,
-  useState,
-  useCallback,
-  type FC,
-  Dispatch,
-  SetStateAction,
-} from 'react';
+import { useMemo, useState, useCallback, type FC } from 'react';
 import {
   createColumnHelper,
   getCoreRowModel,
@@ -44,12 +37,7 @@ interface ServiceWithBlueprint extends Service {
 
 const columnHelper = createColumnHelper<ServiceWithBlueprint>();
 
-interface RunningInstanceTableProps {
-  refreshTrigger: number;
-  setRefreshTrigger: Dispatch<SetStateAction<number>>;
-}
-
-export const RunningInstanceTable: FC<RunningInstanceTableProps> = () => {
+export const RunningInstanceTable: FC = () => {
   const { address: currentUserAddress } = useAccount();
   const { isOperator, operatorAddress } = useEvmOperatorInfo();
 

--- a/apps/tangle-cloud/src/pages/instances/Instances/index.tsx
+++ b/apps/tangle-cloud/src/pages/instances/Instances/index.tsx
@@ -82,10 +82,7 @@ export const InstancesTabs: FC<InstancesTabsProps> = ({
         value={InstancesTab.RUNNING_INSTANCES}
         className="flex justify-center mx-auto w-full"
       >
-        <RunningInstanceTable
-          refreshTrigger={refreshTrigger}
-          setRefreshTrigger={setRefreshTrigger}
-        />
+        <RunningInstanceTable />
       </TabContent>
 
       {shouldShowOperatorTabs && (

--- a/apps/tangle-cloud/src/pages/services/[id]/page.tsx
+++ b/apps/tangle-cloud/src/pages/services/[id]/page.tsx
@@ -4,8 +4,7 @@
 
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router';
-import { useAccount, useChainId, usePublicClient } from 'wagmi';
-import { useQueries } from '@tanstack/react-query';
+import { useAccount } from 'wagmi';
 import {
   Button,
   Card,
@@ -36,10 +35,9 @@ import {
   useBlueprintJobs,
 } from '@tangle-network/tangle-shared-ui/data/services';
 import { addressesEqual } from '@tangle-network/tangle-shared-ui/utils/safeParseAddress';
-import useTxHistoryStore from '@tangle-network/tangle-shared-ui/context/useTxHistoryStore';
 import useEvmOperatorInfo from '../../../hooks/useEvmOperatorInfo';
 import { twMerge } from 'tailwind-merge';
-import { Address, Hash, getAddress, isAddress, zeroAddress } from 'viem';
+import { Address, getAddress, isAddress, zeroAddress } from 'viem';
 import { JobSubmissionForm } from './JobSubmissionForm';
 import { JobHistoryTable } from './JobHistoryTable';
 import ServiceOnChainDetails from './ServiceOnChainDetails';
@@ -97,18 +95,12 @@ const ServiceDetailPage: FC = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { address } = useAccount();
-  const chainId = useChainId();
-  const publicClient = usePublicClient({ chainId });
   const { isOperator, operatorAddress } = useEvmOperatorInfo();
-  const txHistory = useTxHistoryStore((store) => store.transactions);
 
   const [isFundModalOpen, setIsFundModalOpen] = useState(false);
   const [callerInput, setCallerInput] = useState('');
   const [callerInputError, setCallerInputError] = useState<string | null>(null);
   const [removingCaller, setRemovingCaller] = useState<Address | null>(null);
-  const [lastAclAction, setLastAclAction] = useState<'add' | 'remove' | null>(
-    null,
-  );
 
   const serviceId = useMemo(() => {
     if (!id) return undefined;
@@ -192,53 +184,7 @@ const ServiceDetailPage: FC = () => {
     setCallerInput('');
     setCallerInputError(null);
     setRemovingCaller(null);
-    setLastAclAction(null);
   }, [serviceId]);
-
-  const aclHistoryTxs = useMemo(
-    () =>
-      txHistory
-        .filter(
-          (tx) =>
-            (tx.name === 'add permitted caller' ||
-              tx.name === 'remove permitted caller') &&
-            tx.status === 'finalized',
-        )
-        .filter((tx) => {
-          const serviceIdDetail = tx.details?.get('Service ID');
-          if (serviceIdDetail === undefined || serviceIdDetail === null) {
-            return false;
-          }
-          return serviceIdDetail.toString() === serviceId?.toString();
-        })
-        .sort((a, b) => a.timestamp - b.timestamp)
-        .slice(-100),
-    [serviceId, txHistory],
-  );
-
-  const aclHistoryTxChecks = useQueries({
-    queries: aclHistoryTxs.map((tx) => ({
-      queryKey: ['acl-tx-valid', chainId, tx.hash],
-      queryFn: async () => {
-        if (!publicClient) {
-          return false;
-        }
-        try {
-          const receipt = await publicClient.getTransactionReceipt({
-            hash: tx.hash as Hash,
-          });
-          return receipt.status === 'success';
-        } catch {
-          // Most commonly means tx hash doesn't exist on the current chain
-          // (e.g., local chain reset), so treat as stale.
-          return false;
-        }
-      },
-      enabled: !!publicClient,
-      retry: false,
-      staleTime: 30_000,
-    })),
-  });
 
   const permittedCallers = useMemo(() => {
     const owner = onChainDetails?.owner
@@ -246,54 +192,16 @@ const ServiceDetailPage: FC = () => {
       : null;
     const callers = new Map<string, Address>();
 
-    const upsertCaller = (rawCaller: string | Address) => {
-      if (!isAddress(rawCaller, { strict: false })) {
-        return;
-      }
-      const normalized = getAddress(rawCaller);
-      callers.set(normalized.toLowerCase(), normalized);
-    };
-
-    // Base callers from indexer (if available in schema)
     for (const caller of service?.permittedCallers ?? []) {
-      upsertCaller(caller);
+      if (!isAddress(caller, { strict: false })) {
+        continue;
+      }
+      const normalized = getAddress(caller);
+      callers.set(normalized.toLowerCase(), normalized);
     }
 
-    // Owner is always a permitted caller by contract activation logic.
     if (owner) {
-      upsertCaller(owner);
-    }
-
-    // Apply finalized ACL txs that are valid on the current chain.
-    for (let i = 0; i < aclHistoryTxs.length; i += 1) {
-      if (aclHistoryTxChecks[i]?.data !== true) {
-        continue;
-      }
-
-      const tx = aclHistoryTxs[i];
-      const callerDetail = tx.details?.get('Caller');
-      if (callerDetail === undefined || callerDetail === null) {
-        continue;
-      }
-      const rawCaller = callerDetail.toString();
-      if (!isAddress(rawCaller, { strict: false })) {
-        continue;
-      }
-
-      const normalized = getAddress(rawCaller);
-      const key = normalized.toLowerCase();
-
-      // Keep owner entry stable in the UI.
-      if (owner && addressesEqual(owner, normalized)) {
-        callers.set(key, owner);
-        continue;
-      }
-
-      if (tx.name === 'add permitted caller') {
-        callers.set(key, normalized);
-      } else {
-        callers.delete(key);
-      }
+      callers.set(owner.toLowerCase(), owner);
     }
 
     const allCallers = [...callers.values()];
@@ -305,12 +213,7 @@ const ServiceDetailPage: FC = () => {
       (caller) => !addressesEqual(caller, owner),
     );
     return [owner, ...withoutOwner];
-  }, [
-    onChainDetails?.owner,
-    service?.permittedCallers,
-    aclHistoryTxs,
-    aclHistoryTxChecks,
-  ]);
+  }, [onChainDetails?.owner, service?.permittedCallers]);
 
   // User can submit jobs if they are the owner or a permitted caller
   const canSubmitJobs = useMemo(() => {
@@ -326,10 +229,7 @@ const ServiceDetailPage: FC = () => {
   }, [address, isOwner, isPermittedCaller, permittedCallers]);
 
   const isAclTxPending = isAddingPermittedCaller || isRemovingPermittedCaller;
-  const activeAclError =
-    lastAclAction === 'add'
-      ? addPermittedCallerError
-      : removePermittedCallerError;
+  const activeAclError = addPermittedCallerError ?? removePermittedCallerError;
 
   const callerValidation = useMemo(
     () =>
@@ -395,7 +295,6 @@ const ServiceDetailPage: FC = () => {
       return;
     }
 
-    setLastAclAction('add');
     resetAddPermittedCallerTx();
     resetRemovePermittedCallerTx();
 
@@ -437,21 +336,16 @@ const ServiceDetailPage: FC = () => {
         return;
       }
 
-      setLastAclAction('remove');
       setRemovingCaller(caller);
       resetAddPermittedCallerTx();
       resetRemovePermittedCallerTx();
       setCallerInputError(null);
 
       try {
-        const result = await removePermittedCaller({
+        await removePermittedCaller({
           serviceId,
           caller,
         });
-
-        if (result?.status === 'success') {
-          // Source of truth is refreshed from indexer/query cache in onSuccess.
-        }
       } finally {
         setRemovingCaller(null);
       }
@@ -611,120 +505,132 @@ const ServiceDetailPage: FC = () => {
           </Typography>
         </div>
 
-        <div className="rounded-lg border border-mono-60 dark:border-mono-140 p-3">
-          <Typography variant="body2" className="text-mono-100">
-            Connected account access:{' '}
-            <span
-              className={
-                canSubmitJobs
-                  ? 'text-green-400 font-semibold'
-                  : 'text-yellow-300 font-semibold'
-              }
-            >
-              {canSubmitJobs ? 'Allowed' : 'Not allowed'}
-            </span>
-          </Typography>
-        </div>
-
-        <div className="space-y-2">
-          <Typography variant="body2" className="text-mono-100">
-            Current permitted callers
-          </Typography>
-          {permittedCallers.length === 0 ? (
-            <Typography variant="body2" className="text-mono-120">
-              No permitted callers configured.
-            </Typography>
-          ) : (
-            <div className="space-y-2">
-              {permittedCallers.map((caller) => (
-                <div
-                  key={caller}
-                  className="flex items-center justify-between gap-3 rounded-lg border border-mono-60 dark:border-mono-140 px-3 py-2"
-                >
-                  <div className="flex items-center gap-2">
-                    <Typography variant="body2" className="font-mono">
-                      {shortenHex(caller, 6)}
-                    </Typography>
-                    {onChainDetails?.owner &&
-                      addressesEqual(caller, onChainDetails.owner) && (
-                        <span className="px-2 py-0.5 rounded bg-blue-20 dark:bg-blue-110 text-blue-70 dark:text-blue-30 text-xs font-semibold">
-                          Owner
-                        </span>
-                      )}
-                  </div>
-
-                  {isOwner &&
-                    !(
-                      onChainDetails?.owner &&
-                      addressesEqual(caller, onChainDetails.owner)
-                    ) && (
-                      <Button
-                        variant="utility"
-                        size="sm"
-                        className="uppercase body4 bg-red-10 dark:bg-red-120 text-red-70 dark:text-red-40 hover:bg-red-20 dark:hover:bg-red-110 border border-red-30 dark:border-red-100 transition-all duration-200"
-                        isLoading={
-                          isRemovingPermittedCaller &&
-                          removingCaller !== null &&
-                          addressesEqual(caller, removingCaller)
-                        }
-                        isDisabled={isAclTxPending}
-                        onClick={() => void handleRemovePermittedCaller(caller)}
-                      >
-                        Remove
-                      </Button>
-                    )}
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {isOwner ? (
-          <div className="space-y-2">
-            <Typography variant="body2" className="text-mono-100">
-              Add permitted caller
-            </Typography>
-            <div className="flex flex-col md:flex-row gap-2">
-              <Input
-                id="permitted-caller-input"
-                value={callerInput}
-                isControlled
-                onChange={handleCallerInputChange}
-                onBlur={handleCallerInputBlur}
-                placeholder="0x..."
-                autoComplete="off"
-                isInvalid={!!callerInputError}
-                errorMessage={callerInputError ?? undefined}
-                aria-invalid={callerInputError ? 'true' : undefined}
-                inputClassName="h-10"
-              />
-              <Button
-                onClick={() => void handleAddPermittedCaller()}
-                isLoading={isAddingPermittedCaller}
-                isDisabled={!canAddPermittedCaller}
-                className="md:min-w-40"
-              >
-                Add Caller
-              </Button>
-            </div>
+        {isLoadingOnChainDetails || isLoadingServices ? (
+          <div className="space-y-3">
+            <SkeletonLoader className="h-10" />
+            <SkeletonLoader className="h-14" />
+            <SkeletonLoader className="h-14" />
           </div>
         ) : (
-          <div className="space-y-2">
-            <Typography variant="body2" className="text-mono-100">
-              Add permitted caller
-            </Typography>
-            <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
-              <Typography variant="body2" className="text-yellow-400">
-                Only the service owner can add or remove permitted callers.
+          <>
+            <div className="rounded-lg border border-mono-60 dark:border-mono-140 p-3">
+              <Typography variant="body2" className="text-mono-100">
+                Connected account access:{' '}
+                <span
+                  className={
+                    canSubmitJobs
+                      ? 'text-green-400 font-semibold'
+                      : 'text-yellow-300 font-semibold'
+                  }
+                >
+                  {canSubmitJobs ? 'Allowed' : 'Not allowed'}
+                </span>
               </Typography>
             </div>
-          </div>
-        )}
 
-        {activeAclError && (
-          <Typography variant="body2" className="text-red-400">
-            ACL update failed: {activeAclError.message}
-          </Typography>
+            <div className="space-y-2">
+              <Typography variant="body2" className="text-mono-100">
+                Current permitted callers
+              </Typography>
+              {permittedCallers.length === 0 ? (
+                <Typography variant="body2" className="text-mono-120">
+                  No permitted callers configured.
+                </Typography>
+              ) : (
+                <div className="space-y-2">
+                  {permittedCallers.map((caller) => (
+                    <div
+                      key={caller}
+                      className="flex items-center justify-between gap-3 rounded-lg border border-mono-60 dark:border-mono-140 px-3 py-2"
+                    >
+                      <div className="flex items-center gap-2">
+                        <Typography variant="body2" className="font-mono">
+                          {shortenHex(caller, 6)}
+                        </Typography>
+                        {onChainDetails?.owner &&
+                          addressesEqual(caller, onChainDetails.owner) && (
+                            <span className="px-2 py-0.5 rounded bg-blue-20 dark:bg-blue-110 text-blue-70 dark:text-blue-30 text-xs font-semibold">
+                              Owner
+                            </span>
+                          )}
+                      </div>
+
+                      {isOwner &&
+                        !(
+                          onChainDetails?.owner &&
+                          addressesEqual(caller, onChainDetails.owner)
+                        ) && (
+                          <Button
+                            variant="utility"
+                            size="sm"
+                            className="uppercase body4 bg-red-10 dark:bg-red-120 text-red-70 dark:text-red-40 hover:bg-red-20 dark:hover:bg-red-110 border border-red-30 dark:border-red-100 transition-all duration-200"
+                            isLoading={
+                              isRemovingPermittedCaller &&
+                              removingCaller !== null &&
+                              addressesEqual(caller, removingCaller)
+                            }
+                            isDisabled={isAclTxPending}
+                            onClick={() =>
+                              void handleRemovePermittedCaller(caller)
+                            }
+                          >
+                            Remove
+                          </Button>
+                        )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {isOwner ? (
+              <div className="space-y-2">
+                <Typography variant="body2" className="text-mono-100">
+                  Add permitted caller
+                </Typography>
+                <div className="flex flex-col md:flex-row gap-2">
+                  <Input
+                    id="permitted-caller-input"
+                    value={callerInput}
+                    isControlled
+                    onChange={handleCallerInputChange}
+                    onBlur={handleCallerInputBlur}
+                    placeholder="0x..."
+                    autoComplete="off"
+                    isInvalid={!!callerInputError}
+                    errorMessage={callerInputError ?? undefined}
+                    aria-invalid={callerInputError ? 'true' : undefined}
+                    inputClassName="h-10"
+                  />
+                  <Button
+                    onClick={() => void handleAddPermittedCaller()}
+                    isLoading={isAddingPermittedCaller}
+                    isDisabled={!canAddPermittedCaller}
+                    className="md:min-w-40"
+                  >
+                    Add Caller
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <Typography variant="body2" className="text-mono-100">
+                  Add permitted caller
+                </Typography>
+                <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
+                  <Typography variant="body2" className="text-yellow-400">
+                    Only the service owner can add or remove permitted callers.
+                  </Typography>
+                </div>
+              </div>
+            )}
+
+            {activeAclError && (
+              <Typography variant="body2" className="text-red-400">
+                ACL update failed: {activeAclError.message}
+              </Typography>
+            )}
+          </>
         )}
       </Card>
 

--- a/apps/tangle-cloud/src/pages/services/[id]/page.tsx
+++ b/apps/tangle-cloud/src/pages/services/[id]/page.tsx
@@ -2,17 +2,20 @@
  * Service detail page - view service info and submit jobs.
  */
 
-import { FC, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router';
-import { useAccount } from 'wagmi';
+import { useAccount, useChainId, usePublicClient } from 'wagmi';
+import { useQueries } from '@tanstack/react-query';
 import {
   Button,
   Card,
   CardVariant,
+  Input,
   Typography,
   SkeletonLoader,
   EMPTY_VALUE_PLACEHOLDER,
 } from '@tangle-network/ui-components';
+import { shortenHex } from '@tangle-network/ui-components/utils/shortenHex';
 import {
   ArrowLeft,
   ExternalLinkLine,
@@ -27,12 +30,16 @@ import {
   useServiceDetails,
   useIsPermittedCaller,
   useIsServiceOperator,
+  useAddPermittedCallerTx,
+  useRemovePermittedCallerTx,
   MembershipModel,
   useBlueprintJobs,
 } from '@tangle-network/tangle-shared-ui/data/services';
 import { addressesEqual } from '@tangle-network/tangle-shared-ui/utils/safeParseAddress';
+import useTxHistoryStore from '@tangle-network/tangle-shared-ui/context/useTxHistoryStore';
 import useEvmOperatorInfo from '../../../hooks/useEvmOperatorInfo';
 import { twMerge } from 'tailwind-merge';
+import { Address, Hash, getAddress, isAddress, zeroAddress } from 'viem';
 import { JobSubmissionForm } from './JobSubmissionForm';
 import { JobHistoryTable } from './JobHistoryTable';
 import ServiceOnChainDetails from './ServiceOnChainDetails';
@@ -41,13 +48,67 @@ import OperatorMembershipPanel from './OperatorMembershipPanel';
 import OperatorExitPanel from './OperatorExitPanel';
 import { PagePath } from '../../../types';
 
+const validatePermittedCallerInput = ({
+  value,
+  owner,
+  permittedCallers,
+}: {
+  value: string;
+  owner?: Address;
+  permittedCallers: Address[];
+}): { normalized: Address | null; error: string | null } => {
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return { normalized: null, error: 'Caller address is required.' };
+  }
+
+  if (!isAddress(trimmed, { strict: false })) {
+    return { normalized: null, error: 'Please enter a valid EVM address.' };
+  }
+
+  const normalized = getAddress(trimmed);
+
+  if (addressesEqual(normalized, zeroAddress)) {
+    return {
+      normalized: null,
+      error: 'Zero address cannot be a permitted caller.',
+    };
+  }
+
+  if (owner && addressesEqual(owner, normalized)) {
+    return {
+      normalized: null,
+      error: 'Owner address already has access and cannot be added.',
+    };
+  }
+
+  if (permittedCallers.some((caller) => addressesEqual(caller, normalized))) {
+    return {
+      normalized: null,
+      error: 'Address is already a permitted caller.',
+    };
+  }
+
+  return { normalized, error: null };
+};
+
 const ServiceDetailPage: FC = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { address } = useAccount();
+  const chainId = useChainId();
+  const publicClient = usePublicClient({ chainId });
   const { isOperator, operatorAddress } = useEvmOperatorInfo();
+  const txHistory = useTxHistoryStore((store) => store.transactions);
 
   const [isFundModalOpen, setIsFundModalOpen] = useState(false);
+  const [callerInput, setCallerInput] = useState('');
+  const [callerInputError, setCallerInputError] = useState<string | null>(null);
+  const [removingCaller, setRemovingCaller] = useState<Address | null>(null);
+  const [lastAclAction, setLastAclAction] = useState<'add' | 'remove' | null>(
+    null,
+  );
 
   const serviceId = useMemo(() => {
     if (!id) return undefined;
@@ -59,8 +120,11 @@ const ServiceDetailPage: FC = () => {
   }, [id]);
 
   // Fetch service by ID (visible to all users)
-  const { data: service, isLoading: isLoadingServices } =
-    useServiceById(serviceId);
+  const {
+    data: service,
+    isLoading: isLoadingServices,
+    refetch: refetchService,
+  } = useServiceById(serviceId);
 
   // Fetch on-chain service details to get owner
   const { data: onChainDetails, isLoading: isLoadingOnChainDetails } =
@@ -81,8 +145,35 @@ const ServiceDetailPage: FC = () => {
   );
 
   // Check if user is permitted to submit jobs
-  const { data: isPermittedCaller, isLoading: isLoadingPermission } =
-    useIsPermittedCaller(serviceId, address);
+  const {
+    data: isPermittedCaller,
+    isLoading: isLoadingPermission,
+    refetch: refetchPermission,
+  } = useIsPermittedCaller(serviceId, address);
+
+  const {
+    execute: addPermittedCaller,
+    isPending: isAddingPermittedCaller,
+    error: addPermittedCallerError,
+    reset: resetAddPermittedCallerTx,
+  } = useAddPermittedCallerTx({
+    onSuccess: () => {
+      void refetchPermission();
+      void refetchService();
+    },
+  });
+
+  const {
+    execute: removePermittedCaller,
+    isPending: isRemovingPermittedCaller,
+    error: removePermittedCallerError,
+    reset: resetRemovePermittedCallerTx,
+  } = useRemovePermittedCallerTx({
+    onSuccess: () => {
+      void refetchPermission();
+      void refetchService();
+    },
+  });
 
   // Check if current user is a service operator
   const { data: isServiceOperator } = useIsServiceOperator(
@@ -97,8 +188,282 @@ const ServiceDetailPage: FC = () => {
     return addressesEqual(onChainDetails.owner, address);
   }, [address, onChainDetails?.owner]);
 
+  useEffect(() => {
+    setCallerInput('');
+    setCallerInputError(null);
+    setRemovingCaller(null);
+    setLastAclAction(null);
+  }, [serviceId]);
+
+  const aclHistoryTxs = useMemo(
+    () =>
+      txHistory
+        .filter(
+          (tx) =>
+            (tx.name === 'add permitted caller' ||
+              tx.name === 'remove permitted caller') &&
+            tx.status === 'finalized',
+        )
+        .filter((tx) => {
+          const serviceIdDetail = tx.details?.get('Service ID');
+          if (serviceIdDetail === undefined || serviceIdDetail === null) {
+            return false;
+          }
+          return serviceIdDetail.toString() === serviceId?.toString();
+        })
+        .sort((a, b) => a.timestamp - b.timestamp)
+        .slice(-100),
+    [serviceId, txHistory],
+  );
+
+  const aclHistoryTxChecks = useQueries({
+    queries: aclHistoryTxs.map((tx) => ({
+      queryKey: ['acl-tx-valid', chainId, tx.hash],
+      queryFn: async () => {
+        if (!publicClient) {
+          return false;
+        }
+        try {
+          const receipt = await publicClient.getTransactionReceipt({
+            hash: tx.hash as Hash,
+          });
+          return receipt.status === 'success';
+        } catch {
+          // Most commonly means tx hash doesn't exist on the current chain
+          // (e.g., local chain reset), so treat as stale.
+          return false;
+        }
+      },
+      enabled: !!publicClient,
+      retry: false,
+      staleTime: 30_000,
+    })),
+  });
+
+  const permittedCallers = useMemo(() => {
+    const owner = onChainDetails?.owner
+      ? getAddress(onChainDetails.owner)
+      : null;
+    const callers = new Map<string, Address>();
+
+    const upsertCaller = (rawCaller: string | Address) => {
+      if (!isAddress(rawCaller, { strict: false })) {
+        return;
+      }
+      const normalized = getAddress(rawCaller);
+      callers.set(normalized.toLowerCase(), normalized);
+    };
+
+    // Base callers from indexer (if available in schema)
+    for (const caller of service?.permittedCallers ?? []) {
+      upsertCaller(caller);
+    }
+
+    // Owner is always a permitted caller by contract activation logic.
+    if (owner) {
+      upsertCaller(owner);
+    }
+
+    // Apply finalized ACL txs that are valid on the current chain.
+    for (let i = 0; i < aclHistoryTxs.length; i += 1) {
+      if (aclHistoryTxChecks[i]?.data !== true) {
+        continue;
+      }
+
+      const tx = aclHistoryTxs[i];
+      const callerDetail = tx.details?.get('Caller');
+      if (callerDetail === undefined || callerDetail === null) {
+        continue;
+      }
+      const rawCaller = callerDetail.toString();
+      if (!isAddress(rawCaller, { strict: false })) {
+        continue;
+      }
+
+      const normalized = getAddress(rawCaller);
+      const key = normalized.toLowerCase();
+
+      // Keep owner entry stable in the UI.
+      if (owner && addressesEqual(owner, normalized)) {
+        callers.set(key, owner);
+        continue;
+      }
+
+      if (tx.name === 'add permitted caller') {
+        callers.set(key, normalized);
+      } else {
+        callers.delete(key);
+      }
+    }
+
+    const allCallers = [...callers.values()];
+    if (!owner) {
+      return allCallers;
+    }
+
+    const withoutOwner = allCallers.filter(
+      (caller) => !addressesEqual(caller, owner),
+    );
+    return [owner, ...withoutOwner];
+  }, [
+    onChainDetails?.owner,
+    service?.permittedCallers,
+    aclHistoryTxs,
+    aclHistoryTxChecks,
+  ]);
+
   // User can submit jobs if they are the owner or a permitted caller
-  const canSubmitJobs = isOwner || isPermittedCaller;
+  const canSubmitJobs = useMemo(() => {
+    if (isOwner || isPermittedCaller) {
+      return true;
+    }
+
+    if (!address) {
+      return false;
+    }
+
+    return permittedCallers.some((caller) => addressesEqual(caller, address));
+  }, [address, isOwner, isPermittedCaller, permittedCallers]);
+
+  const isAclTxPending = isAddingPermittedCaller || isRemovingPermittedCaller;
+  const activeAclError =
+    lastAclAction === 'add'
+      ? addPermittedCallerError
+      : removePermittedCallerError;
+
+  const callerValidation = useMemo(
+    () =>
+      validatePermittedCallerInput({
+        value: callerInput,
+        owner: onChainDetails?.owner,
+        permittedCallers,
+      }),
+    [callerInput, onChainDetails?.owner, permittedCallers],
+  );
+
+  const canAddPermittedCaller =
+    isOwner &&
+    !isAclTxPending &&
+    addPermittedCaller !== null &&
+    callerValidation.error === null &&
+    callerValidation.normalized !== null;
+
+  const handleCallerInputChange = useCallback(
+    (nextValue: string) => {
+      setCallerInput(nextValue);
+      const validation = validatePermittedCallerInput({
+        value: nextValue,
+        owner: onChainDetails?.owner,
+        permittedCallers,
+      });
+      setCallerInputError(
+        nextValue.trim().length === 0 ? null : validation.error,
+      );
+    },
+    [onChainDetails?.owner, permittedCallers],
+  );
+
+  const handleCallerInputBlur = useCallback(() => {
+    const trimmed = callerInput.trim();
+    if (trimmed.length === 0) {
+      setCallerInputError('Caller address is required.');
+      return;
+    }
+
+    const validation = validatePermittedCallerInput({
+      value: trimmed,
+      owner: onChainDetails?.owner,
+      permittedCallers,
+    });
+    setCallerInputError(validation.error);
+
+    if (isAddress(trimmed, { strict: false })) {
+      const normalized = getAddress(trimmed);
+      if (normalized !== callerInput) {
+        setCallerInput(normalized);
+      }
+    }
+  }, [callerInput, onChainDetails?.owner, permittedCallers]);
+
+  const handleAddPermittedCaller = useCallback(async () => {
+    if (serviceId === undefined || !isOwner) {
+      return;
+    }
+
+    if (!addPermittedCaller) {
+      setCallerInputError('Connect your wallet to update ACL settings.');
+      return;
+    }
+
+    setLastAclAction('add');
+    resetAddPermittedCallerTx();
+    resetRemovePermittedCallerTx();
+
+    if (
+      callerValidation.error !== null ||
+      callerValidation.normalized === null
+    ) {
+      setCallerInputError(callerValidation.error ?? 'Invalid caller address.');
+      return;
+    }
+
+    setCallerInputError(null);
+
+    const result = await addPermittedCaller({
+      serviceId,
+      caller: callerValidation.normalized,
+    });
+
+    if (result?.status === 'success') {
+      setCallerInput('');
+      setCallerInputError(null);
+    }
+  }, [
+    serviceId,
+    isOwner,
+    resetAddPermittedCallerTx,
+    resetRemovePermittedCallerTx,
+    callerValidation,
+    addPermittedCaller,
+  ]);
+
+  const handleRemovePermittedCaller = useCallback(
+    async (caller: Address) => {
+      if (serviceId === undefined || !isOwner) {
+        return;
+      }
+
+      if (!removePermittedCaller) {
+        return;
+      }
+
+      setLastAclAction('remove');
+      setRemovingCaller(caller);
+      resetAddPermittedCallerTx();
+      resetRemovePermittedCallerTx();
+      setCallerInputError(null);
+
+      try {
+        const result = await removePermittedCaller({
+          serviceId,
+          caller,
+        });
+
+        if (result?.status === 'success') {
+          // Source of truth is refreshed from indexer/query cache in onSuccess.
+        }
+      } finally {
+        setRemovingCaller(null);
+      }
+    },
+    [
+      serviceId,
+      isOwner,
+      resetAddPermittedCallerTx,
+      resetRemovePermittedCallerTx,
+      removePermittedCaller,
+    ],
+  );
 
   // Check if this is a dynamic membership service
   const isDynamicService =
@@ -234,6 +599,134 @@ const ServiceDetailPage: FC = () => {
         }
         onFundClick={() => setIsFundModalOpen(true)}
       />
+
+      {/* Permitted Callers Management */}
+      <Card variant={CardVariant.GLASS} className="p-6 space-y-4">
+        <div className="space-y-1">
+          <Typography variant="h5" fw="bold">
+            Service Settings: Permitted Callers
+          </Typography>
+          <Typography variant="body2" className="text-mono-100">
+            Manage which addresses can submit jobs to this service at runtime.
+          </Typography>
+        </div>
+
+        <div className="rounded-lg border border-mono-60 dark:border-mono-140 p-3">
+          <Typography variant="body2" className="text-mono-100">
+            Connected account access:{' '}
+            <span
+              className={
+                canSubmitJobs
+                  ? 'text-green-400 font-semibold'
+                  : 'text-yellow-300 font-semibold'
+              }
+            >
+              {canSubmitJobs ? 'Allowed' : 'Not allowed'}
+            </span>
+          </Typography>
+        </div>
+
+        <div className="space-y-2">
+          <Typography variant="body2" className="text-mono-100">
+            Current permitted callers
+          </Typography>
+          {permittedCallers.length === 0 ? (
+            <Typography variant="body2" className="text-mono-120">
+              No permitted callers configured.
+            </Typography>
+          ) : (
+            <div className="space-y-2">
+              {permittedCallers.map((caller) => (
+                <div
+                  key={caller}
+                  className="flex items-center justify-between gap-3 rounded-lg border border-mono-60 dark:border-mono-140 px-3 py-2"
+                >
+                  <div className="flex items-center gap-2">
+                    <Typography variant="body2" className="font-mono">
+                      {shortenHex(caller, 6)}
+                    </Typography>
+                    {onChainDetails?.owner &&
+                      addressesEqual(caller, onChainDetails.owner) && (
+                        <span className="px-2 py-0.5 rounded bg-blue-20 dark:bg-blue-110 text-blue-70 dark:text-blue-30 text-xs font-semibold">
+                          Owner
+                        </span>
+                      )}
+                  </div>
+
+                  {isOwner &&
+                    !(
+                      onChainDetails?.owner &&
+                      addressesEqual(caller, onChainDetails.owner)
+                    ) && (
+                      <Button
+                        variant="utility"
+                        size="sm"
+                        className="uppercase body4 bg-red-10 dark:bg-red-120 text-red-70 dark:text-red-40 hover:bg-red-20 dark:hover:bg-red-110 border border-red-30 dark:border-red-100 transition-all duration-200"
+                        isLoading={
+                          isRemovingPermittedCaller &&
+                          removingCaller !== null &&
+                          addressesEqual(caller, removingCaller)
+                        }
+                        isDisabled={isAclTxPending}
+                        onClick={() => void handleRemovePermittedCaller(caller)}
+                      >
+                        Remove
+                      </Button>
+                    )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {isOwner ? (
+          <div className="space-y-2">
+            <Typography variant="body2" className="text-mono-100">
+              Add permitted caller
+            </Typography>
+            <div className="flex flex-col md:flex-row gap-2">
+              <Input
+                id="permitted-caller-input"
+                value={callerInput}
+                isControlled
+                onChange={handleCallerInputChange}
+                onBlur={handleCallerInputBlur}
+                placeholder="0x..."
+                autoComplete="off"
+                isInvalid={!!callerInputError}
+                errorMessage={callerInputError ?? undefined}
+                aria-invalid={callerInputError ? 'true' : undefined}
+                inputClassName="h-10"
+              />
+              <Button
+                onClick={() => void handleAddPermittedCaller()}
+                isLoading={isAddingPermittedCaller}
+                isDisabled={!canAddPermittedCaller}
+                className="md:min-w-40"
+              >
+                Add Caller
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <Typography variant="body2" className="text-mono-100">
+              Add permitted caller
+            </Typography>
+            <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
+              <Typography variant="body2" className="text-yellow-400">
+                Only the service owner can add or remove permitted callers.
+              </Typography>
+            </div>
+          </div>
+        )}
+
+        {activeAclError && (
+          <Typography variant="body2" className="text-red-400">
+            ACL update failed: {activeAclError.message}
+          </Typography>
+        )}
+      </Card>
 
       {/* Operator Membership Panel - Show for Dynamic services */}
       {isDynamicService && service.status === 'ACTIVE' && (

--- a/libs/tangle-shared-ui/src/data/graphql/useServices.ts
+++ b/libs/tangle-shared-ui/src/data/graphql/useServices.ts
@@ -32,6 +32,7 @@ export interface Service {
   owner: Address;
   status: ServiceStatus;
   operators: Address[];
+  permittedCallers: Address[];
   createdAt: bigint;
   terminatedAt: bigint | null;
 }
@@ -63,6 +64,7 @@ interface ServiceQueryResponse {
     terminatedAt: string | null;
     request: {
       operatorCandidates: string[];
+      permittedCallers?: string[];
     } | null;
   }>;
 }
@@ -128,7 +130,7 @@ const fetchServices = async (
 
   const whereClause = where.length > 0 ? `where: { ${where.join(', ')} }` : '';
 
-  const query = `
+  const buildQuery = (includePermittedCallers: boolean) => `
     query GetServices($limit: Int!, $offset: Int!) {
       Service(
         limit: $limit
@@ -145,29 +147,54 @@ const fetchServices = async (
         terminatedAt
         request {
           operatorCandidates
+          ${includePermittedCallers ? 'permittedCallers' : ''}
         }
       }
     }
   `;
 
-  const result = await executeEnvioGraphQL<
+  const variables = {
+    limit: options.limit ?? 100,
+    offset: options.offset ?? 0,
+  };
+
+  let result = await executeEnvioGraphQL<
     ServiceQueryResponse,
     {
       limit: number;
       offset: number;
     }
-  >(
-    query,
-    { limit: options.limit ?? 100, offset: options.offset ?? 0 },
-    network,
-  );
+  >(buildQuery(true), variables, network);
 
   if (result.errors?.length) {
-    throw new Error(
-      `Failed to fetch services: ${result.errors
-        .map((error) => error.message)
-        .join('; ')}`,
+    const hasPermittedCallerSchemaError = result.errors.some((error) =>
+      error.message.toLowerCase().includes('permittedcallers'),
     );
+
+    if (!hasPermittedCallerSchemaError) {
+      throw new Error(
+        `Failed to fetch services: ${result.errors
+          .map((error) => error.message)
+          .join('; ')}`,
+      );
+    }
+
+    // Backward compatibility for indexers that don't expose `request.permittedCallers`.
+    result = await executeEnvioGraphQL<
+      ServiceQueryResponse,
+      {
+        limit: number;
+        offset: number;
+      }
+    >(buildQuery(false), variables, network);
+
+    if (result.errors?.length) {
+      throw new Error(
+        `Failed to fetch services: ${result.errors
+          .map((error) => error.message)
+          .join('; ')}`,
+      );
+    }
   }
 
   return (result.data.Service ?? []).map((s) => ({
@@ -177,6 +204,7 @@ const fetchServices = async (
     owner: s.owner as Address,
     status: s.status as ServiceStatus,
     operators: (s.request?.operatorCandidates ?? []) as Address[],
+    permittedCallers: (s.request?.permittedCallers ?? []) as Address[],
     createdAt: BigInt(s.createdAt),
     terminatedAt: s.terminatedAt ? BigInt(s.terminatedAt) : null,
   }));


### PR DESCRIPTION
## Summary
- Add permitted callers management UI to the service detail page, allowing service owners to add/remove addresses that can submit jobs at runtime
- Fetch `permittedCallers` from the GraphQL indexer with backward-compatible fallback for older indexer schemas
- Rename "View" button to "Blueprint" in running instance table for clarity

## Video
https://github.com/user-attachments/assets/38264975-c6e5-418a-a800-053e1b060987

## Test plan
- [ ] Verify service detail page loads permitted callers list correctly
- [ ] Verify owner can add a new permitted caller address
- [ ] Verify owner can remove a permitted caller
- [ ] Verify non-owners see a read-only view with an info message
- [ ] Verify input validation (zero address, duplicate, owner address, invalid format)
- [ ] Verify backward compatibility when indexer doesn't expose `permittedCallers` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)