### PR TITLE
fix(wallet-flows): fail fast on launch preflight and align runtime options

### DIFF
--- a/docs/wallet-flow-suite.md
+++ b/docs/wallet-flow-suite.md
@@ -28,12 +28,17 @@ Optional wallet env vars:
   - `yarn test:wallet-flows:list`
 - Run all launch flows:
   - `yarn test:wallet-flows`
+- Run all launch flows in Docker + Xvfb (recommended on Linux hosts without a desktop session):
+  - `yarn test:wallet-flows:docker`
 - Run one flow:
   - `yarn test:wallet-flows --flow FLOW-001`
 - Run by persona:
   - `yarn test:wallet-flows --persona user`
 - Run service/blueprint-id-dependent flows with explicit ids:
   - `yarn test:wallet-flows --blueprint-id 1 --service-id 1`
+- Override LLM runtime directly from CLI:
+  - `yarn test:wallet-flows --provider openai --model gpt-4o --api-key $OPENAI_API_KEY`
+  - `yarn test:wallet-flows --base-url http://localhost:4000/v1 --api-key local-dev-key`
 
 ## Covered Launch Flows
 | Flow ID | Persona | Flow | Start Surface |

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "script:setupServices": "bun scripts/setupServices.ts",
     "script:setupStaking": "bun scripts/setupStaking.ts",
     "test:wallet-flows": "node ./scripts/agent-browser/run-wallet-flow-suite.mjs",
-    "test:wallet-flows:list": "node ./scripts/agent-browser/run-wallet-flow-suite.mjs --list"
+    "test:wallet-flows:list": "node ./scripts/agent-browser/run-wallet-flow-suite.mjs --list",
+    "test:wallet-flows:docker": "bash ./scripts/agent-browser/run-wallet-flow-suite-docker.sh"
   },
   "resolutions": {
     "@polkadot/api": "^13.2.1",

--- a/scripts/agent-browser/run-wallet-flow-suite-docker.sh
+++ b/scripts/agent-browser/run-wallet-flow-suite-docker.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DAPP_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CODE_DIR="$(cd "${DAPP_DIR}/.." && pwd)"
+
+IMAGE="${PLAYWRIGHT_IMAGE:-mcr.microsoft.com/playwright:v1.51.1-noble}"
+WORKSPACE_MOUNT="${CODE_DIR}:/work"
+WORKDIR="/work/dapp"
+
+echo "[wallet-flows:docker] image=${IMAGE}"
+echo "[wallet-flows:docker] workdir=${WORKDIR}"
+
+ENV_ARGS=()
+for name in OPENAI_API_KEY ANTHROPIC_API_KEY GOOGLE_GENERATIVE_AI_API_KEY LLM_BASE_URL AGENT_BROWSER_DRIVER_MODULE AGENT_BROWSER_PROVIDER AGENT_BROWSER_MODEL AGENT_BROWSER_TIMEOUT_MS AGENT_BROWSER_MAX_TURNS AGENT_BROWSER_OUTPUT_DIR AGENT_WALLET_EXTENSION_PATHS AGENT_WALLET_USER_DATA_DIR; do
+  if [[ -n "${!name:-}" ]]; then
+    ENV_ARGS+=("-e" "${name}")
+  fi
+done
+
+if [[ -z "${AGENT_BROWSER_DRIVER_MODULE:-}" ]]; then
+  ENV_ARGS+=("-e" "AGENT_BROWSER_DRIVER_MODULE=file:///work/agent-browser-driver/dist/index.js")
+fi
+
+exec docker run --rm --network host \
+  -v "${WORKSPACE_MOUNT}" \
+  -w "${WORKDIR}" \
+  "${ENV_ARGS[@]}" \
+  "${IMAGE}" \
+  bash -lc '
+set -euo pipefail
+Xvfb :99 -screen 0 1280x1024x24 -nolisten tcp >/tmp/xvfb.log 2>&1 &
+XVFB_PID=$!
+cleanup() {
+  kill "${XVFB_PID}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+export DISPLAY=:99
+for _ in $(seq 1 50); do
+  if xdpyinfo -display "${DISPLAY}" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+node scripts/agent-browser/run-wallet-flow-suite.mjs "$@"
+' _ "$@"

--- a/scripts/agent-browser/run-wallet-flow-suite.mjs
+++ b/scripts/agent-browser/run-wallet-flow-suite.mjs
@@ -194,6 +194,10 @@ const options = parseArgs({
   options: {
     cases: { type: 'string' },
     config: { type: 'string' },
+    provider: { type: 'string' },
+    model: { type: 'string' },
+    'api-key': { type: 'string' },
+    'base-url': { type: 'string' },
     'dapp-base-url': { type: 'string' },
     'cloud-base-url': { type: 'string' },
     'blueprint-id': { type: 'string' },
@@ -222,6 +226,10 @@ Usage:
 Options:
   --cases <path>                  Cases module/JSON file (default: ${DEFAULT_CASES_PATH})
   --config <path>                 agent-browser-driver config file (default: ${DEFAULT_CONFIG_PATH})
+  --provider <name>               LLM provider override (openai/anthropic/google)
+  --model <name>                  LLM model override
+  --api-key <value>               LLM API key override
+  --base-url <url>                LLM base URL override (LiteLLM/local proxy/etc.)
   --dapp-base-url <url>           dApp base URL (default: http://localhost:4200)
   --cloud-base-url <url>          cloud base URL (default: http://localhost:4300)
   --blueprint-id <id>             Blueprint ID for flows requiring /blueprints/:id paths
@@ -260,6 +268,18 @@ const main = async () => {
   if (options['output-dir']) {
     runtimeOverrides.outputDir = options['output-dir'];
   }
+  if (options.provider) {
+    runtimeOverrides.provider = options.provider;
+  }
+  if (options.model) {
+    runtimeOverrides.model = options.model;
+  }
+  if (options['api-key']) {
+    runtimeOverrides.apiKey = options['api-key'];
+  }
+  if (options['base-url']) {
+    runtimeOverrides.baseUrl = options['base-url'];
+  }
   const walletExtensions = options['wallet-extension'] ?? [];
   const walletUserDataDir = options['wallet-user-data-dir'];
   if (walletExtensions.length > 0 || walletUserDataDir) {
@@ -297,6 +317,23 @@ const main = async () => {
   if (options.list) {
     return;
   }
+
+  const applyCaseRuntimeOverrides = (testCase) => {
+    const next = { ...testCase };
+    if (maxTurnsOverride !== undefined) {
+      next.maxTurns = maxTurnsOverride;
+    } else if (next.maxTurns === undefined && mergedConfig.maxTurns !== undefined) {
+      next.maxTurns = mergedConfig.maxTurns;
+    }
+
+    if (timeoutOverride !== undefined) {
+      next.timeoutMs = timeoutOverride;
+    } else if (next.timeoutMs === undefined && mergedConfig.timeoutMs !== undefined) {
+      next.timeoutMs = mergedConfig.timeoutMs;
+    }
+
+    return next;
+  };
 
   const driverModule = await loadAgentDriverModule();
   const playwrightModule = await loadPlaywright();
@@ -398,16 +435,21 @@ const main = async () => {
       process.env.ANTHROPIC_API_KEY ??
       process.env.GOOGLE_GENERATIVE_AI_API_KEY;
 
-    if (!apiKey) {
+    if (!apiKey && !mergedConfig.baseUrl) {
       throw new Error(
         'Missing LLM API key. Set OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY, or configure apiKey in agent-browser-driver config.',
+      );
+    }
+    if (!apiKey && mergedConfig.baseUrl) {
+      log(
+        'warning: no API key provided; continuing because base-url is configured (use --api-key if your proxy requires auth).',
       );
     }
 
     const testRunner = new TestRunner({
       config: {
         ...toAgentConfig(mergedConfig),
-        apiKey,
+        apiKey: apiKey ?? 'local-dev-key',
         debug: Boolean(options.debug),
       },
       defaultTimeoutMs: mergedConfig.timeoutMs,
@@ -423,7 +465,9 @@ const main = async () => {
         ),
     });
 
-    const suite = await testRunner.runSuite(selectedCases);
+    const suite = await testRunner.runSuite(
+      selectedCases.map((testCase) => applyCaseRuntimeOverrides(testCase)),
+    );
 
     log(
       `Suite complete: passed=${suite.summary.passed} failed=${suite.summary.failed} skipped=${suite.summary.skipped}`,

--- a/scripts/agent-browser/run-wallet-flow-suite.mjs
+++ b/scripts/agent-browser/run-wallet-flow-suite.mjs
@@ -328,6 +328,14 @@ const main = async () => {
   log(
     `Launch mode: wallet=${launchPlan.walletMode} headless=${launchPlan.headless} concurrency=${launchPlan.concurrency}`,
   );
+  for (const warning of launchPlan.warnings ?? []) {
+    log(`warning: ${warning}`);
+  }
+  if ((launchPlan.errors ?? []).length > 0) {
+    throw new Error(
+      `Browser launch preflight failed:\n- ${launchPlan.errors.join('\n- ')}`,
+    );
+  }
 
   let browser;
   let persistentContext;
@@ -364,11 +372,10 @@ const main = async () => {
       const userDataDir =
         launchPlan.userDataDir ?? path.resolve('.agent-wallet-profile');
       fs.mkdirSync(userDataDir, { recursive: true });
-      const walletHeadless = Boolean(mergedConfig.headless);
 
       persistentContext = await chromium.launchPersistentContext(userDataDir, {
         channel: 'chromium',
-        headless: walletHeadless,
+        headless: launchPlan.headless,
         args: launchPlan.browserArgs,
         viewport: launchPlan.viewport,
         ignoreHTTPSErrors: true,
@@ -403,6 +410,7 @@ const main = async () => {
         apiKey,
         debug: Boolean(options.debug),
       },
+      defaultTimeoutMs: mergedConfig.timeoutMs,
       driver: singletonDriver,
       driverFactory: launchPlan.concurrency > 1 ? createDriver : undefined,
       concurrency: launchPlan.concurrency,

--- a/scripts/agent-browser/run-wallet-flow-suite.mjs
+++ b/scripts/agent-browser/run-wallet-flow-suite.mjs
@@ -459,21 +459,27 @@ const main = async () => {
       screenshotInterval: mergedConfig.screenshotInterval,
       artifactSink: new FilesystemSink(outputDir),
       onTestStart: (testCase) => log(`start ${testCase.id} ${testCase.name}`),
-      onTestComplete: (result) =>
+      onTestComplete: (result) => {
+        const strictPass = Boolean(result.agentSuccess && result.verified);
         log(
-          `${result.verified ? 'pass' : 'fail'} ${result.testCase.id} verdict=${result.verdict} durationMs=${result.durationMs}`,
-        ),
+          `${strictPass ? 'pass' : 'fail'} ${result.testCase.id} verdict=${result.verdict} durationMs=${result.durationMs}`,
+        );
+      },
     });
 
     const suite = await testRunner.runSuite(
       selectedCases.map((testCase) => applyCaseRuntimeOverrides(testCase)),
     );
 
+    const strictPassed = suite.results.filter(
+      (result) => result.agentSuccess && result.verified,
+    ).length;
+    const strictFailed = suite.results.length - strictPassed;
     log(
-      `Suite complete: passed=${suite.summary.passed} failed=${suite.summary.failed} skipped=${suite.summary.skipped}`,
+      `Suite complete: passed=${strictPassed} failed=${strictFailed} skipped=${suite.summary.skipped}`,
     );
 
-    if (suite.summary.failed > 0 || suite.summary.skipped > 0) {
+    if (strictFailed > 0 || suite.summary.skipped > 0) {
       process.exitCode = 1;
     }
 


### PR DESCRIPTION
## Summary
- make wallet-flow harness honor `buildBrowserLaunchPlan` preflight warnings/errors before Playwright launch
- use `launchPlan.headless` in wallet mode instead of raw config to avoid inconsistent behavior
- pass `defaultTimeoutMs` into `TestRunner` for consistent case timeout fallback
- add wallet-flow Docker runner with built-in Xvfb (`yarn test:wallet-flows:docker`) for Linux hosts without a desktop display
- add direct runtime overrides: `--provider`, `--model`, `--api-key`, `--base-url`
- allow base-url proxy mode without a hard API-key requirement (uses warning + fallback key)
- apply `--max-turns` / `--timeout-ms` reliably to selected cases at runtime
- enforce strict pass criteria in harness logs/exit gating: pass requires `agentSuccess && verified`

## Why
The harness previously bypassed launch-plan preflight and attempted browser launch directly, producing opaque Playwright crashes on Linux hosts without a display server. It also lacked a simple local execution path for wallet/headed runs and strict result accounting for launch gating.

## Validation
- `yarn test:wallet-flows:list` (18 launch-gate flows selected)
- `yarn test:wallet-flows --flow FLOW-006 --output-dir ./agent-results/post-merge-smoke --max-turns 10 --timeout-ms 180000`
  - fails fast with explicit preflight error when display is missing
- `yarn test:wallet-flows:docker --flow FLOW-006 --max-turns 6 --timeout-ms 120000 --debug --output-dir ./agent-results/post-merge-docker-wrapper`
  - passes end-to-end in Docker+Xvfb (wallet mode)
- `yarn test:wallet-flows:docker --flow FLOW-015 --max-turns 3 --timeout-ms 120000 --output-dir ./agent-results/post-merge-strict-flow015`
  - strict accounting verified (`Suite complete: passed=0 failed=1 skipped=0`)
- Full strict bounded snapshot:
  - `yarn test:wallet-flows:docker --max-turns 2 --timeout-ms 60000 --output-dir ./agent-results/post-merge-docker-full18-strict`
  - strict result: `passed=2 failed=16 skipped=0`
  - report: `agent-results/post-merge-docker-full18-strict/suite/report.json`
- push hook quality gates passed on branch push (repo lint/test/build)

## Remaining runtime prerequisites for full launch-quality pass rates
- wallet profile/extension prepared for automated connect/sign steps
- funded accounts / chain state for tx-submitting flows
- app/data readiness for operator/developer flows currently timing out under bounded runs