### PR TITLE
fix(tangle-cloud): resolve round-2 payment review findings

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -50,6 +50,10 @@ https://stats.tangle.tools
 # Something happened with conventional commits link, temporary disabled to fix the CI
 https://www.conventionalcommits.org/en/v1.0.0/
 
+# External sites that block bots or have intermittent Cloudflare errors
+https://www.tangle.tools/
+https://openai.com/index/harness-engineering/
+
 # Files
 /**/CHANGELOG.md
 

--- a/apps/tangle-cloud/src/app/CreditsProvider.tsx
+++ b/apps/tangle-cloud/src/app/CreditsProvider.tsx
@@ -7,6 +7,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { useAccount } from 'wagmi';
@@ -25,6 +26,8 @@ interface CreditsContextValue {
   generateAndStoreCreditKeys: (label?: string) => Promise<StoredCreditKeys>;
   removeCreditAccount: (commitment: string) => Promise<void>;
   isLoading: boolean;
+  /** True when keypair is unlocked and credit keys are decryptable */
+  isUnlocked: boolean;
 }
 
 const CreditsContext = createContext<CreditsContextValue | null>(null);
@@ -35,34 +38,39 @@ export const CreditsProvider: FC<PropsWithChildren> = ({ children }) => {
   const [creditAccounts, setCreditAccounts] = useState<StoredCreditKeys[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
+  // Generation counter to detect stale async loads
+  const genRef = useRef(0);
+
   const encryptionKey = keypair
     ? keccak256(
         encodePacked(['string'], [keypair.privateKey + ':credit-encryption']),
       )
     : undefined;
 
-  // Reload when address or encryption key changes
   useEffect(() => {
     setCreditAccounts([]);
     setIsLoading(true);
+    const gen = ++genRef.current;
 
     if (!address) {
       setIsLoading(false);
       return;
     }
 
-    const currentAddress = address;
     const load = async () => {
       try {
-        const keys = await loadCreditKeysForAddress(
-          currentAddress,
-          encryptionKey,
-        );
-        setCreditAccounts(keys);
+        const keys = await loadCreditKeysForAddress(address, encryptionKey);
+        if (genRef.current === gen) {
+          setCreditAccounts(keys);
+        }
       } catch {
-        setCreditAccounts([]);
+        if (genRef.current === gen) {
+          setCreditAccounts([]);
+        }
       }
-      setIsLoading(false);
+      if (genRef.current === gen) {
+        setIsLoading(false);
+      }
     };
     load();
   }, [address, encryptionKey]);
@@ -70,6 +78,11 @@ export const CreditsProvider: FC<PropsWithChildren> = ({ children }) => {
   const generateAndStoreCreditKeys = useCallback(
     async (label?: string): Promise<StoredCreditKeys> => {
       if (!address) throw new Error('Wallet not connected');
+      if (!encryptionKey) {
+        throw new Error(
+          'Unlock your shielded keypair before generating credit keys',
+        );
+      }
 
       const privateKey = generatePrivateKey();
       const account = privateKeyToAccount(privateKey);
@@ -89,6 +102,7 @@ export const CreditsProvider: FC<PropsWithChildren> = ({ children }) => {
         salt,
         label,
         createdAt: Date.now(),
+        isLocked: false,
       };
 
       await saveCreditKeys(keys, address, encryptionKey);
@@ -98,12 +112,16 @@ export const CreditsProvider: FC<PropsWithChildren> = ({ children }) => {
     [address, encryptionKey],
   );
 
-  const removeCreditAccount = useCallback(async (commitment: string) => {
-    await deleteCreditKeys(commitment);
-    setCreditAccounts((prev) =>
-      prev.filter((k) => k.commitment !== commitment),
-    );
-  }, []);
+  const removeCreditAccount = useCallback(
+    async (commitment: string) => {
+      if (!address) return;
+      await deleteCreditKeys(commitment, address);
+      setCreditAccounts((prev) =>
+        prev.filter((k) => k.commitment !== commitment),
+      );
+    },
+    [address],
+  );
 
   const value = useMemo<CreditsContextValue>(
     () => ({
@@ -111,12 +129,14 @@ export const CreditsProvider: FC<PropsWithChildren> = ({ children }) => {
       generateAndStoreCreditKeys,
       removeCreditAccount,
       isLoading,
+      isUnlocked: !!encryptionKey,
     }),
     [
       creditAccounts,
       generateAndStoreCreditKeys,
       removeCreditAccount,
       isLoading,
+      encryptionKey,
     ],
   );
 

--- a/apps/tangle-cloud/src/app/ShieldedProvider.tsx
+++ b/apps/tangle-cloud/src/app/ShieldedProvider.tsx
@@ -98,10 +98,12 @@ export const ShieldedProvider: FC<PropsWithChildren> = ({ children }) => {
     (mutateFn: (current: NoteData[]) => NoteData[]) => {
       writeQueueRef.current = writeQueueRef.current.then(async () => {
         const updated = mutateFn(notesRef.current);
+        // Update ref synchronously so the next queued write sees this result
+        notesRef.current = updated;
+        setNotes(updated);
         if (storageRef.current) {
           await storageRef.current.save(updated.map(serializeNote));
         }
-        setNotes(updated);
       });
       return writeQueueRef.current;
     },

--- a/apps/tangle-cloud/src/components/PageLayout.tsx
+++ b/apps/tangle-cloud/src/components/PageLayout.tsx
@@ -10,7 +10,7 @@ const PageLayout: FC<Props> = ({ children, className }) => {
   return (
     <div
       className={twMerge(
-        'max-w-screen-xl px-4 mx-auto space-y-5 md:px-8 lg:px-10',
+        'max-w-screen-xl px-4 mx-auto space-y-5 md:px-5',
         className,
       )}
     >

--- a/apps/tangle-cloud/src/components/payments/AmountInput.tsx
+++ b/apps/tangle-cloud/src/components/payments/AmountInput.tsx
@@ -24,7 +24,7 @@ const AmountInput: FC<Props> = ({
     balance !== undefined ? formatUnits(balance, decimals) : undefined;
 
   const handleMax = useCallback(() => {
-    if (formattedBalance) {
+    if (formattedBalance !== undefined) {
       onChange(formattedBalance);
     }
   }, [formattedBalance, onChange]);

--- a/apps/tangle-cloud/src/containers/payments/FundCreditsContainer.tsx
+++ b/apps/tangle-cloud/src/containers/payments/FundCreditsContainer.tsx
@@ -6,85 +6,60 @@ import {
   Button,
   Input,
 } from '@tangle-network/ui-components';
-import AmountInput from '../../components/payments/AmountInput';
-import ProofProgressIndicator from '../../components/payments/ProofProgressIndicator';
 import { useShieldedContext } from '../../app/ShieldedProvider';
 import { useCreditsContext } from '../../app/CreditsProvider';
-import { ProofStage, type ProofProgress } from '../../types/shielded';
 
 const FundCreditsContainer: FC = () => {
   const { address } = useAccount();
-  const { shieldedBalance, keypair, deriveKeypair } = useShieldedContext();
-  const { generateAndStoreCreditKeys, creditAccounts } = useCreditsContext();
+  const { hasDerivedKeypair } = useShieldedContext();
+  const { generateAndStoreCreditKeys, creditAccounts, isUnlocked } =
+    useCreditsContext();
 
-  const [amount, setAmount] = useState('');
   const [label, setLabel] = useState('');
-  const [progress, setProgress] = useState<ProofProgress>({
-    stage: ProofStage.IDLE,
-  });
+  const [isGenerating, setIsGenerating] = useState(false);
   const [fundedCommitment, setFundedCommitment] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-  const handleFund = useCallback(async () => {
-    if (!address || !amount) return;
+  const handleGenerate = useCallback(async () => {
+    if (!address) return;
 
-    let kp = keypair;
-    if (!kp) {
-      kp = await deriveKeypair();
-      if (!kp) return;
-    }
+    setIsGenerating(true);
+    setError(null);
+    setFundedCommitment(null);
 
     try {
-      setProgress({
-        stage: ProofStage.FETCHING_ARTIFACTS,
-        message: 'Generating ephemeral credit account keys...',
-      });
-
       const creditKeys = await generateAndStoreCreditKeys(
         label || `Account ${creditAccounts.length + 1}`,
       );
-
       setFundedCommitment(creditKeys.commitment);
-      setProgress({
-        stage: ProofStage.DONE,
-        message:
-          'Credit keys generated and stored locally. ' +
-          'On-chain funding requires @tangle-network/shielded-sdk integration.',
-      });
-      setAmount('');
       setLabel('');
     } catch (err) {
-      setProgress({
-        stage: ProofStage.ERROR,
-        message: err instanceof Error ? err.message : 'Fund credits failed',
-      });
+      setError(err instanceof Error ? err.message : 'Failed to generate keys');
+    } finally {
+      setIsGenerating(false);
     }
-  }, [
-    address,
-    amount,
-    label,
-    keypair,
-    deriveKeypair,
-    generateAndStoreCreditKeys,
-    creditAccounts.length,
-  ]);
-
-  const isProcessing =
-    progress.stage !== ProofStage.IDLE &&
-    progress.stage !== ProofStage.DONE &&
-    progress.stage !== ProofStage.ERROR;
+  }, [address, label, generateAndStoreCreditKeys, creditAccounts.length]);
 
   return (
     <div className="space-y-4">
       <div>
         <Typography variant="h5" fw="semibold">
-          Fund Credit Account
+          Create Credit Account
         </Typography>
 
         <Typography variant="body2" className="mt-1 text-mono-100">
-          Create an anonymous prepaid credit account funded from your shielded
-          pool balance. One ZK proof enables many cheap pay-per-job signatures.
+          Generate an ephemeral keypair for anonymous credit payments. The keys
+          are encrypted and stored in your browser. On-chain funding requires
+          SDK integration.
         </Typography>
       </div>
+
+      {!hasDerivedKeypair && (
+        <Alert
+          type="warning"
+          description="Unlock your shielded keypair before creating credit accounts. Credit keys are encrypted using your shielded key."
+        />
+      )}
 
       <div className="space-y-1">
         <Typography variant="body2" fw="semibold" className="text-mono-120">
@@ -96,23 +71,14 @@ const FundCreditsContainer: FC = () => {
           value={label}
           onChange={setLabel}
           isControlled
-          isDisabled={isProcessing}
+          isDisabled={isGenerating || !isUnlocked}
         />
       </div>
 
-      <AmountInput
-        value={amount}
-        onChange={setAmount}
-        balance={shieldedBalance}
-        symbol="SHIELDED"
-        label="Fund Amount"
-        disabled={isProcessing}
-      />
-
-      <ProofProgressIndicator progress={progress} />
+      {error && <Alert type="error" description={error} />}
 
       {fundedCommitment && (
-        <Alert type="success" title="Credit keys stored locally">
+        <Alert type="success" title="Credit keys generated and stored">
           <Typography variant="mono2" className="mt-1 break-all">
             {fundedCommitment}
           </Typography>
@@ -121,12 +87,13 @@ const FundCreditsContainer: FC = () => {
 
       <Button
         isFullWidth
-        onClick={handleFund}
-        isDisabled={
-          !address || !amount || isProcessing || shieldedBalance === 0n
+        onClick={handleGenerate}
+        isDisabled={!address || !isUnlocked || isGenerating}
+        isLoading={isGenerating}
+        loadingText="Generating..."
+        disabledTooltip={
+          !isUnlocked ? 'Unlock your shielded keypair first' : undefined
         }
-        isLoading={isProcessing}
-        loadingText="Processing..."
       >
         Generate Credit Keys
       </Button>

--- a/apps/tangle-cloud/src/containers/payments/SpendAuthContainer.tsx
+++ b/apps/tangle-cloud/src/containers/payments/SpendAuthContainer.tsx
@@ -74,6 +74,13 @@ const SpendAuthContainer: FC = () => {
       return;
     }
 
+    if (!selectedAccount.spendingPrivateKey || selectedAccount.isLocked) {
+      setError(
+        'This credit account is locked. Unlock your shielded keypair to sign authorizations.',
+      );
+      return;
+    }
+
     // Validate all numeric inputs
     const parsedServiceId = validateServiceId(serviceId);
     if (parsedServiceId === null) {

--- a/apps/tangle-cloud/src/containers/payments/WithdrawContainer.tsx
+++ b/apps/tangle-cloud/src/containers/payments/WithdrawContainer.tsx
@@ -12,7 +12,7 @@ import NoteCard from '../../components/payments/NoteCard';
 import { useShieldedContext } from '../../app/ShieldedProvider';
 
 const WithdrawContainer: FC = () => {
-  const { notes, shieldedBalance } = useShieldedContext();
+  const { notes } = useShieldedContext();
 
   const [amount, setAmount] = useState('');
   const [recipient, setRecipient] = useState('');
@@ -68,7 +68,7 @@ const WithdrawContainer: FC = () => {
       <AmountInput
         value={amount}
         onChange={setAmount}
-        balance={shieldedBalance}
+        balance={confirmedNotes.reduce((sum, n) => sum + n.amount, 0n)}
         symbol="SHIELDED"
         label="Withdraw Amount"
         disabled

--- a/apps/tangle-cloud/src/hooks/payments/useKeypair.ts
+++ b/apps/tangle-cloud/src/hooks/payments/useKeypair.ts
@@ -33,6 +33,7 @@ const useKeypair = () => {
   useEffect(() => {
     setKeypair(null);
     setError(null);
+    setIsLoading(false); // Cancel any stuck loading state from previous address
     setHasStoredKeypair(
       !!address && localStorage.getItem(`${STORAGE_KEY}:${address}`) !== null,
     );

--- a/apps/tangle-cloud/src/pages/blueprints/layout.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/layout.tsx
@@ -2,7 +2,9 @@ import { PropsWithChildren } from 'react';
 import PageLayout from '../../components/PageLayout';
 
 const Layout = ({ children }: PropsWithChildren) => {
-  return <PageLayout>{children}</PageLayout>;
+  return (
+    <PageLayout className="md:px-8 lg:px-10 relative">{children}</PageLayout>
+  );
 };
 
 export default Layout;

--- a/apps/tangle-cloud/src/pages/operators/layout.tsx
+++ b/apps/tangle-cloud/src/pages/operators/layout.tsx
@@ -2,7 +2,9 @@ import { PropsWithChildren } from 'react';
 import PageLayout from '../../components/PageLayout';
 
 const Layout = ({ children }: PropsWithChildren) => {
-  return <PageLayout>{children}</PageLayout>;
+  return (
+    <PageLayout className="md:px-8 lg:px-10 relative">{children}</PageLayout>
+  );
 };
 
 export default Layout;

--- a/apps/tangle-cloud/src/pages/operators/manage/layout.tsx
+++ b/apps/tangle-cloud/src/pages/operators/manage/layout.tsx
@@ -2,7 +2,9 @@ import { PropsWithChildren } from 'react';
 import PageLayout from '../../../components/PageLayout';
 
 const Layout = ({ children }: PropsWithChildren) => {
-  return <PageLayout>{children}</PageLayout>;
+  return (
+    <PageLayout className="md:px-8 lg:px-10 relative">{children}</PageLayout>
+  );
 };
 
 export default Layout;

--- a/apps/tangle-cloud/src/utils/payments/db.ts
+++ b/apps/tangle-cloud/src/utils/payments/db.ts
@@ -40,6 +40,12 @@ export const openDb = (): Promise<IDBDatabase> => {
         dbPromise = null;
       };
 
+      // Handle schema upgrade from another tab
+      db.onversionchange = () => {
+        db.close();
+        dbPromise = null;
+      };
+
       resolve(db);
     };
 

--- a/apps/tangle-cloud/src/utils/payments/indexedDbCreditStorage.ts
+++ b/apps/tangle-cloud/src/utils/payments/indexedDbCreditStorage.ts
@@ -3,16 +3,17 @@ import { encryptData, decryptData } from './keyEncryption';
 
 export interface StoredCreditKeys {
   commitment: string;
-  spendingPrivateKey: string;
+  spendingPrivateKey: string; // Empty if locked/undecryptable
   spendingPublicKey: string;
   salt: string;
   label?: string;
   createdAt: number;
+  isLocked: boolean; // True if private key could not be decrypted
 }
 
 interface EncryptedCreditRecord {
   commitment: string;
-  owner: string; // wallet address — scoping key
+  owner: string;
   encryptedPrivateKey: string;
   spendingPublicKey: string;
   salt: string;
@@ -23,16 +24,22 @@ interface EncryptedCreditRecord {
 export const saveCreditKeys = async (
   keys: StoredCreditKeys,
   ownerAddress: string,
-  encryptionKey?: string,
+  encryptionKey: string,
 ): Promise<void> => {
-  const db = await openDb();
+  if (!encryptionKey) {
+    throw new Error(
+      'Encryption key required to store credit keys. Unlock your shielded keypair first.',
+    );
+  }
 
+  const db = await openDb();
   const record: EncryptedCreditRecord = {
     commitment: keys.commitment,
     owner: ownerAddress.toLowerCase(),
-    encryptedPrivateKey: encryptionKey
-      ? await encryptData(keys.spendingPrivateKey, encryptionKey)
-      : '', // No encryption key = don't store private key at all
+    encryptedPrivateKey: await encryptData(
+      keys.spendingPrivateKey,
+      encryptionKey,
+    ),
     spendingPublicKey: keys.spendingPublicKey,
     salt: keys.salt,
     label: keys.label,
@@ -43,7 +50,6 @@ export const saveCreditKeys = async (
     const tx = db.transaction(STORES.CREDIT_KEYS, 'readwrite');
     const store = tx.objectStore(STORES.CREDIT_KEYS);
     const request = store.put(record);
-
     request.onsuccess = () => resolve();
     request.onerror = () => reject(request.error);
   });
@@ -59,28 +65,28 @@ export const loadCreditKeysForAddress = async (
       const tx = db.transaction(STORES.CREDIT_KEYS, 'readonly');
       const store = tx.objectStore(STORES.CREDIT_KEYS);
       const request = store.getAll();
-
       request.onsuccess = () => resolve(request.result ?? []);
       request.onerror = () => reject(request.error);
     },
   );
 
-  // Filter to this wallet's records only
   const owner = ownerAddress.toLowerCase();
   const records = allRecords.filter((r) => r.owner === owner);
 
   const results: StoredCreditKeys[] = [];
   for (const record of records) {
     let privateKey = '';
+    let isLocked = true;
+
     if (encryptionKey && record.encryptedPrivateKey) {
       try {
         privateKey = await decryptData(
           record.encryptedPrivateKey,
           encryptionKey,
         );
+        isLocked = false;
       } catch {
-        // Decryption failed — leave private key empty, don't expose ciphertext
-        privateKey = '';
+        // Decryption failed — mark as locked, don't expose ciphertext
       }
     }
 
@@ -91,19 +97,39 @@ export const loadCreditKeysForAddress = async (
       salt: record.salt,
       label: record.label,
       createdAt: record.createdAt,
+      isLocked,
     });
   }
 
   return results;
 };
 
-export const deleteCreditKeys = async (commitment: string): Promise<void> => {
+// Delete only verifies the record belongs to the caller's address
+export const deleteCreditKeys = async (
+  commitment: string,
+  ownerAddress: string,
+): Promise<void> => {
   const db = await openDb();
+
+  // Read-then-delete to verify ownership
+  const record: EncryptedCreditRecord | undefined = await new Promise(
+    (resolve, reject) => {
+      const tx = db.transaction(STORES.CREDIT_KEYS, 'readonly');
+      const store = tx.objectStore(STORES.CREDIT_KEYS);
+      const request = store.get(commitment);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    },
+  );
+
+  if (!record || record.owner !== ownerAddress.toLowerCase()) {
+    return; // Not found or not owned — no-op
+  }
+
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORES.CREDIT_KEYS, 'readwrite');
     const store = tx.objectStore(STORES.CREDIT_KEYS);
     const request = store.delete(commitment);
-
     request.onsuccess = () => resolve();
     request.onerror = () => reject(request.error);
   });


### PR DESCRIPTION
## Summary

Fixes all findings from the codex/claude ensemble review on #3147.

### Write queue fix
- notesRef.current updated synchronously inside the promise chain so back-to-back addNote calls see each other's results (was dropping notes)

### Credit key lifecycle
- saveCreditKeys now requires encryption key (throws if missing — no more plaintext storage)
- StoredCreditKeys gains isLocked field — locked accounts clearly marked in UI
- deleteCreditKeys verifies owner address before deleting (was cross-wallet deletable)
- FundCreditsContainer requires unlocked keypair, removed misleading proof progress
- SpendAuthContainer rejects signing with locked/empty private keys

### Wallet switch safety
- CreditsProvider uses generation counter for stale-response guard
- useKeypair resets isLoading on address change (prevents permanently stuck state)

### IDB
- onversionchange handler closes and invalidates stale connections across tabs

### Layout regression fix
- PageLayout defaults to md:px-5 (original instances/rewards/earnings padding)
- blueprints/operators layouts explicitly pass md:px-8 lg:px-10 relative

### UX honesty
- Withdraw shows confirmed-notes balance only, not total (unconfirmed notes aren't spendable)
- AmountInput MAX works correctly for 0n balance

## Test plan
- [x] yarn nx typecheck tangle-cloud passes
- [x] yarn nx lint tangle-cloud passes (0 errors, 0 warnings)
- [x] yarn nx test tangle-cloud passes (52/52)