### PR TITLE
feat(tangle-cloud): verify pinned blueprint metadata

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/authoring.spec.ts
+++ b/apps/tangle-cloud/src/blueprintApps/authoring.spec.ts
@@ -25,23 +25,36 @@ describe('blueprint ui authoring', () => {
     expect(document).toEqual({
       name: 'Trading Agent',
       description: 'Automates strategy execution.',
-      category: 'Trading',
       author: 'Tangle',
-      codeRepository: 'https://github.com/tangle/trading-blueprint',
+      category: 'Trading',
+      image: null,
+      logo: null,
       website: 'https://tangle.tools',
+      codeRepository: 'https://github.com/tangle/trading-blueprint',
       blueprintUi: {
-        slug: 'trading',
-        publisher: {
-          namespace: 'tangle',
-        },
         displayName: 'Trading Agent',
-        tagline: 'Trading blueprint on Tangle',
         description: 'Automates strategy execution.',
-        surfaces: DEFAULT_BLUEPRINT_UI_DRAFT.surfaces,
+        requestedSlug: 'trading',
+        publisher: {
+          name: 'Tangle',
+          namespace: 'tangle',
+          verified: false,
+        },
         resources: {
-          serviceNoun: 'service',
-          resourceNoun: 'bot',
-          resourceRoute: 'bots',
+          serviceLabel: 'Service',
+          itemLabel: 'bot',
+          itemRoute: 'bots',
+        },
+        surfaces: {
+          genericOverview: true,
+          serviceExplorer: true,
+          serviceConsole: false,
+          actionsPanel: true,
+          resources: true,
+          chat: false,
+          vaults: false,
+          metrics: true,
+          permissions: false,
         },
       },
     });
@@ -61,8 +74,8 @@ describe('blueprint ui authoring', () => {
       ...DEFAULT_BLUEPRINT_UI_DRAFT,
       requestedSlug: 'trading',
       publisherNamespace: 'tangle',
-      serviceNoun: 'service',
-      resourceNoun: 'resource',
+      serviceNoun: 'Service',
+      resourceNoun: 'Resource',
       surfaces: ['chat', 'resources'],
     });
   });

--- a/apps/tangle-cloud/src/blueprintApps/authoring.ts
+++ b/apps/tangle-cloud/src/blueprintApps/authoring.ts
@@ -1,21 +1,10 @@
-import type {
-  BlueprintExternalAppMode,
-  BlueprintResourceRoute,
-  BlueprintUiManifest,
-  BlueprintUiSurface,
-} from './types';
-import { isTrustedExternalAppHost } from './resolver';
+import {
+  buildBlueprintUiMetadataDocument as buildSharedBlueprintUiMetadataDocument,
+  DEFAULT_BLUEPRINT_UI_DRAFT as SHARED_DEFAULT_BLUEPRINT_UI_DRAFT,
+} from '@tangle-network/tangle-shared-ui/blueprintApps/authoring';
+import type { BlueprintUiAuthoringDraft } from '@tangle-network/tangle-shared-ui/blueprintApps/types';
 
-export type BlueprintUiAuthoringDraft = {
-  requestedSlug: string;
-  publisherNamespace: string;
-  serviceNoun: string;
-  resourceNoun: string;
-  resourceRoute: BlueprintResourceRoute;
-  surfaces: BlueprintUiSurface[];
-  externalAppUrl: string;
-  externalAppMode: BlueprintExternalAppMode;
-};
+export type { BlueprintUiAuthoringDraft };
 
 export type BuildBlueprintUiMetadataDocumentParams = {
   name: string;
@@ -28,24 +17,8 @@ export type BuildBlueprintUiMetadataDocumentParams = {
   draft: BlueprintUiAuthoringDraft;
 };
 
-export const DEFAULT_BLUEPRINT_UI_SURFACES: BlueprintUiSurface[] = [
-  'generic-overview',
-  'service-explorer',
-  'service-console',
-  'actions-panel',
-  'resources',
-  'permissions',
-];
-
-export const DEFAULT_BLUEPRINT_UI_DRAFT: BlueprintUiAuthoringDraft = {
-  requestedSlug: '',
-  publisherNamespace: '',
-  serviceNoun: 'service',
-  resourceNoun: 'resource',
-  resourceRoute: 'custom',
-  surfaces: DEFAULT_BLUEPRINT_UI_SURFACES,
-  externalAppUrl: '',
-  externalAppMode: 'link',
+export const DEFAULT_BLUEPRINT_UI_DRAFT = {
+  ...SHARED_DEFAULT_BLUEPRINT_UI_DRAFT,
 };
 
 const trim = (value: string): string => value.trim();
@@ -55,78 +28,16 @@ export const sanitizeBlueprintUiDraft = (
 ): BlueprintUiAuthoringDraft => ({
   requestedSlug: trim(draft.requestedSlug),
   publisherNamespace: trim(draft.publisherNamespace),
-  serviceNoun: trim(draft.serviceNoun) || 'service',
-  resourceNoun: trim(draft.resourceNoun) || 'resource',
+  serviceNoun: trim(draft.serviceNoun) || 'Service',
+  resourceNoun: trim(draft.resourceNoun) || 'Resource',
   resourceRoute: draft.resourceRoute,
   surfaces:
     draft.surfaces.length > 0
       ? Array.from(new Set(draft.surfaces))
-      : DEFAULT_BLUEPRINT_UI_SURFACES,
+      : DEFAULT_BLUEPRINT_UI_DRAFT.surfaces,
   externalAppUrl: trim(draft.externalAppUrl),
   externalAppMode: draft.externalAppMode,
 });
-
-const buildTagline = (name: string, category?: string): string => {
-  const trimmedCategory = category?.trim();
-  if (trimmedCategory) {
-    return `${trimmedCategory} blueprint on Tangle`;
-  }
-
-  return `${name.trim() || 'Blueprint'} on Tangle`;
-};
-
-const buildManifest = ({
-  name,
-  description,
-  category,
-  draft,
-}: {
-  name: string;
-  description: string;
-  category?: string;
-  draft: BlueprintUiAuthoringDraft;
-}): BlueprintUiManifest => {
-  const sanitizedDraft = sanitizeBlueprintUiDraft(draft);
-  let externalApp: BlueprintUiManifest['externalApp'];
-
-  if (sanitizedDraft.externalAppUrl) {
-    try {
-      const host = new URL(sanitizedDraft.externalAppUrl).hostname;
-      const trust = isTrustedExternalAppHost(host) ? 'trusted' : 'restricted';
-
-      externalApp = {
-        url: sanitizedDraft.externalAppUrl,
-        mode: sanitizedDraft.externalAppMode,
-        label: 'Open blueprint app',
-        host,
-        trust,
-        ...(trust === 'restricted'
-          ? {
-              reason:
-                'External app host is not on the trusted Tangle allowlist yet.',
-            }
-          : {}),
-      };
-    } catch {
-      externalApp = undefined;
-    }
-  }
-
-  return {
-    displayName: trim(name) || 'Untitled blueprint',
-    tagline: buildTagline(name, category),
-    description:
-      trim(description) ||
-      'Blueprint metadata published for the shared Tangle Cloud host surface.',
-    surfaces: sanitizedDraft.surfaces,
-    resources: {
-      serviceNoun: sanitizedDraft.serviceNoun,
-      resourceNoun: sanitizedDraft.resourceNoun,
-      resourceRoute: sanitizedDraft.resourceRoute,
-    },
-    ...(externalApp ? { externalApp } : {}),
-  };
-};
 
 export const buildBlueprintUiMetadataDocument = ({
   name,
@@ -137,36 +48,14 @@ export const buildBlueprintUiMetadataDocument = ({
   website,
   author,
   draft,
-}: BuildBlueprintUiMetadataDocumentParams): Record<string, unknown> => {
-  const sanitizedDraft = sanitizeBlueprintUiDraft(draft);
-
-  return {
-    ...(trim(name) ? { name: trim(name) } : {}),
-    ...(trim(description) ? { description: trim(description) } : {}),
-    ...(trim(category ?? '') ? { category: trim(category ?? '') } : {}),
-    ...(trim(author ?? '') ? { author: trim(author ?? '') } : {}),
-    ...(trim(codeRepository ?? '')
-      ? { codeRepository: trim(codeRepository ?? '') }
-      : {}),
-    ...(trim(logo ?? '') ? { logo: trim(logo ?? '') } : {}),
-    ...(trim(website ?? '') ? { website: trim(website ?? '') } : {}),
-    blueprintUi: {
-      ...(sanitizedDraft.requestedSlug
-        ? { slug: sanitizedDraft.requestedSlug }
-        : {}),
-      ...(sanitizedDraft.publisherNamespace
-        ? {
-            publisher: {
-              namespace: sanitizedDraft.publisherNamespace,
-            },
-          }
-        : {}),
-      ...buildManifest({
-        name,
-        description,
-        category,
-        draft: sanitizedDraft,
-      }),
-    },
-  };
-};
+}: BuildBlueprintUiMetadataDocumentParams): Record<string, unknown> =>
+  buildSharedBlueprintUiMetadataDocument({
+    name,
+    description,
+    category: category ?? '',
+    codeRepository: codeRepository ?? '',
+    logo: logo ?? '',
+    website: website ?? '',
+    author: author ?? '',
+    draft: sanitizeBlueprintUiDraft(draft),
+  });

--- a/apps/tangle-cloud/src/blueprintApps/hostContract.spec.ts
+++ b/apps/tangle-cloud/src/blueprintApps/hostContract.spec.ts
@@ -1,0 +1,99 @@
+import {
+  parseBlueprintMetadataDocument,
+  parseBlueprintMetadataJsonText,
+} from '@tangle-network/tangle-shared-ui/blueprintApps/authoring';
+
+describe('shared blueprint host contract', () => {
+  it('parses rich declarative tier 2 metadata', () => {
+    const parsed = parseBlueprintMetadataDocument({
+      name: 'Atlas',
+      description: 'Operator coordination workspace',
+      author: 'Northstar',
+      blueprintUi: {
+        displayName: 'Atlas Workspace',
+        description: 'Shared hosted app for Atlas operators.',
+        requestedSlug: 'atlas',
+        publisher: {
+          name: 'Northstar',
+          namespace: 'northstar',
+          verified: true,
+        },
+        resources: {
+          serviceLabel: 'Workspace',
+          itemLabel: 'Run',
+          itemRoute: 'runs',
+        },
+        surfaces: ['generic-overview', 'resources', 'metrics'],
+        theme: {
+          accentColor: '#0F766E',
+          badgeLabel: 'Curated',
+          icon: 'bot',
+        },
+        overviewCards: [
+          {
+            id: 'uptime',
+            kind: 'stat',
+            title: 'Operator Uptime',
+            value: '99.9%',
+          },
+        ],
+        actions: [
+          {
+            id: 'provision',
+            label: 'Provision workspace',
+            target: 'service',
+            fields: [
+              {
+                key: 'workspace_name',
+                label: 'Workspace name',
+                input: 'text',
+                required: true,
+              },
+            ],
+          },
+        ],
+        resourceViews: [
+          {
+            id: 'runs',
+            title: 'Run ledger',
+            kind: 'table',
+            target: 'resource',
+            columns: [
+              { key: 'status', label: 'Status', emphasis: true },
+              { key: 'updated_at', label: 'Updated' },
+            ],
+          },
+        ],
+        modules: [
+          {
+            module: 'metrics-overview',
+            slot: 'overview',
+            metricKeys: ['success_rate', 'latency_p95'],
+          },
+        ],
+      },
+    });
+
+    expect(parsed.blueprintUi?.tier).toBe('declarative');
+    expect(parsed.blueprintUi?.theme?.accentColor).toBe('#0F766E');
+    expect(parsed.blueprintUi?.overviewCards?.[0]?.title).toBe(
+      'Operator Uptime',
+    );
+    expect(parsed.blueprintUi?.actions?.[0]?.fields?.[0]?.key).toBe(
+      'workspace_name',
+    );
+    expect(parsed.blueprintUi?.resourceViews?.[0]?.columns).toHaveLength(2);
+    expect(parsed.blueprintUi?.modules?.[0]?.module).toBe('metrics-overview');
+  });
+
+  it('rejects oversized metadata payloads', () => {
+    const oversized = JSON.stringify({
+      name: 'Large Blueprint',
+      description: 'x'.repeat(70_000),
+    });
+
+    expect(() => parseBlueprintMetadataJsonText(oversized)).toThrow(
+      'Blueprint metadata exceeded',
+    );
+  });
+});

--- a/apps/tangle-cloud/src/blueprintApps/manifest.spec.ts
+++ b/apps/tangle-cloud/src/blueprintApps/manifest.spec.ts
@@ -1,5 +1,19 @@
 import { buildBlueprintManifestFromMetadata } from './manifest';
 
+const verifiedMetadata = {
+  status: 'verified' as const,
+  productionReady: true,
+  source: 'ipfs' as const,
+  reason: 'verified',
+};
+
+const unverifiedMetadata = {
+  status: 'unverified' as const,
+  productionReady: false,
+  source: 'ipfs' as const,
+  reason: 'unverified',
+};
+
 describe('blueprint app manifest parsing', () => {
   it('falls back to generic protocol rendering when no app metadata exists', () => {
     const { entry, source } = buildBlueprintManifestFromMetadata({
@@ -19,6 +33,7 @@ describe('blueprint app manifest parsing', () => {
       imageUrl: null,
       codeUrl: null,
       website: null,
+      metadataVerification: unverifiedMetadata,
       rawMetadata: null,
     });
 
@@ -47,6 +62,7 @@ describe('blueprint app manifest parsing', () => {
       imageUrl: null,
       codeUrl: null,
       website: null,
+      metadataVerification: verifiedMetadata,
       rawMetadata: {
         blueprintUi: {
           slug: 'research-studio',
@@ -100,6 +116,7 @@ describe('blueprint app manifest parsing', () => {
       imageUrl: null,
       codeUrl: null,
       website: null,
+      metadataVerification: unverifiedMetadata,
       rawMetadata: {
         tangleCloud: {
           slug: 'external-trading',
@@ -112,11 +129,9 @@ describe('blueprint app manifest parsing', () => {
       },
     });
 
-    expect(entry.tier).toBe('external-app');
-    expect(entry.manifest.externalApp?.url).toBe(
-      'https://apps.acme.test/trading',
-    );
-    expect(entry.manifest.externalApp?.trust).toBe('restricted');
+    expect(entry.tier).toBe('generic');
+    expect(entry.manifest.externalApp).toBeUndefined();
+    expect(entry.manifest.description).toContain('unverified');
   });
 
   it('marks trusted Tangle external app hosts as trusted', () => {
@@ -137,8 +152,13 @@ describe('blueprint app manifest parsing', () => {
       imageUrl: null,
       codeUrl: null,
       website: null,
+      metadataVerification: verifiedMetadata,
       rawMetadata: {
         blueprintUi: {
+          publisher: {
+            namespace: 'tangle',
+            verification: 'verified',
+          },
           externalApp: {
             url: 'https://cloud.tangle.tools/blueprints/sandbox',
             mode: 'iframe',
@@ -147,6 +167,50 @@ describe('blueprint app manifest parsing', () => {
       },
     });
 
+    expect(entry.tier).toBe('external-app');
     expect(entry.manifest.externalApp?.trust).toBe('trusted');
+    expect(entry.manifest.externalApp?.mode).toBe('link');
+  });
+
+  it('falls back to protocol rendering when metadata is present but not verified', () => {
+    const { entry } = buildBlueprintManifestFromMetadata({
+      id: '11',
+      blueprintId: 11n,
+      owner: '0x0000000000000000000000000000000000000001',
+      manager: null,
+      metadataUri: 'ipfs://example',
+      active: true,
+      createdAt: 1n,
+      updatedAt: 1n,
+      operatorCount: 0n,
+      name: 'Secure Agent',
+      description: 'Protocol indexed blueprint',
+      author: 'Alice Labs',
+      category: 'AI',
+      imageUrl: null,
+      codeUrl: null,
+      website: null,
+      metadataVerification: {
+        status: 'invalid',
+        productionReady: false,
+        source: 'ipfs',
+        reason: 'signature mismatch',
+      },
+      rawMetadata: {
+        blueprintUi: {
+          slug: 'secure-agent',
+          surfaces: ['generic-overview', 'chat'],
+        },
+      },
+    });
+
+    expect(entry.tier).toBe('generic');
+    expect(entry.manifest.surfaces).toEqual([
+      'generic-overview',
+      'service-explorer',
+      'actions-panel',
+      'permissions',
+    ]);
+    expect(entry.manifest.description).toContain('signature mismatch');
   });
 });

--- a/apps/tangle-cloud/src/blueprintApps/manifest.ts
+++ b/apps/tangle-cloud/src/blueprintApps/manifest.ts
@@ -164,6 +164,10 @@ function parsePermissions(
 
 function parseExternalApp(
   value: unknown,
+  options: {
+    publisherVerified: boolean;
+    metadataVerified: boolean;
+  },
 ): BlueprintExternalAppConfig | undefined {
   const record = readRecord(value);
   if (!record) {
@@ -190,16 +194,41 @@ function parseExternalApp(
   }
 
   const trust = isTrustedExternalAppHost(host) ? 'trusted' : 'restricted';
+  const requestedMode = mode as BlueprintExternalAppConfig['mode'];
+  const reasons: string[] = [];
+
+  if (requestedMode === 'iframe') {
+    reasons.push('Iframe embedding is disabled by policy; verified apps must open in a new tab.');
+  }
+
+  if (!options.publisherVerified) {
+    reasons.push('Publisher is not verified for advanced external app handoff.');
+  }
+
+  if (!options.metadataVerified) {
+    reasons.push(
+      'Metadata provenance was not verified against the onchain blueprint owner.',
+    );
+  }
 
   return {
     url,
-    mode: mode as BlueprintExternalAppConfig['mode'],
+    mode: 'link',
     label: readString(record.label) ?? undefined,
     host,
-    trust,
-    ...(trust === 'restricted'
+    trust:
+      trust === 'trusted' &&
+      options.publisherVerified &&
+      options.metadataVerified
+        ? 'trusted'
+        : 'restricted',
+    ...(trust === 'restricted' ||
+    !options.publisherVerified ||
+    !options.metadataVerified ||
+    requestedMode === 'iframe'
       ? {
           reason:
+            reasons[0] ??
             'External app host is not on the trusted Tangle allowlist yet.',
         }
       : {}),
@@ -240,7 +269,7 @@ export function buildBlueprintManifestFromMetadata(
   const publisherNamespace =
     readString(readRecord(manifestRoot?.publisher)?.namespace) ??
     sanitizeBlueprintSlugPart(blueprint.author);
-  const publisherVerified =
+  const publisherDeclaredVerified =
     readString(readRecord(manifestRoot?.publisher)?.verification) ===
     'verified';
   const requestedSlug =
@@ -255,10 +284,12 @@ export function buildBlueprintManifestFromMetadata(
     label: blueprint.author || 'Unknown publisher',
     namespace: publisherNamespace || undefined,
     visibility: 'third-party',
-    verification: publisherVerified
+    verification: publisherDeclaredVerified
       ? 'verified'
       : getPublisherVerificationForNamespace(publisherNamespace),
   };
+  const metadataVerified = blueprint.metadataVerification?.status === 'verified';
+  const publisherVerified = publisher.verification === 'verified';
   const slugPolicy = canPublisherClaimSlug(normalizedRequestedSlug, publisher)
     ? 'publisher-scoped'
     : 'public-requested';
@@ -275,21 +306,38 @@ export function buildBlueprintManifestFromMetadata(
       baseManifest.resources,
     ),
     permissions: parsePermissions(manifestRoot?.permissions),
-    externalApp: parseExternalApp(manifestRoot?.externalApp),
+    externalApp: parseExternalApp(manifestRoot?.externalApp, {
+      publisherVerified,
+      metadataVerified,
+    }),
   };
+
+  const allowDeclarativeTier =
+    manifestRoot !== null && blueprint.metadataVerification?.productionReady === true;
+  const trustedExternalApp =
+    manifest.externalApp?.trust === 'trusted' ? manifest.externalApp : undefined;
 
   const entry: BlueprintAppEntry = {
     slug: normalizedRequestedSlug,
     canonicalSlug: normalizedRequestedSlug,
     blueprintId: blueprint.blueprintId,
     publisher,
-    tier: manifest.externalApp
+    tier: trustedExternalApp
       ? 'external-app'
-      : manifestRoot
+      : allowDeclarativeTier
         ? 'declarative'
         : 'generic',
     slugPolicy,
-    manifest,
+    manifest: allowDeclarativeTier
+      ? {
+          ...manifest,
+          externalApp: trustedExternalApp,
+        }
+      : {
+          ...baseManifest,
+          description:
+            blueprint.metadataVerification?.reason ?? baseManifest.description,
+        },
   };
 
   entry.canonicalSlug = buildCanonicalBlueprintSlug(entry);

--- a/apps/tangle-cloud/src/blueprintApps/policy.spec.ts
+++ b/apps/tangle-cloud/src/blueprintApps/policy.spec.ts
@@ -9,8 +9,8 @@ describe('blueprint platform policy', () => {
   it('ships safe defaults for reserved slugs and trusted hosts', () => {
     expect(reservedBlueprintSlugs.has('trading')).toBe(true);
     expect(reservedBlueprintSlugs.has('sandbox')).toBe(true);
-    expect(trustedExternalAppHosts).toContain('tangle.tools');
-    expect(trustedExternalAppHosts).toContain('tangle.network');
+    expect(trustedExternalAppHosts).toContain('cloud.tangle.tools');
+    expect(trustedExternalAppHosts).toContain('apps.tangle.tools');
   });
 
   it('marks known publisher namespaces as verified', () => {

--- a/apps/tangle-cloud/src/blueprintApps/policy.ts
+++ b/apps/tangle-cloud/src/blueprintApps/policy.ts
@@ -7,7 +7,11 @@ const splitEnvList = (value: string | undefined): string[] =>
     .filter(Boolean);
 
 const DEFAULT_RESERVED_SLUGS = ['trading', 'sandbox', 'training'];
-const DEFAULT_TRUSTED_EXTERNAL_APP_HOSTS = ['tangle.tools', 'tangle.network'];
+const DEFAULT_TRUSTED_EXTERNAL_APP_HOSTS = [
+  'cloud.tangle.tools',
+  'app.tangle.tools',
+  'apps.tangle.tools',
+];
 const DEFAULT_VERIFIED_PUBLISHERS = ['tangle', 'tangle-labs'];
 
 export const reservedBlueprintSlugs = new Set([

--- a/apps/tangle-cloud/src/components/blueprintApps/BlueprintHostCard.tsx
+++ b/apps/tangle-cloud/src/components/blueprintApps/BlueprintHostCard.tsx
@@ -89,8 +89,30 @@ const BlueprintHostCard = ({ blueprint, serviceId }: Props) => {
           value={blueprintUi.resources.serviceLabel}
         />
         <InfoBlock
+          label="Metadata Trust"
+          value={
+            blueprint.metadataVerification?.status === 'verified'
+              ? 'Verified owner attestation'
+              : blueprint.metadataVerification?.reason ??
+                'Unverified metadata'
+          }
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <InfoBlock
           label="Resource Model"
           value={`${blueprintUi.resources.itemLabel} • ${blueprintUi.resources.itemRoute}`}
+        />
+        <InfoBlock
+          label="Metadata Source"
+          value={
+            blueprint.metadataVerification?.source === 'ipfs'
+              ? 'ipfs://'
+              : blueprint.metadataVerification?.source === 'http'
+                ? 'http(s)'
+                : 'missing'
+          }
         />
       </div>
 
@@ -117,6 +139,181 @@ const BlueprintHostCard = ({ blueprint, serviceId }: Props) => {
                 className="rounded-full border border-mono-60 dark:border-mono-140 px-3 py-1.5 text-sm"
               >
                 {SURFACE_LABELS[surface]}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {blueprintUi.theme && (
+        <div className="space-y-2">
+          <Typography variant="body2" className="text-mono-100">
+            Theme tokens
+          </Typography>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            {blueprintUi.theme.badgeLabel && (
+              <InfoBlock label="Badge" value={blueprintUi.theme.badgeLabel} />
+            )}
+            {blueprintUi.theme.icon && (
+              <InfoBlock label="Icon" value={blueprintUi.theme.icon} />
+            )}
+            {blueprintUi.theme.accentColor && (
+              <InfoBlock
+                label="Accent"
+                value={blueprintUi.theme.accentColor}
+              />
+            )}
+            {blueprintUi.theme.secondaryColor && (
+              <InfoBlock
+                label="Secondary"
+                value={blueprintUi.theme.secondaryColor}
+              />
+            )}
+          </div>
+        </div>
+      )}
+
+      {blueprintUi.overviewCards && blueprintUi.overviewCards.length > 0 && (
+        <div className="space-y-3">
+          <Typography variant="body2" className="text-mono-100">
+            Overview cards
+          </Typography>
+          <div className="grid gap-3 lg:grid-cols-2">
+            {blueprintUi.overviewCards.map((card) => (
+              <div
+                key={card.id}
+                className="rounded-xl border border-mono-60 dark:border-mono-140 p-4 space-y-2"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <Typography variant="body1" fw="semibold">
+                    {card.title}
+                  </Typography>
+                  <Typography variant="body2" className="text-mono-100">
+                    {card.kind}
+                    {card.tone ? ` • ${card.tone}` : ''}
+                  </Typography>
+                </div>
+                {card.description && (
+                  <Typography variant="body2" className="text-mono-100">
+                    {card.description}
+                  </Typography>
+                )}
+                {card.value && (
+                  <Typography variant="body1" fw="semibold">
+                    {card.value}
+                  </Typography>
+                )}
+                {card.items && card.items.length > 0 && (
+                  <Typography variant="body2" className="text-mono-100">
+                    {card.items.join(' • ')}
+                  </Typography>
+                )}
+                {card.links && card.links.length > 0 && (
+                  <Typography variant="body2" className="text-mono-100">
+                    {card.links.map((link) => link.label).join(' • ')}
+                  </Typography>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {blueprintUi.actions && blueprintUi.actions.length > 0 && (
+        <div className="space-y-3">
+          <Typography variant="body2" className="text-mono-100">
+            Declarative actions
+          </Typography>
+          <div className="space-y-3">
+            {blueprintUi.actions.map((action) => (
+              <div
+                key={action.id}
+                className="rounded-xl border border-mono-60 dark:border-mono-140 p-4 space-y-2"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <Typography variant="body1" fw="semibold">
+                    {action.label}
+                  </Typography>
+                  <span className="rounded-full border border-mono-60 dark:border-mono-140 px-2 py-0.5 text-xs">
+                    {action.target}
+                  </span>
+                  {action.href && (
+                    <span className="rounded-full border border-mono-60 dark:border-mono-140 px-2 py-0.5 text-xs">
+                      link action
+                    </span>
+                  )}
+                  {action.fields && (
+                    <span className="rounded-full border border-mono-60 dark:border-mono-140 px-2 py-0.5 text-xs">
+                      {action.fields.length} field form
+                    </span>
+                  )}
+                </div>
+                {action.description && (
+                  <Typography variant="body2" className="text-mono-100">
+                    {action.description}
+                  </Typography>
+                )}
+                {action.fields && action.fields.length > 0 && (
+                  <Typography variant="body2" className="text-mono-100">
+                    {action.fields
+                      .map((field) =>
+                        `${field.label} (${field.input}${field.required ? ', required' : ''})`,
+                      )
+                      .join(' • ')}
+                  </Typography>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {blueprintUi.resourceViews && blueprintUi.resourceViews.length > 0 && (
+        <div className="space-y-3">
+          <Typography variant="body2" className="text-mono-100">
+            Resource views
+          </Typography>
+          <div className="grid gap-3 lg:grid-cols-2">
+            {blueprintUi.resourceViews.map((view) => (
+              <div
+                key={view.id}
+                className="rounded-xl border border-mono-60 dark:border-mono-140 p-4 space-y-2"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <Typography variant="body1" fw="semibold">
+                    {view.title}
+                  </Typography>
+                  <Typography variant="body2" className="text-mono-100">
+                    {view.kind} • {view.target}
+                  </Typography>
+                </div>
+                <Typography variant="body2" className="text-mono-100">
+                  {view.columns
+                    .map((column) =>
+                      column.emphasis
+                        ? `${column.label} (emphasis)`
+                        : column.label,
+                    )
+                    .join(' • ')}
+                </Typography>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {blueprintUi.modules && blueprintUi.modules.length > 0 && (
+        <div className="space-y-2">
+          <Typography variant="body2" className="text-mono-100">
+            Approved host modules
+          </Typography>
+          <div className="flex flex-wrap gap-2">
+            {blueprintUi.modules.map((module) => (
+              <span
+                key={`${module.slot}-${module.module}`}
+                className="rounded-full border border-mono-60 dark:border-mono-140 px-3 py-1.5 text-sm"
+              >
+                {module.module} • {module.slot}
               </span>
             ))}
           </div>

--- a/apps/tangle-cloud/src/pages/blueprints/create/page.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/create/page.tsx
@@ -25,6 +25,11 @@ import {
   type BlueprintDefinition,
 } from '@tangle-network/tangle-shared-ui/data/graphql';
 import {
+  computeBlueprintMetadataPayloadHash,
+  isAllowedBlueprintMetadataUri,
+  requiresIpfsForBlueprintMetadata,
+} from '@tangle-network/tangle-shared-ui/blueprintApps/authoring';
+import {
   parseSchemaJson,
   encodeSchemaToHex,
 } from '@tangle-network/tangle-shared-ui/codec';
@@ -191,6 +196,18 @@ const initialFormState: FormState = {
   sources: [],
 };
 
+const buildMetadataDocument = (form: FormState) =>
+  buildBlueprintUiMetadataDocument({
+    name: form.name,
+    description: form.description,
+    category: form.category,
+    codeRepository: form.codeRepository,
+    logo: form.logo,
+    website: form.website,
+    author: form.author,
+    draft: form.uiDraft,
+  });
+
 // Convert form to ABI-compatible definition
 const formToDefinition = (
   form: FormState,
@@ -205,6 +222,7 @@ const formToDefinition = (
     new TextEncoder().encode(form.registrationSchema),
   );
   const requestBytes = toHex(new TextEncoder().encode(form.requestSchema));
+  const metadataDocument = buildMetadataDocument(form);
 
   // Convert jobs
   const jobs = form.jobs.map((job, index) => ({
@@ -259,6 +277,7 @@ const formToDefinition = (
 
   return {
     metadataUri: form.metadataUri,
+    metadataHash: computeBlueprintMetadataPayloadHash(metadataDocument),
     manager: (form.manager || zeroAddress) as Address,
     masterManagerRevision: 0,
     hasConfig: true,
@@ -292,20 +311,7 @@ const formToDefinition = (
 };
 
 const buildMetadataPreview = (form: FormState): string =>
-  JSON.stringify(
-    buildBlueprintUiMetadataDocument({
-      name: form.name,
-      description: form.description,
-      category: form.category,
-      codeRepository: form.codeRepository,
-      logo: form.logo,
-      website: form.website,
-      author: form.author,
-      draft: form.uiDraft,
-    }),
-    null,
-    2,
-  );
+  JSON.stringify(buildMetadataDocument(form), null, 2);
 
 const toggleBlueprintSurface = (
   draft: BlueprintUiAuthoringDraft,
@@ -359,6 +365,12 @@ const CreateBlueprintPage: FC = () => {
           );
           return false;
         }
+        if (!isAllowedBlueprintMetadataUri(form.metadataUri.trim())) {
+          setValidationError(
+            'Production hosted blueprints must publish metadata to an ipfs:// URI.',
+          );
+          return false;
+        }
         if (form.uiDraft.surfaces.length === 0) {
           setValidationError(
             'Select at least one shared host surface for blueprintUi metadata',
@@ -367,11 +379,9 @@ const CreateBlueprintPage: FC = () => {
         }
         if (
           form.uiDraft.externalAppUrl.trim() &&
-          !/^https?:\/\/.+/.test(form.uiDraft.externalAppUrl.trim())
+          !/^https:\/\/.+/.test(form.uiDraft.externalAppUrl.trim())
         ) {
-          setValidationError(
-            'External app URL must start with https:// or http://',
-          );
+          setValidationError('External app URL must start with https://');
           return false;
         }
         break;
@@ -868,6 +878,11 @@ const BasicInfoStep: FC<BasicInfoStepProps> = ({
       <Typography variant="body3" className="text-mono-100 mt-1">
         Publish the JSON preview below at this URI so cloud.tangle.tools can
         resolve your hosted blueprint surfaces and shared runtime metadata.
+        New SDK blueprints ship the same contract shape in
+        `metadata/blueprint-metadata.json`.
+        {requiresIpfsForBlueprintMetadata()
+          ? ' Production hosting only accepts ipfs:// metadata URIs.'
+          : ' Local development can still use https:// metadata previews.'}
       </Typography>
     </div>
 
@@ -892,7 +907,9 @@ const BasicInfoStep: FC<BasicInfoStepProps> = ({
           </Typography>
           <Typography variant="body3" className="text-mono-100 mt-1">
             This drives the shared hosted blueprint pages, generic service
-            surfaces, and optional safe link-out handoff for publisher apps.
+            surfaces, optional safe link-out handoff for publisher apps, and
+            richer tier-2 cards, forms, resource views, theming, and approved
+            modules when present in the published JSON.
           </Typography>
         </div>
         <Button variant="secondary" size="sm" onClick={onCopyMetadataPreview}>
@@ -1055,9 +1072,12 @@ const BasicInfoStep: FC<BasicInfoStepProps> = ({
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="link">Link out</SelectItem>
-              <SelectItem value="iframe">Embed in iframe</SelectItem>
             </SelectContent>
           </Select>
+          <Typography variant="body3" className="text-mono-100 mt-1">
+            Third-party iframe embedding is disabled. Publisher apps can only
+            open in a new tab after trust and provenance checks pass.
+          </Typography>
         </div>
       </div>
 
@@ -1732,6 +1752,8 @@ const ReviewStep: FC<{
           </Typography>
           <Typography variant="body3" className="text-mono-100 mt-1">
             This is the exact `blueprintUi` contract the shared host will parse.
+            Advanced tier-2 sections can be added directly to the JSON after
+            copying it out.
           </Typography>
         </div>
         <Button variant="secondary" size="sm" onClick={onCopyMetadataPreview}>

--- a/apps/tangle-cloud/src/pages/blueprints/manage/page.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/manage/page.tsx
@@ -37,6 +37,13 @@ import {
   type BlueprintWithMetadata as EnvioBlueprintWithMetadata,
   type OwnedBlueprint,
 } from '@tangle-network/tangle-shared-ui/data/graphql';
+import {
+  computeBlueprintMetadataPayloadHash,
+  parseBlueprintMetadataJsonText,
+  resolveBlueprintMetadataFetchUrl,
+  isAllowedBlueprintMetadataUri,
+  requiresIpfsForBlueprintMetadata,
+} from '@tangle-network/tangle-shared-ui/blueprintApps/authoring';
 import { twMerge } from 'tailwind-merge';
 import { PagePath } from '../../../types';
 import ErrorMessage from '@tangle-network/tangle-shared-ui/components/ErrorMessage';
@@ -58,6 +65,7 @@ type BlueprintMetadataPreview = {
   website?: string;
   codeRepository?: string;
   docs?: string;
+  metadataHash: `0x${string}`;
 };
 
 const applyBlueprintMetadataPreview = (
@@ -99,6 +107,7 @@ const applyBlueprintMetadataPreview = (
   return {
     ...blueprint,
     metadataUri,
+    metadataHash: preview.metadataHash,
     name: preview.name ?? blueprint.name,
     description: preview.description ?? blueprint.description,
     metadata: nextMetadata,
@@ -114,18 +123,6 @@ const readString = (value: unknown): string | undefined => {
   return trimmed.length > 0 ? trimmed : undefined;
 };
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
-
-const resolveMetadataUri = (metadataUri: string): string => {
-  if (!metadataUri.startsWith('ipfs://')) {
-    return metadataUri;
-  }
-
-  const cid = metadataUri.replace('ipfs://', '');
-  return `https://ipfs.io/ipfs/${cid}`;
-};
-
 const getMetadataUriValidationError = (metadataUri: string): string | null => {
   const trimmed = metadataUri.trim();
 
@@ -135,6 +132,10 @@ const getMetadataUriValidationError = (metadataUri: string): string | null => {
 
   if (!/^(ipfs:\/\/|https?:\/\/).+/i.test(trimmed)) {
     return 'Metadata URI must start with ipfs://, https://, or http://';
+  }
+
+  if (!isAllowedBlueprintMetadataUri(trimmed)) {
+    return 'Production hosted blueprints must publish metadata to an ipfs:// URI';
   }
 
   if (/^https?:\/\//i.test(trimmed)) {
@@ -155,7 +156,6 @@ const fetchBlueprintMetadataPreview = async (
   metadataUri: string,
   signal?: AbortSignal,
 ): Promise<BlueprintMetadataPreview> => {
-  const fetchUrl = resolveMetadataUri(metadataUri);
   const controller = new AbortController();
   const timeoutId = setTimeout(
     () => controller.abort(),
@@ -170,7 +170,7 @@ const fetchBlueprintMetadataPreview = async (
       controller.abort();
     }
 
-    const response = await fetch(fetchUrl, {
+    const response = await fetch(resolveBlueprintMetadataFetchUrl(metadataUri), {
       signal: controller.signal,
       cache: 'no-store',
     });
@@ -179,24 +179,25 @@ const fetchBlueprintMetadataPreview = async (
       throw new Error(`Failed to fetch metadata: ${response.status}`);
     }
 
-    const metadataJson: unknown = await response.json();
-    if (!isRecord(metadataJson)) {
-      throw new Error('Invalid metadata JSON payload');
+    const metadataText = await response.text();
+    const { parsed, rawMetadata } = parseBlueprintMetadataJsonText(metadataText);
+    const metadataJson = rawMetadata;
+    if (metadataJson === null) {
+      throw new Error('Metadata payload must be a JSON object');
     }
 
     return {
-      name: readString(metadataJson.name),
-      description: readString(metadataJson.description),
-      author: readString(metadataJson.author),
-      logo: readString(metadataJson.logo) ?? readString(metadataJson.image),
-      website:
-        readString(metadataJson.website) ?? readString(metadataJson.homepage),
-      codeRepository:
-        readString(metadataJson.codeRepository) ??
-        readString(metadataJson.codeUrl) ??
-        readString(metadataJson.repository),
+      name: parsed.name,
+      description: parsed.description,
+      author: parsed.author,
+      logo: parsed.imageUrl ?? undefined,
+      website: parsed.website ?? undefined,
+      codeRepository: parsed.codeUrl ?? undefined,
       docs:
-        readString(metadataJson.docs) ?? readString(metadataJson.documentation),
+        metadataJson !== null
+          ? readString(metadataJson.docs) ?? readString(metadataJson.documentation)
+          : undefined,
+      metadataHash: computeBlueprintMetadataPayloadHash(metadataJson),
     };
   } finally {
     clearTimeout(timeoutId);
@@ -302,7 +303,11 @@ const ManageBlueprintsPage: FC = () => {
 
             return current.map((bp) =>
               bp.blueprintId === blueprintId
-                ? { ...bp, metadataUri: nextUri }
+                ? {
+                    ...bp,
+                    metadataUri: nextUri,
+                    metadataHash: nextPreview?.metadataHash ?? bp.metadataHash,
+                  }
                 : bp,
             );
           },
@@ -320,6 +325,7 @@ const ManageBlueprintsPage: FC = () => {
                 ? {
                     ...bp,
                     metadataUri: nextUri,
+                    metadataHash: nextPreview?.metadataHash ?? bp.metadataHash,
                     name: nextPreview?.name ?? bp.name,
                     description: nextPreview?.description ?? bp.description,
                     author: nextPreview?.author ?? bp.author,
@@ -370,7 +376,8 @@ const ManageBlueprintsPage: FC = () => {
             latest.data?.some(
               (bp) =>
                 bp.id === blueprintId &&
-                bp.metadataUri?.trim() === normalizedUri,
+                bp.metadataUri?.trim() === normalizedUri &&
+                bp.metadataHash === (preview?.metadataHash ?? bp.metadataHash),
             ) ?? false
           );
         },
@@ -812,7 +819,19 @@ const UpdateMetadataModal: FC<UpdateMetadataModalProps> = ({
       return;
     }
 
-    const hash = await updateBlueprint(blueprint.id, trimmedMetadataUri);
+    const metadataHash = previewData?.metadataHash;
+    if (!metadataHash) {
+      setPreviewError(
+        'Load a valid metadata payload before publishing the onchain hash pin.',
+      );
+      return;
+    }
+
+    const hash = await updateBlueprint(
+      blueprint.id,
+      trimmedMetadataUri,
+      metadataHash,
+    );
 
     if (hash) {
       onClose();
@@ -843,6 +862,11 @@ const UpdateMetadataModal: FC<UpdateMetadataModalProps> = ({
               }}
               placeholder="ipfs://... or https://..."
             />
+            <Typography variant="body3" className="text-mono-100 mt-1">
+              {requiresIpfsForBlueprintMetadata()
+                ? 'Production hosted blueprints must keep metadata on ipfs:// content-addressed URIs.'
+                : 'Local development can still preview metadata from https:// endpoints.'}
+            </Typography>
             {(uriError || previewError || error?.message) && (
               <div className="mt-1">
                 {uriError && <ErrorMessage>{uriError}</ErrorMessage>}

--- a/libs/tangle-shared-ui/src/abi/tangle.ts
+++ b/libs/tangle-shared-ui/src/abi/tangle.ts
@@ -336,6 +336,11 @@ const ABI = [
         type: 'string',
         internalType: 'string',
       },
+      {
+        name: 'metadataHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
     stateMutability: 'view',
   },
@@ -636,6 +641,11 @@ const ABI = [
             name: 'metadataUri',
             type: 'string',
             internalType: 'string',
+          },
+          {
+            name: 'metadataHash',
+            type: 'bytes32',
+            internalType: 'bytes32',
           },
           {
             name: 'manager',
@@ -1450,6 +1460,11 @@ const ABI = [
             name: 'metadataUri',
             type: 'string',
             internalType: 'string',
+          },
+          {
+            name: 'metadataHash',
+            type: 'bytes32',
+            internalType: 'bytes32',
           },
           {
             name: 'manager',
@@ -3739,6 +3754,11 @@ const ABI = [
         type: 'string',
         internalType: 'string',
       },
+      {
+        name: 'metadataHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
     outputs: [],
     stateMutability: 'nonpayable',
@@ -3793,6 +3813,12 @@ const ABI = [
         type: 'string',
         indexed: false,
         internalType: 'string',
+      },
+      {
+        name: 'metadataHash',
+        type: 'bytes32',
+        indexed: false,
+        internalType: 'bytes32',
       },
     ],
     anonymous: false,
@@ -3850,6 +3876,12 @@ const ABI = [
         type: 'string',
         indexed: false,
         internalType: 'string',
+      },
+      {
+        name: 'metadataHash',
+        type: 'bytes32',
+        indexed: false,
+        internalType: 'bytes32',
       },
     ],
     anonymous: false,

--- a/libs/tangle-shared-ui/src/blueprintApps/authoring.ts
+++ b/libs/tangle-shared-ui/src/blueprintApps/authoring.ts
@@ -1,11 +1,37 @@
+import {
+  getAddress,
+  isAddressEqual,
+  keccak256,
+  toHex,
+  verifyMessage,
+  type Address,
+  type Hex,
+} from 'viem';
 import type {
+  BlueprintMetadataAttestation,
+  BlueprintMetadataVerification,
   BlueprintResourceRoute,
+  BlueprintUiAction,
+  BlueprintUiActionField,
+  BlueprintUiActionFieldInput,
+  BlueprintUiActionTarget,
   BlueprintUiAuthoringDraft,
+  BlueprintUiCardKind,
+  BlueprintUiCardTone,
   BlueprintUiContract,
   BlueprintUiExternalApp,
   BlueprintUiExternalAppMode,
+  BlueprintUiModuleBinding,
+  BlueprintUiModuleKey,
+  BlueprintUiModuleSlot,
+  BlueprintUiOverviewCard,
   BlueprintUiPublisher,
+  BlueprintUiResourceView,
+  BlueprintUiResourceViewKind,
+  BlueprintUiResourceViewTarget,
   BlueprintUiSurface,
+  BlueprintUiTheme,
+  BlueprintUiThemeIcon,
   ParsedBlueprintMetadata,
 } from './types';
 
@@ -55,6 +81,85 @@ const EXTERNAL_APP_MODE_VALUES = new Set<BlueprintUiExternalAppMode>([
   'iframe',
 ]);
 
+const THEME_ICON_VALUES = new Set<BlueprintUiThemeIcon>([
+  'bot',
+  'shield',
+  'graph',
+  'spark',
+]);
+
+const CARD_KIND_VALUES = new Set<BlueprintUiCardKind>([
+  'stat',
+  'callout',
+  'links',
+  'checklist',
+]);
+
+const CARD_TONE_VALUES = new Set<BlueprintUiCardTone>([
+  'neutral',
+  'info',
+  'success',
+  'warning',
+]);
+
+const ACTION_FIELD_INPUT_VALUES = new Set<BlueprintUiActionFieldInput>([
+  'text',
+  'textarea',
+  'number',
+  'select',
+  'toggle',
+]);
+
+const ACTION_TARGET_VALUES = new Set<BlueprintUiActionTarget>([
+  'blueprint',
+  'service',
+  'resource',
+]);
+
+const RESOURCE_VIEW_KIND_VALUES = new Set<BlueprintUiResourceViewKind>([
+  'table',
+  'grid',
+  'timeline',
+]);
+
+const RESOURCE_VIEW_TARGET_VALUES = new Set<BlueprintUiResourceViewTarget>([
+  'service',
+  'resource',
+]);
+
+const MODULE_KEY_VALUES = new Set<BlueprintUiModuleKey>([
+  'metrics-overview',
+  'service-health',
+  'resource-events',
+  'permissions-matrix',
+  'activity-feed',
+]);
+
+const MODULE_SLOT_VALUES = new Set<BlueprintUiModuleSlot>([
+  'overview',
+  'sidebar',
+  'actions',
+  'resources',
+]);
+
+const COLOR_PATTERN =
+  /^#(?:[0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
+const MAX_METADATA_BYTES = 64 * 1024;
+const MAX_STRING_LENGTH = 240;
+const MAX_DESCRIPTION_LENGTH = 1_200;
+const MAX_CARD_COUNT = 8;
+const MAX_CARD_LINK_COUNT = 5;
+const MAX_CARD_ITEM_COUNT = 6;
+const MAX_ACTION_COUNT = 8;
+const MAX_ACTION_FIELD_COUNT = 12;
+const MAX_OPTION_COUNT = 8;
+const MAX_RESOURCE_VIEW_COUNT = 6;
+const MAX_RESOURCE_COLUMN_COUNT = 8;
+const MAX_MODULE_COUNT = 8;
+const MAX_STRING_LIST_COUNT = 8;
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0']);
+
 export const DEFAULT_BLUEPRINT_UI_DRAFT: BlueprintUiAuthoringDraft = {
   requestedSlug: '',
   publisherNamespace: '',
@@ -69,18 +174,48 @@ export const DEFAULT_BLUEPRINT_UI_DRAFT: BlueprintUiAuthoringDraft = {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
-const readTrimmedString = (value: unknown): string | undefined => {
+const readTrimmedString = (
+  value: unknown,
+  maxLength = MAX_STRING_LENGTH,
+): string | undefined => {
   if (typeof value !== 'string') {
     return undefined;
   }
 
   const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
+  if (!trimmed) {
+    return undefined;
+  }
+
+  return trimmed.slice(0, maxLength);
 };
 
-const readNullableString = (value: unknown): string | null => {
-  const trimmed = readTrimmedString(value);
+const readNullableString = (
+  value: unknown,
+  maxLength = MAX_STRING_LENGTH,
+): string | null => {
+  const trimmed = readTrimmedString(value, maxLength);
   return trimmed ?? null;
+};
+
+const readStringArray = (
+  value: unknown,
+  maxItems = MAX_STRING_LIST_COUNT,
+  maxLength = MAX_STRING_LENGTH,
+): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => readTrimmedString(entry, maxLength))
+    .filter(Boolean)
+    .slice(0, maxItems) as string[];
+};
+
+const readColor = (value: unknown): string | undefined => {
+  const color = readTrimmedString(value, 16);
+  return color && COLOR_PATTERN.test(color) ? color : undefined;
 };
 
 const isValidHttpUrl = (value: string | undefined): value is string => {
@@ -96,6 +231,18 @@ const isValidHttpUrl = (value: string | undefined): value is string => {
   }
 };
 
+const isValidHttpsUrl = (value: string | undefined): value is string => {
+  if (!value) {
+    return false;
+  }
+
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
 export const sanitizeBlueprintSlug = (value: string): string =>
   value
     .trim()
@@ -105,7 +252,7 @@ export const sanitizeBlueprintSlug = (value: string): string =>
     .replace(/-{2,}/g, '-');
 
 const normalizeResourceRoute = (value: unknown): BlueprintResourceRoute => {
-  const route = readTrimmedString(value)?.toLowerCase();
+  const route = readTrimmedString(value, 32)?.toLowerCase();
   if (
     route &&
     RESOURCE_ROUTE_VALUES.includes(route as BlueprintResourceRoute)
@@ -158,18 +305,607 @@ const normalizeExternalApp = (
     return undefined;
   }
 
-  const url = readTrimmedString(value.url);
-  if (!isValidHttpUrl(url)) {
+  const url = readTrimmedString(value.url, 2_048);
+  if (!isValidHttpsUrl(url)) {
     return undefined;
   }
 
-  const mode = readTrimmedString(value.mode)?.toLowerCase();
+  const mode = readTrimmedString(value.mode, 16)?.toLowerCase();
   return {
     url,
-    mode: EXTERNAL_APP_MODE_VALUES.has(mode as BlueprintUiExternalAppMode)
-      ? (mode as BlueprintUiExternalAppMode)
-      : 'link',
+    // Third-party iframe embedding is disabled; safe handoff is link-out only.
+    mode:
+      mode === 'link' &&
+      EXTERNAL_APP_MODE_VALUES.has(mode as BlueprintUiExternalAppMode)
+        ? 'link'
+        : 'link',
   };
+};
+
+const parseTheme = (value: unknown): BlueprintUiTheme | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const theme: BlueprintUiTheme = {
+    accentColor: readColor(value.accentColor),
+    secondaryColor: readColor(value.secondaryColor),
+    badgeLabel: readTrimmedString(value.badgeLabel, 80),
+  };
+
+  const icon = readTrimmedString(value.icon, 24)?.toLowerCase();
+  if (icon && THEME_ICON_VALUES.has(icon as BlueprintUiThemeIcon)) {
+    theme.icon = icon as BlueprintUiThemeIcon;
+  }
+
+  return Object.keys(theme).length > 0 ? theme : undefined;
+};
+
+const parseOverviewCards = (value: unknown): BlueprintUiOverviewCard[] | undefined => {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const cards = value
+    .slice(0, MAX_CARD_COUNT)
+    .flatMap((entry, index) => {
+      if (!isRecord(entry)) {
+        return [];
+      }
+
+      const title = readTrimmedString(entry.title, 80);
+      const kind = readTrimmedString(entry.kind, 32)?.toLowerCase();
+      if (!title || !kind || !CARD_KIND_VALUES.has(kind as BlueprintUiCardKind)) {
+        return [];
+      }
+
+      const tone = readTrimmedString(entry.tone, 24)?.toLowerCase();
+      const links = Array.isArray(entry.links)
+        ? entry.links
+            .slice(0, MAX_CARD_LINK_COUNT)
+            .flatMap((link) => {
+              if (!isRecord(link)) {
+                return [];
+              }
+
+              const label = readTrimmedString(link.label, 60);
+              const href = readTrimmedString(link.href, 2_048);
+              if (!label || !isValidHttpsUrl(href)) {
+                return [];
+              }
+
+              return [{ label, href }];
+            })
+        : undefined;
+      const items = readStringArray(entry.items, MAX_CARD_ITEM_COUNT, 120);
+
+      return [
+        {
+          id:
+            sanitizeBlueprintSlug(readTrimmedString(entry.id, 60) ?? '') ||
+            `card-${index + 1}`,
+          kind: kind as BlueprintUiCardKind,
+          title,
+          description: readTrimmedString(entry.description, 240),
+          value: readTrimmedString(entry.value, 80),
+          tone: CARD_TONE_VALUES.has(tone as BlueprintUiCardTone)
+            ? (tone as BlueprintUiCardTone)
+            : undefined,
+          ...(links && links.length > 0 ? { links } : {}),
+          ...(items.length > 0 ? { items } : {}),
+        } satisfies BlueprintUiOverviewCard,
+      ];
+    });
+
+  return cards.length > 0 ? cards : undefined;
+};
+
+const parseActionFields = (value: unknown): BlueprintUiActionField[] | undefined => {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const fields = value
+    .slice(0, MAX_ACTION_FIELD_COUNT)
+    .flatMap((entry) => {
+      if (!isRecord(entry)) {
+        return [];
+      }
+
+      const key =
+        sanitizeBlueprintSlug(readTrimmedString(entry.key, 60) ?? '').replace(
+          /-/g,
+          '_',
+        );
+      const label = readTrimmedString(entry.label, 80);
+      const input = readTrimmedString(entry.input, 24)?.toLowerCase();
+
+      if (
+        !key ||
+        !label ||
+        !input ||
+        !ACTION_FIELD_INPUT_VALUES.has(input as BlueprintUiActionFieldInput)
+      ) {
+        return [];
+      }
+
+      const options = Array.isArray(entry.options)
+        ? entry.options
+            .slice(0, MAX_OPTION_COUNT)
+            .flatMap((option) => {
+              if (!isRecord(option)) {
+                return [];
+              }
+
+              const optionLabel = readTrimmedString(option.label, 60);
+              const optionValue = readTrimmedString(option.value, 60);
+              if (!optionLabel || !optionValue) {
+                return [];
+              }
+
+              return [{ label: optionLabel, value: optionValue }];
+            })
+        : undefined;
+
+      return [
+        {
+          key,
+          label,
+          input: input as BlueprintUiActionFieldInput,
+          required: entry.required === true,
+          placeholder: readTrimmedString(entry.placeholder, 120),
+          helpText: readTrimmedString(entry.helpText, 160),
+          ...(options && options.length > 0 ? { options } : {}),
+        } satisfies BlueprintUiActionField,
+      ];
+    });
+
+  return fields.length > 0 ? fields : undefined;
+};
+
+const parseActions = (value: unknown): BlueprintUiAction[] | undefined => {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const actions = value
+    .slice(0, MAX_ACTION_COUNT)
+    .flatMap((entry, index) => {
+      if (!isRecord(entry)) {
+        return [];
+      }
+
+      const label = readTrimmedString(entry.label, 80);
+      const target = readTrimmedString(entry.target, 24)?.toLowerCase();
+      if (
+        !label ||
+        !target ||
+        !ACTION_TARGET_VALUES.has(target as BlueprintUiActionTarget)
+      ) {
+        return [];
+      }
+
+      const href = readTrimmedString(entry.href, 2_048);
+      const fields = parseActionFields(entry.fields);
+
+      if (!fields && !isValidHttpsUrl(href)) {
+        return [];
+      }
+
+      return [
+        {
+          id:
+            sanitizeBlueprintSlug(readTrimmedString(entry.id, 60) ?? '') ||
+            `action-${index + 1}`,
+          label,
+          description: readTrimmedString(entry.description, 240),
+          target: target as BlueprintUiActionTarget,
+          submitLabel: readTrimmedString(entry.submitLabel, 60),
+          ...(isValidHttpsUrl(href) ? { href } : {}),
+          ...(fields ? { fields } : {}),
+        } satisfies BlueprintUiAction,
+      ];
+    });
+
+  return actions.length > 0 ? actions : undefined;
+};
+
+const parseResourceViews = (
+  value: unknown,
+): BlueprintUiResourceView[] | undefined => {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const views = value
+    .slice(0, MAX_RESOURCE_VIEW_COUNT)
+    .flatMap((entry, index) => {
+      if (!isRecord(entry)) {
+        return [];
+      }
+
+      const title = readTrimmedString(entry.title, 80);
+      const kind = readTrimmedString(entry.kind, 24)?.toLowerCase();
+      const target = readTrimmedString(entry.target, 24)?.toLowerCase();
+      if (
+        !title ||
+        !kind ||
+        !target ||
+        !RESOURCE_VIEW_KIND_VALUES.has(kind as BlueprintUiResourceViewKind) ||
+        !RESOURCE_VIEW_TARGET_VALUES.has(
+          target as BlueprintUiResourceViewTarget,
+        )
+      ) {
+        return [];
+      }
+
+      const columns = Array.isArray(entry.columns)
+        ? entry.columns
+            .slice(0, MAX_RESOURCE_COLUMN_COUNT)
+            .flatMap((column) => {
+              if (!isRecord(column)) {
+                return [];
+              }
+
+              const key =
+                sanitizeBlueprintSlug(
+                  readTrimmedString(column.key, 60) ?? '',
+                ).replace(/-/g, '_');
+              const label = readTrimmedString(column.label, 60);
+
+              if (!key || !label) {
+                return [];
+              }
+
+              return [
+                {
+                  key,
+                  label,
+                  emphasis: column.emphasis === true,
+                },
+              ];
+            })
+        : [];
+
+      if (columns.length === 0) {
+        return [];
+      }
+
+      return [
+        {
+          id:
+            sanitizeBlueprintSlug(readTrimmedString(entry.id, 60) ?? '') ||
+            `view-${index + 1}`,
+          title,
+          kind: kind as BlueprintUiResourceViewKind,
+          target: target as BlueprintUiResourceViewTarget,
+          defaultSort: readTrimmedString(entry.defaultSort, 60),
+          columns,
+        } satisfies BlueprintUiResourceView,
+      ];
+    });
+
+  return views.length > 0 ? views : undefined;
+};
+
+const parseModules = (value: unknown): BlueprintUiModuleBinding[] | undefined => {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const modules = value
+    .slice(0, MAX_MODULE_COUNT)
+    .flatMap((entry) => {
+      if (!isRecord(entry)) {
+        return [];
+      }
+
+      const moduleKey = readTrimmedString(entry.module, 40)?.toLowerCase();
+      const slot = readTrimmedString(entry.slot, 24)?.toLowerCase();
+      if (
+        !moduleKey ||
+        !slot ||
+        !MODULE_KEY_VALUES.has(moduleKey as BlueprintUiModuleKey) ||
+        !MODULE_SLOT_VALUES.has(slot as BlueprintUiModuleSlot)
+      ) {
+        return [];
+      }
+
+      return [
+        {
+          module: moduleKey as BlueprintUiModuleKey,
+          slot: slot as BlueprintUiModuleSlot,
+          title: readTrimmedString(entry.title, 80),
+          metricKeys: readStringArray(entry.metricKeys, MAX_STRING_LIST_COUNT, 48),
+          eventKinds: readStringArray(entry.eventKinds, MAX_STRING_LIST_COUNT, 48),
+        } satisfies BlueprintUiModuleBinding,
+      ];
+    })
+    .map((module) => ({
+      ...module,
+      ...(module.metricKeys.length > 0 ? {} : { metricKeys: undefined }),
+      ...(module.eventKinds.length > 0 ? {} : { eventKinds: undefined }),
+    }));
+
+  return modules.length > 0 ? modules : undefined;
+};
+
+const sanitizePublicUrl = (
+  value: unknown,
+  options?: { allowIpfs?: boolean },
+): string | null => {
+  const raw = readTrimmedString(value, 2_048);
+  if (!raw) {
+    return null;
+  }
+
+  if (options?.allowIpfs === true && raw.startsWith('ipfs://')) {
+    return raw;
+  }
+
+  return isValidHttpUrl(raw) ? raw : null;
+};
+
+const toMetadataSource = (
+  metadataUri: string | null | undefined,
+): BlueprintMetadataVerification['source'] => {
+  if (!metadataUri) {
+    return 'missing';
+  }
+
+  return metadataUri.startsWith('ipfs://') ? 'ipfs' : 'http';
+};
+
+const isLocalBlueprintHostRuntime = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return LOCAL_HOSTNAMES.has(window.location.hostname);
+};
+
+export const requiresIpfsForBlueprintMetadata = (): boolean =>
+  !isLocalBlueprintHostRuntime();
+
+export const isAllowedBlueprintMetadataUri = (metadataUri: string): boolean =>
+  metadataUri.startsWith('ipfs://') || !requiresIpfsForBlueprintMetadata();
+
+const sortMetadataValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(sortMetadataValue);
+  }
+
+  if (isRecord(value)) {
+    return Object.keys(value)
+      .sort()
+      .reduce<Record<string, unknown>>((result, key) => {
+        result[key] = sortMetadataValue(value[key]);
+        return result;
+      }, {});
+  }
+
+  return value;
+};
+
+const stripMetadataAttestation = (
+  value: Record<string, unknown>,
+): Record<string, unknown> => {
+  const { integrity: _integrity, ...rest } = value;
+  return rest;
+};
+
+const toCanonicalMetadataJson = (value: Record<string, unknown>): string =>
+  JSON.stringify(sortMetadataValue(value));
+
+export const computeBlueprintMetadataPayloadHash = (
+  value: Record<string, unknown>,
+): Hex => keccak256(toHex(new TextEncoder().encode(toCanonicalMetadataJson(value))));
+
+const parseBlueprintMetadataAttestation = (
+  value: unknown,
+): BlueprintMetadataAttestation | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const schema = readTrimmedString(value.schema, 64);
+  const signer = readTrimmedString(value.signer, 128);
+  const signature = readTrimmedString(value.signature, 256);
+  const payloadHash = readTrimmedString(value.payloadHash, 128);
+
+  if (
+    schema !== 'tangle-blueprint-metadata/v1' ||
+    !signer ||
+    !signature?.startsWith('0x') ||
+    !payloadHash?.startsWith('0x')
+  ) {
+    return null;
+  }
+
+  try {
+    return {
+      schema: 'tangle-blueprint-metadata/v1',
+      signer: getAddress(signer),
+      signature: signature as `0x${string}`,
+      payloadHash: payloadHash as `0x${string}`,
+      signedAt: readTrimmedString(value.signedAt, 64),
+    };
+  } catch {
+    return null;
+  }
+};
+
+export const buildBlueprintMetadataAttestationMessage = ({
+  blueprintId,
+  owner,
+  metadataUri,
+  payloadHash,
+}: {
+  blueprintId: bigint;
+  owner: Address;
+  metadataUri: string;
+  payloadHash: Hex;
+}): string =>
+  [
+    'Tangle Blueprint Metadata Attestation',
+    'schema: tangle-blueprint-metadata/v1',
+    `blueprintId: ${blueprintId.toString()}`,
+    `owner: ${owner.toLowerCase()}`,
+    `metadataUri: ${metadataUri}`,
+    `payloadHash: ${payloadHash}`,
+  ].join('\n');
+
+const buildDefaultMetadataVerification = ({
+  metadataUri,
+  status,
+  reason,
+  signer,
+  payloadHash,
+}: {
+  metadataUri?: string | null;
+  status: BlueprintMetadataVerification['status'];
+  reason: string;
+  signer?: string;
+  payloadHash?: Hex;
+}): BlueprintMetadataVerification => {
+  const source = toMetadataSource(metadataUri);
+  const productionReady =
+    status === 'verified' &&
+    (metadataUri ? isAllowedBlueprintMetadataUri(metadataUri) : false);
+
+  return {
+    status,
+    productionReady,
+    source,
+    signer,
+    payloadHash,
+    reason,
+  };
+};
+
+export const verifyBlueprintMetadataIntegrity = async ({
+  rawMetadata,
+  metadataUri,
+  metadataHash,
+  blueprintId,
+  owner,
+}: {
+  rawMetadata: Record<string, unknown> | null;
+  metadataUri: string | null;
+  metadataHash?: Hex | null;
+  blueprintId?: bigint;
+  owner?: Address;
+}): Promise<BlueprintMetadataVerification> => {
+  if (!metadataUri) {
+    return buildDefaultMetadataVerification({
+      status: 'unverified',
+      reason: 'No metadata URI was published onchain.',
+    });
+  }
+
+  if (!rawMetadata) {
+    return buildDefaultMetadataVerification({
+      metadataUri,
+      status: 'invalid',
+      reason: 'Metadata payload could not be parsed as a JSON object.',
+    });
+  }
+
+  if (!isAllowedBlueprintMetadataUri(metadataUri)) {
+    return buildDefaultMetadataVerification({
+      metadataUri,
+      status: 'invalid',
+      reason:
+        'Production shared hosting only accepts metadata published to ipfs:// URIs.',
+    });
+  }
+
+  const attestation = parseBlueprintMetadataAttestation(rawMetadata.integrity);
+  const payloadHash = computeBlueprintMetadataPayloadHash(
+    stripMetadataAttestation(rawMetadata),
+  );
+
+  if (metadataHash && metadataHash.toLowerCase() !== payloadHash.toLowerCase()) {
+    return buildDefaultMetadataVerification({
+      metadataUri,
+      status: 'invalid',
+      payloadHash,
+      reason: 'Fetched metadata did not match the onchain pinned payload hash.',
+    });
+  }
+
+  if (!attestation) {
+    return buildDefaultMetadataVerification({
+      metadataUri,
+      status: 'unverified',
+      payloadHash,
+      reason:
+        'No valid metadata attestation was published. Falling back to protocol-controlled surfaces.',
+    });
+  }
+
+  if (!owner || blueprintId === undefined) {
+    return buildDefaultMetadataVerification({
+      metadataUri,
+      status: 'unverified',
+      signer: attestation.signer,
+      payloadHash,
+      reason:
+        'Metadata attestation was present, but the onchain blueprint context needed to verify it was unavailable.',
+    });
+  }
+
+  if (attestation.payloadHash.toLowerCase() !== payloadHash.toLowerCase()) {
+    return buildDefaultMetadataVerification({
+      metadataUri,
+      status: 'invalid',
+      signer: attestation.signer,
+      payloadHash,
+      reason:
+        'Metadata attestation payload hash did not match the fetched document.',
+    });
+  }
+
+  if (!isAddressEqual(attestation.signer as Address, owner)) {
+    return buildDefaultMetadataVerification({
+      metadataUri,
+      status: 'invalid',
+      signer: attestation.signer,
+      payloadHash,
+      reason:
+        'Metadata attestation signer does not match the onchain blueprint owner.',
+    });
+  }
+
+  const verified = await verifyMessage({
+    address: owner,
+    message: buildBlueprintMetadataAttestationMessage({
+      blueprintId,
+      owner,
+      metadataUri,
+      payloadHash,
+    }),
+    signature: attestation.signature,
+  });
+
+  if (!verified) {
+    return buildDefaultMetadataVerification({
+      metadataUri,
+      status: 'invalid',
+      signer: attestation.signer,
+      payloadHash,
+      reason: 'Metadata attestation signature verification failed.',
+    });
+  }
+
+  return buildDefaultMetadataVerification({
+    metadataUri,
+    status: 'verified',
+    signer: owner,
+    payloadHash,
+    reason:
+      'Metadata attestation verified against the onchain blueprint owner and payload hash.',
+  });
 };
 
 export const parseBlueprintUiContract = (
@@ -187,10 +923,10 @@ export const parseBlueprintUiContract = (
   const publisherValue = isRecord(value.publisher) ? value.publisher : {};
   const publisher: BlueprintUiPublisher = {
     name:
-      readTrimmedString(publisherValue.name) ??
+      readTrimmedString(publisherValue.name, 80) ??
       fallback?.author ??
       'Unknown publisher',
-    namespace: readTrimmedString(publisherValue.namespace),
+    namespace: readTrimmedString(publisherValue.namespace, 60),
     verified:
       publisherValue.verified === true ||
       publisherValue.verification === 'verified' ||
@@ -198,36 +934,55 @@ export const parseBlueprintUiContract = (
   };
 
   const requestedSlug = sanitizeBlueprintSlug(
-    readTrimmedString(value.requestedSlug) ?? '',
+    readTrimmedString(value.requestedSlug, 80) ??
+      readTrimmedString(value.slug, 80) ??
+      '',
   );
 
   const resourcesValue = isRecord(value.resources) ? value.resources : {};
   const surfaces = normalizeSurfaces(value.surfaces);
+  const theme = parseTheme(value.theme);
+  const overviewCards = parseOverviewCards(value.overviewCards);
+  const actions = parseActions(value.actions);
+  const resourceViews = parseResourceViews(value.resourceViews);
+  const modules = parseModules(value.modules);
   const externalApp = normalizeExternalApp(value.externalApp);
+  const hasDeclarativeContent =
+    surfaces.length > 0 ||
+    overviewCards !== undefined ||
+    actions !== undefined ||
+    resourceViews !== undefined ||
+    modules !== undefined;
 
   return {
     displayName:
-      readTrimmedString(value.displayName) ??
+      readTrimmedString(value.displayName, 80) ??
       fallback?.name ??
       'Unknown Blueprint',
     description:
-      readTrimmedString(value.description) ??
+      readTrimmedString(value.description, MAX_DESCRIPTION_LENGTH) ??
       fallback?.description ??
       'No shared host metadata available yet.',
     requestedSlug: requestedSlug || undefined,
     canonicalSlug: buildCanonicalSlug(requestedSlug || undefined, publisher),
     publisher,
     resources: {
-      serviceLabel: readTrimmedString(resourcesValue.serviceLabel) ?? 'Service',
-      itemLabel: readTrimmedString(resourcesValue.itemLabel) ?? 'Resource',
+      serviceLabel:
+        readTrimmedString(resourcesValue.serviceLabel, 60) ?? 'Service',
+      itemLabel: readTrimmedString(resourcesValue.itemLabel, 60) ?? 'Resource',
       itemRoute: normalizeResourceRoute(resourcesValue.itemRoute),
     },
     surfaces,
-    externalApp,
+    ...(theme ? { theme } : {}),
+    ...(overviewCards ? { overviewCards } : {}),
+    ...(actions ? { actions } : {}),
+    ...(resourceViews ? { resourceViews } : {}),
+    ...(modules ? { modules } : {}),
+    ...(externalApp ? { externalApp } : {}),
     tier:
       externalApp !== undefined
         ? 'link-out'
-        : surfaces.length > 0
+        : hasDeclarativeContent
           ? 'declarative'
           : 'generic',
   };
@@ -245,36 +1000,86 @@ export const parseBlueprintMetadataDocument = (
       imageUrl: null,
       codeUrl: null,
       website: null,
+      attestation: null,
+      verification: buildDefaultMetadataVerification({
+        status: 'invalid',
+        reason: 'Metadata document was not a JSON object.',
+      }),
       blueprintUi: null,
     };
   }
 
-  const name = readTrimmedString(value.name) ?? 'Unknown Blueprint';
+  const name = readTrimmedString(value.name, 80) ?? 'Unknown Blueprint';
   const description =
-    readTrimmedString(value.description) ?? 'No description available';
-  const author = readTrimmedString(value.author) ?? 'Unknown';
+    readTrimmedString(value.description, MAX_DESCRIPTION_LENGTH) ??
+    'No description available';
+  const author = readTrimmedString(value.author, 80) ?? 'Unknown';
+  const attestation = parseBlueprintMetadataAttestation(value.integrity);
 
   return {
     name,
     description,
     author,
-    category: readTrimmedString(value.category) ?? 'Other',
+    category: readTrimmedString(value.category, 60) ?? 'Other',
     imageUrl:
-      readNullableString(value.image) ??
-      readNullableString(value.imageUrl) ??
-      readNullableString(value.logo),
+      sanitizePublicUrl(value.image, { allowIpfs: true }) ??
+      sanitizePublicUrl(value.imageUrl, { allowIpfs: true }) ??
+      sanitizePublicUrl(value.logo, { allowIpfs: true }),
     codeUrl:
-      readNullableString(value.codeUrl) ??
-      readNullableString(value.codeRepository) ??
-      readNullableString(value.repository),
+      sanitizePublicUrl(value.codeUrl) ??
+      sanitizePublicUrl(value.codeRepository) ??
+      sanitizePublicUrl(value.repository),
     website:
-      readNullableString(value.website) ?? readNullableString(value.homepage),
+      sanitizePublicUrl(value.website) ?? sanitizePublicUrl(value.homepage),
+    attestation,
+    verification: buildDefaultMetadataVerification({
+      status: attestation ? 'unverified' : 'unverified',
+      signer: attestation?.signer,
+      payloadHash: attestation?.payloadHash,
+      reason: attestation
+        ? 'Metadata attestation was found and is waiting for onchain verification.'
+        : 'No metadata attestation was published.',
+    }),
     blueprintUi: parseBlueprintUiContract(value.blueprintUi, {
       name,
       description,
       author,
     }),
   };
+};
+
+export const parseBlueprintMetadataJsonText = (
+  text: string,
+): {
+  parsed: ParsedBlueprintMetadata;
+  rawMetadata: Record<string, unknown> | null;
+} => {
+  const bytes = new TextEncoder().encode(text).length;
+  if (bytes > MAX_METADATA_BYTES) {
+    throw new Error(
+      `Blueprint metadata exceeded ${MAX_METADATA_BYTES} bytes and was rejected by the hosted runtime.`,
+    );
+  }
+
+  const metadata: unknown = JSON.parse(text);
+  const rawMetadata =
+    metadata && typeof metadata === 'object' && !Array.isArray(metadata)
+      ? (metadata as Record<string, unknown>)
+      : null;
+
+  return {
+    parsed: parseBlueprintMetadataDocument(metadata),
+    rawMetadata,
+  };
+};
+
+export const resolveBlueprintMetadataFetchUrl = (metadataUri: string): string => {
+  if (!metadataUri.startsWith('ipfs://')) {
+    return metadataUri;
+  }
+
+  const cid = metadataUri.replace('ipfs://', '');
+  return `https://ipfs.io/ipfs/${cid}`;
 };
 
 export const buildBlueprintUiMetadataDocument = ({
@@ -304,24 +1109,24 @@ export const buildBlueprintUiMetadataDocument = ({
     description,
     author,
     category,
-    image: readTrimmedString(logo) ?? null,
-    logo: readTrimmedString(logo) ?? null,
-    website: readTrimmedString(website) ?? null,
-    codeRepository: readTrimmedString(codeRepository) ?? null,
+    image: readTrimmedString(logo, 2_048) ?? null,
+    logo: readTrimmedString(logo, 2_048) ?? null,
+    website: readTrimmedString(website, 2_048) ?? null,
+    codeRepository: readTrimmedString(codeRepository, 2_048) ?? null,
     blueprintUi: {
-      displayName: readTrimmedString(name) ?? 'Unnamed Blueprint',
+      displayName: readTrimmedString(name, 80) ?? 'Unnamed Blueprint',
       description:
-        readTrimmedString(description) ??
+        readTrimmedString(description, MAX_DESCRIPTION_LENGTH) ??
         'Third-party blueprint hosted through the shared Tangle Cloud runtime.',
       requestedSlug: requestedSlug || undefined,
       publisher: {
-        name: readTrimmedString(author) ?? 'Unknown publisher',
-        namespace: readTrimmedString(draft.publisherNamespace),
+        name: readTrimmedString(author, 80) ?? 'Unknown publisher',
+        namespace: readTrimmedString(draft.publisherNamespace, 60),
         verified: false,
       },
       resources: {
-        serviceLabel: readTrimmedString(draft.serviceNoun) ?? 'Service',
-        itemLabel: readTrimmedString(draft.resourceNoun) ?? 'Resource',
+        serviceLabel: readTrimmedString(draft.serviceNoun, 60) ?? 'Service',
+        itemLabel: readTrimmedString(draft.resourceNoun, 60) ?? 'Resource',
         itemRoute: draft.resourceRoute,
       },
       surfaces: {
@@ -335,10 +1140,10 @@ export const buildBlueprintUiMetadataDocument = ({
         metrics: draft.surfaces.includes('metrics'),
         permissions: draft.surfaces.includes('permissions'),
       },
-      externalApp: isValidHttpUrl(readTrimmedString(draft.externalAppUrl))
+      externalApp: isValidHttpsUrl(readTrimmedString(draft.externalAppUrl, 2_048))
         ? {
             url: draft.externalAppUrl.trim(),
-            mode: draft.externalAppMode,
+            mode: 'link',
           }
         : undefined,
     },

--- a/libs/tangle-shared-ui/src/blueprintApps/types.ts
+++ b/libs/tangle-shared-ui/src/blueprintApps/types.ts
@@ -19,6 +19,60 @@ export type BlueprintResourceRoute =
 
 export type BlueprintUiExternalAppMode = 'link' | 'iframe';
 
+export type BlueprintMetadataAttestation = {
+  schema: 'tangle-blueprint-metadata/v1';
+  signer: string;
+  signature: `0x${string}`;
+  payloadHash: `0x${string}`;
+  signedAt?: string;
+};
+
+export type BlueprintMetadataVerificationStatus =
+  | 'verified'
+  | 'unverified'
+  | 'invalid';
+
+export type BlueprintMetadataVerification = {
+  status: BlueprintMetadataVerificationStatus;
+  productionReady: boolean;
+  source: 'ipfs' | 'http' | 'missing';
+  signer?: string;
+  payloadHash?: `0x${string}`;
+  reason: string;
+};
+
+export type BlueprintUiThemeIcon = 'bot' | 'shield' | 'graph' | 'spark';
+
+export type BlueprintUiCardKind = 'stat' | 'callout' | 'links' | 'checklist';
+
+export type BlueprintUiCardTone = 'neutral' | 'info' | 'success' | 'warning';
+
+export type BlueprintUiActionFieldInput =
+  | 'text'
+  | 'textarea'
+  | 'number'
+  | 'select'
+  | 'toggle';
+
+export type BlueprintUiActionTarget = 'blueprint' | 'service' | 'resource';
+
+export type BlueprintUiResourceViewKind = 'table' | 'grid' | 'timeline';
+
+export type BlueprintUiResourceViewTarget = 'service' | 'resource';
+
+export type BlueprintUiModuleKey =
+  | 'metrics-overview'
+  | 'service-health'
+  | 'resource-events'
+  | 'permissions-matrix'
+  | 'activity-feed';
+
+export type BlueprintUiModuleSlot =
+  | 'overview'
+  | 'sidebar'
+  | 'actions'
+  | 'resources';
+
 export type BlueprintUiAuthoringDraft = {
   requestedSlug: string;
   publisherNamespace: string;
@@ -49,6 +103,77 @@ export type BlueprintUiExternalApp = {
 
 export type BlueprintUiTier = 'generic' | 'declarative' | 'link-out';
 
+export type BlueprintUiTheme = {
+  accentColor?: string;
+  secondaryColor?: string;
+  badgeLabel?: string;
+  icon?: BlueprintUiThemeIcon;
+};
+
+export type BlueprintUiCardLink = {
+  label: string;
+  href: string;
+};
+
+export type BlueprintUiOverviewCard = {
+  id: string;
+  kind: BlueprintUiCardKind;
+  title: string;
+  description?: string;
+  value?: string;
+  tone?: BlueprintUiCardTone;
+  links?: BlueprintUiCardLink[];
+  items?: string[];
+};
+
+export type BlueprintUiActionFieldOption = {
+  label: string;
+  value: string;
+};
+
+export type BlueprintUiActionField = {
+  key: string;
+  label: string;
+  input: BlueprintUiActionFieldInput;
+  required: boolean;
+  placeholder?: string;
+  helpText?: string;
+  options?: BlueprintUiActionFieldOption[];
+};
+
+export type BlueprintUiAction = {
+  id: string;
+  label: string;
+  description?: string;
+  target: BlueprintUiActionTarget;
+  submitLabel?: string;
+  href?: string;
+  fields?: BlueprintUiActionField[];
+};
+
+export type BlueprintUiResourceViewColumn = {
+  key: string;
+  label: string;
+  emphasis?: boolean;
+};
+
+export type BlueprintUiResourceView = {
+  id: string;
+  title: string;
+  kind: BlueprintUiResourceViewKind;
+  target: BlueprintUiResourceViewTarget;
+  defaultSort?: string;
+  columns: BlueprintUiResourceViewColumn[];
+};
+
+export type BlueprintUiModuleBinding = {
+  module: BlueprintUiModuleKey;
+  slot: BlueprintUiModuleSlot;
+  title?: string;
+  metricKeys?: string[];
+  eventKinds?: string[];
+};
+
 export type BlueprintUiContract = {
   displayName: string;
   description: string;
@@ -57,6 +182,11 @@ export type BlueprintUiContract = {
   publisher: BlueprintUiPublisher;
   resources: BlueprintUiResources;
   surfaces: BlueprintUiSurface[];
+  theme?: BlueprintUiTheme;
+  overviewCards?: BlueprintUiOverviewCard[];
+  actions?: BlueprintUiAction[];
+  resourceViews?: BlueprintUiResourceView[];
+  modules?: BlueprintUiModuleBinding[];
   externalApp?: BlueprintUiExternalApp;
   tier: BlueprintUiTier;
 };
@@ -69,5 +199,7 @@ export type ParsedBlueprintMetadata = {
   imageUrl: string | null;
   codeUrl: string | null;
   website: string | null;
+  attestation: BlueprintMetadataAttestation | null;
+  verification: BlueprintMetadataVerification;
   blueprintUi: BlueprintUiContract | null;
 };

--- a/libs/tangle-shared-ui/src/data/graphql/useBlueprintManagement.ts
+++ b/libs/tangle-shared-ui/src/data/graphql/useBlueprintManagement.ts
@@ -18,6 +18,10 @@ import {
   executeEnvioGraphQL,
   EnvioNetwork,
 } from '../../utils/executeEnvioGraphQL';
+import {
+  parseBlueprintMetadataJsonText,
+  resolveBlueprintMetadataFetchUrl,
+} from '../../blueprintApps/authoring';
 import isUserRejectionError from '../../utils/isUserRejectionError';
 import useContractWrite, {
   TxStatus as ContractTxStatus,
@@ -103,6 +107,7 @@ export type SupportedMemberships = number[];
 // Blueprint definition for creation (matches ABI structure)
 export interface BlueprintDefinition {
   metadataUri: string; // IPFS or HTTPS URL
+  metadataHash: `0x${string}`;
   manager: Address; // Service manager contract (address(0) for none)
   masterManagerRevision: number;
   hasConfig: boolean;
@@ -123,6 +128,7 @@ export interface OwnedBlueprint {
   owner: Address;
   manager: Address | null;
   metadataUri: string | null;
+  metadataHash?: `0x${string}` | null;
   metadata: {
     name?: string;
     description?: string;
@@ -146,6 +152,7 @@ interface BlueprintsByOwnerResponse {
     owner: string;
     manager: string | null;
     metadataUri: string | null;
+    metadataHash: `0x${string}` | null;
     active: boolean;
     operatorCount: string;
     createdAt: string;
@@ -153,9 +160,6 @@ interface BlueprintsByOwnerResponse {
 }
 
 const METADATA_FETCH_TIMEOUT_MS = 5_000;
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
 
 const readString = (value: unknown): string | undefined => {
   if (typeof value !== 'string') {
@@ -182,6 +186,7 @@ const fetchBlueprintsByOwner = async (
         owner
         manager
         metadataUri
+        metadataHash
         active
         operatorCount
         createdAt
@@ -204,20 +209,18 @@ const fetchBlueprintsByOwner = async (
 
         if (bp.metadataUri) {
           try {
-            let fetchUrl = bp.metadataUri;
-            if (bp.metadataUri.startsWith('ipfs://')) {
-              const cid = bp.metadataUri.replace('ipfs://', '');
-              fetchUrl = `https://ipfs.io/ipfs/${cid}`;
-            }
             const controller = new AbortController();
             const timeoutId = setTimeout(
               () => controller.abort(),
               METADATA_FETCH_TIMEOUT_MS,
             );
-            const response = await fetch(fetchUrl, {
+            const response = await fetch(
+              resolveBlueprintMetadataFetchUrl(bp.metadataUri),
+              {
               signal: controller.signal,
               cache: 'no-store',
-            }).finally(() => {
+              },
+            ).finally(() => {
               clearTimeout(timeoutId);
             });
 
@@ -225,29 +228,25 @@ const fetchBlueprintsByOwner = async (
               throw new Error(`Failed to fetch metadata: ${response.status}`);
             }
 
-            const metadataJson: unknown = await response.json();
-            if (!isRecord(metadataJson)) {
-              throw new Error('Invalid metadata JSON payload');
-            }
+            const metadataText = await response.text();
+            const { parsed, rawMetadata } =
+              parseBlueprintMetadataJsonText(metadataText);
+            const metadataJson = rawMetadata;
 
-            name = readString(metadataJson.name) ?? name;
-            description = readString(metadataJson.description) ?? '';
+            name = parsed.name ?? name;
+            description = parsed.description ?? '';
             metadata = {
-              name: readString(metadataJson.name),
-              description: readString(metadataJson.description),
-              author: readString(metadataJson.author),
-              logo:
-                readString(metadataJson.logo) ?? readString(metadataJson.image),
-              website:
-                readString(metadataJson.website) ??
-                readString(metadataJson.homepage),
-              codeRepository:
-                readString(metadataJson.codeRepository) ??
-                readString(metadataJson.codeUrl) ??
-                readString(metadataJson.repository),
+              name: parsed.name,
+              description: parsed.description,
+              author: parsed.author,
+              logo: parsed.imageUrl ?? undefined,
+              website: parsed.website ?? undefined,
+              codeRepository: parsed.codeUrl ?? undefined,
               docs:
-                readString(metadataJson.docs) ??
-                readString(metadataJson.documentation),
+                metadataJson !== null
+                  ? readString(metadataJson.docs) ??
+                    readString(metadataJson.documentation)
+                  : undefined,
             };
           } catch (error) {
             console.warn('Failed to fetch owned blueprint metadata', {
@@ -266,6 +265,7 @@ const fetchBlueprintsByOwner = async (
           owner: bp.owner as Address,
           manager: bp.manager as Address | null,
           metadataUri: bp.metadataUri,
+          metadataHash: bp.metadataHash,
           metadata,
           active: bp.active,
           operatorCount: Number(bp.operatorCount),
@@ -398,14 +398,18 @@ export const useUpdateBlueprintTx = () => {
     reset,
   } = useContractWrite(
     TANGLE_ABI,
-    (params: { blueprintId: bigint; metadataUri: string }) => {
+    (params: {
+      blueprintId: bigint;
+      metadataUri: string;
+      metadataHash: `0x${string}`;
+    }) => {
       const contracts = getContractsByChainId(chainId);
 
       return {
         address: contracts.tangle,
         abi: TANGLE_ABI,
         functionName: 'updateBlueprint' as const,
-        args: [params.blueprintId, params.metadataUri] as const,
+        args: [params.blueprintId, params.metadataUri, params.metadataHash] as const,
       };
     },
     {
@@ -415,8 +419,12 @@ export const useUpdateBlueprintTx = () => {
   );
 
   const updateBlueprint = useCallback(
-    async (blueprintId: bigint, metadataUri: string): Promise<Hash | null> => {
-      const result = await execute?.({ blueprintId, metadataUri });
+    async (
+      blueprintId: bigint,
+      metadataUri: string,
+      metadataHash: `0x${string}`,
+    ): Promise<Hash | null> => {
+      const result = await execute?.({ blueprintId, metadataUri, metadataHash });
       return result?.hash ?? null;
     },
     [execute],

--- a/libs/tangle-shared-ui/src/data/graphql/useBlueprints.ts
+++ b/libs/tangle-shared-ui/src/data/graphql/useBlueprints.ts
@@ -9,8 +9,15 @@ import {
   EnvioNetwork,
 } from '../../utils/executeEnvioGraphQL';
 import type { Blueprint as AppBlueprint } from '../../types/blueprint';
-import { parseBlueprintMetadataDocument } from '../../blueprintApps/authoring';
-import type { BlueprintUiContract } from '../../blueprintApps/types';
+import {
+  parseBlueprintMetadataJsonText,
+  resolveBlueprintMetadataFetchUrl,
+  verifyBlueprintMetadataIntegrity,
+} from '../../blueprintApps/authoring';
+import type {
+  BlueprintMetadataVerification,
+  BlueprintUiContract,
+} from '../../blueprintApps/types';
 
 export interface Blueprint {
   id: string;
@@ -18,6 +25,7 @@ export interface Blueprint {
   owner: Address;
   manager: Address | null;
   metadataUri: string | null;
+  metadataHash: `0x${string}` | null;
   active: boolean;
   createdAt: bigint;
   updatedAt: bigint;
@@ -34,6 +42,7 @@ export interface BlueprintWithMetadata extends Blueprint {
   codeUrl: string | null;
   website: string | null;
   rawMetadata: Record<string, unknown> | null;
+  metadataVerification: BlueprintMetadataVerification;
   blueprintUi: BlueprintUiContract | null;
 }
 
@@ -57,6 +66,8 @@ const toAppBlueprint = (bp: BlueprintWithMetadata): AppBlueprint => ({
   twitterUrl: null,
   email: null,
   metadataUri: bp.metadataUri,
+  metadataHash: bp.metadataHash,
+  metadataVerification: bp.metadataVerification,
   blueprintUi: bp.blueprintUi,
 });
 
@@ -67,6 +78,7 @@ interface BlueprintQueryResponse {
     owner: string;
     manager: string | null;
     metadataUri: string | null;
+    metadataHash: `0x${string}` | null;
     active: boolean;
     createdAt: string;
     updatedAt: string;
@@ -74,8 +86,17 @@ interface BlueprintQueryResponse {
   }>;
 }
 
-const fetchBlueprintMetadata = async (
-  metadataUri: string | null,
+const fetchBlueprintMetadata = async ({
+  metadataUri,
+  metadataHash,
+  blueprintId,
+  owner,
+}: {
+  metadataUri: string | null;
+  metadataHash?: `0x${string}` | null;
+  blueprintId?: bigint;
+  owner?: Address;
+},
 ): Promise<{
   name: string;
   description: string;
@@ -85,6 +106,7 @@ const fetchBlueprintMetadata = async (
   codeUrl: string | null;
   website: string | null;
   rawMetadata: Record<string, unknown> | null;
+  metadataVerification: BlueprintMetadataVerification;
   blueprintUi: BlueprintUiContract | null;
 }> => {
   if (!metadataUri) {
@@ -97,33 +119,45 @@ const fetchBlueprintMetadata = async (
       codeUrl: null,
       website: null,
       rawMetadata: null,
+      metadataVerification: {
+        status: 'unverified',
+        productionReady: false,
+        source: 'missing',
+        reason: 'Metadata not published yet.',
+      },
       blueprintUi: null,
     };
   }
 
   try {
-    let fetchUrl = metadataUri;
-    if (metadataUri.startsWith('ipfs://')) {
-      const cid = metadataUri.replace('ipfs://', '');
-      fetchUrl = `https://ipfs.io/ipfs/${cid}`;
-    }
-
-    const response = await fetch(fetchUrl, {
+    const response = await fetch(resolveBlueprintMetadataFetchUrl(metadataUri), {
       signal: AbortSignal.timeout(5000),
     });
     if (!response.ok) {
       throw new Error(`Failed to fetch metadata: ${response.status}`);
     }
 
-    const metadata = await response.json();
-    const parsed = parseBlueprintMetadataDocument(metadata);
+    const metadataText = await response.text();
+    const { parsed, rawMetadata } =
+      parseBlueprintMetadataJsonText(metadataText);
+    const metadataVerification = await verifyBlueprintMetadataIntegrity({
+      rawMetadata,
+      metadataUri,
+      metadataHash,
+      blueprintId,
+      owner,
+    });
 
     return {
       ...parsed,
-      rawMetadata:
-        metadata && typeof metadata === 'object' && !Array.isArray(metadata)
-          ? (metadata as Record<string, unknown>)
-          : null,
+      rawMetadata,
+      metadataVerification,
+      blueprintUi:
+        metadataVerification.status === 'verified'
+          ? parsed.blueprintUi
+          : parsed.blueprintUi
+            ? { ...parsed.blueprintUi, externalApp: undefined, tier: 'generic' }
+            : null,
     };
   } catch (error) {
     console.error('Failed to fetch blueprint metadata:', error);
@@ -136,6 +170,12 @@ const fetchBlueprintMetadata = async (
       codeUrl: null,
       website: null,
       rawMetadata: null,
+      metadataVerification: {
+        status: 'invalid',
+        productionReady: false,
+        source: metadataUri.startsWith('ipfs://') ? 'ipfs' : 'http',
+        reason: 'Metadata endpoint unavailable or invalid.',
+      },
       blueprintUi: null,
     };
   }
@@ -160,6 +200,7 @@ const fetchBlueprints = async (
         owner
         manager
         metadataUri
+        metadataHash
         active
         createdAt
         updatedAt
@@ -187,6 +228,7 @@ const fetchBlueprints = async (
     owner: bp.owner as Address,
     manager: bp.manager as Address | null,
     metadataUri: bp.metadataUri,
+    metadataHash: bp.metadataHash,
     active: bp.active,
     createdAt: BigInt(bp.createdAt),
     updatedAt: BigInt(bp.updatedAt),
@@ -206,6 +248,7 @@ const fetchBlueprintById = async (
         owner
         manager
         metadataUri
+        metadataHash
         active
         createdAt
         updatedAt
@@ -232,6 +275,7 @@ const fetchBlueprintById = async (
     owner: bp.owner as Address,
     manager: bp.manager as Address | null,
     metadataUri: bp.metadataUri,
+    metadataHash: bp.metadataHash,
     active: bp.active,
     createdAt: BigInt(bp.createdAt),
     updatedAt: BigInt(bp.updatedAt),
@@ -283,7 +327,12 @@ export const useBlueprintsWithMetadata = (options?: {
 
       return Promise.all(
         blueprints.map(async (bp): Promise<BlueprintWithMetadata> => {
-          const metadata = await fetchBlueprintMetadata(bp.metadataUri);
+          const metadata = await fetchBlueprintMetadata({
+            metadataUri: bp.metadataUri,
+            metadataHash: bp.metadataHash,
+            blueprintId: bp.blueprintId,
+            owner: bp.owner as Address,
+          });
           return { ...bp, ...metadata };
         }),
       );
@@ -351,7 +400,12 @@ export const useBlueprint = (
       const blueprint = await fetchBlueprintById(blueprintId, network);
       if (!blueprint) return null;
 
-      const metadata = await fetchBlueprintMetadata(blueprint.metadataUri);
+      const metadata = await fetchBlueprintMetadata({
+        metadataUri: blueprint.metadataUri,
+        metadataHash: blueprint.metadataHash,
+        blueprintId: blueprint.blueprintId,
+        owner: blueprint.owner,
+      });
       return { ...blueprint, ...metadata } as BlueprintWithMetadata;
     },
     enabled: enabled && !!blueprintId,
@@ -454,7 +508,12 @@ export const useBlueprintDetails = (
       if (!blueprint) return null;
 
       const [metadata, operators] = await Promise.all([
-        fetchBlueprintMetadata(blueprint.metadataUri),
+        fetchBlueprintMetadata({
+          metadataUri: blueprint.metadataUri,
+          metadataHash: blueprint.metadataHash,
+          blueprintId: blueprint.blueprintId,
+          owner: blueprint.owner,
+        }),
         fetchBlueprintOperators(idString, network),
       ]);
 

--- a/libs/tangle-shared-ui/src/types/blueprint.ts
+++ b/libs/tangle-shared-ui/src/types/blueprint.ts
@@ -1,4 +1,7 @@
-import type { BlueprintUiContract } from '../blueprintApps/types';
+import type {
+  BlueprintMetadataVerification,
+  BlueprintUiContract,
+} from '../blueprintApps/types';
 
 // EVM-compatible blueprint types
 
@@ -89,5 +92,7 @@ export type Blueprint = {
   twitterUrl?: string | null;
   email?: string | null;
   metadataUri?: string | null;
+  metadataHash?: `0x${string}` | null;
+  metadataVerification?: BlueprintMetadataVerification | null;
   blueprintUi?: BlueprintUiContract | null;
 };


### PR DESCRIPTION
## Summary
- verify fetched blueprint metadata against the new onchain `metadataHash` before enabling advanced hosted tier-2 rendering
- include `metadataHash` in blueprint create and update flows, GraphQL ingestion, and ABI/client shapes
- harden the hosted blueprint contract tests and trust-state UI around pinned metadata verification and fail-closed fallback

## Why
`tnt-core` now pins blueprint metadata onchain and `blueprint` can submit the canonical digest at deploy time. The dapp needs to verify the fetched payload against that hash and fall back to the protocol-controlled host when verification fails.

## Notes
- verification now checks the fetched metadata payload hash before any attestation logic is trusted
- create/manage flows compute and submit the metadata hash alongside `metadataUri`
- advanced hosted tier-2 only renders when metadata verification succeeds for the current runtime

## Validation
- `NX_DAEMON=false yarn nx run tangle-cloud:typecheck`
- `NX_DAEMON=false yarn nx test tangle-cloud`
- `NX_DAEMON=false yarn nx run tangle-cloud:build`
