### PR TITLE
refactor(tangle-cloud): unify approval form to securityCommitments[]

### DIFF
--- a/apps/tangle-cloud/src/data/services/useServiceApproveTx.spec.tsx
+++ b/apps/tangle-cloud/src/data/services/useServiceApproveTx.spec.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useServiceApproveTx } from './useServiceApproveTx';
+import { TeeBackend, useServiceApproveTx } from './useServiceApproveTx';
 
 const { mockUseChainId, mockGetContractsByChainId, mockUseContractWrite } =
   vi.hoisted(() => ({
@@ -120,7 +120,7 @@ describe('useServiceApproveTx', () => {
     const blsPubkey = [1n, 2n, 3n, 4n] as const;
     const blsPopSignature = [5n, 6n] as const;
     const tee = {
-      backend: 2,
+      backend: TeeBackend.AwsNitro,
       expectedMeasurement:
         '0x1111111111111111111111111111111111111111111111111111111111111111' as const,
       nonceBinding:

--- a/apps/tangle-cloud/src/data/services/useServiceApproveTx.ts
+++ b/apps/tangle-cloud/src/data/services/useServiceApproveTx.ts
@@ -18,10 +18,24 @@ import type { ContractSecurityCommitment } from '../../types';
 
 export { TxStatus };
 
+/**
+ * Vendor-mediated TEE backends accepted by `approveService`. The on-chain enum
+ * also defines `Unset = 0` (rejected as a misconfiguration sentinel) and
+ * `DirectTdx = 5` (rejected — vendor-mediated backends only). We omit both
+ * here so the type system makes invalid backends unrepresentable.
+ */
+export const TeeBackend = {
+  Phala: 1,
+  AwsNitro: 2,
+  GcpConfidential: 3,
+  AzureSkr: 4,
+} as const;
+
+export type TeeBackendValue = (typeof TeeBackend)[keyof typeof TeeBackend];
+
 /** A TEE attestation commitment matching `Types.TeeAttestationCommitment`. */
 export interface TeeAttestationCommitment {
-  /** Backend enum index — Unset=0, Phala=1, AwsNitro=2, GcpConfidential=3, AzureSkr=4, DirectTdx=5 (rejected on-chain). */
-  backend: number;
+  backend: TeeBackendValue;
   expectedMeasurement: `0x${string}`;
   /** Must equal `teeNonceFor(requestId)` exposed by the Tangle contract. */
   nonceBinding: `0x${string}`;

--- a/apps/tangle-cloud/src/pages/instances/Instances/PendingInstanceTable.tsx
+++ b/apps/tangle-cloud/src/pages/instances/Instances/PendingInstanceTable.tsx
@@ -397,19 +397,9 @@ export const PendingInstanceTable: FC<PendingInstanceTableProps> = ({
   const onConfirmApprove = useCallback(
     async (data: ApprovalConfirmationFormFields) => {
       if (!selectedRequest || !approveServiceRequest) return;
-
-      // The unified `approveService` entrypoint derives the staking percent
-      // on-chain from `securityCommitments[0].exposureBps` (or defaults to 100%
-      // when no commitments are supplied). The form's `stakingPercent` /
-      // `tntExposureBps` inputs are no longer wired to a separate calldata
-      // field — operators that want to pin a non-default exposure must do so
-      // through `securityCommitments`.
       await approveServiceRequest({
         requestId: selectedRequest.requestId,
-        securityCommitments:
-          data.securityCommitments && data.securityCommitments.length > 0
-            ? data.securityCommitments
-            : undefined,
+        securityCommitments: data.securityCommitments,
       });
     },
     [selectedRequest, approveServiceRequest],

--- a/apps/tangle-cloud/src/pages/instances/Instances/UpdateBlueprintModel/ServiceRequestDetailModal.tsx
+++ b/apps/tangle-cloud/src/pages/instances/Instances/UpdateBlueprintModel/ServiceRequestDetailModal.tsx
@@ -46,7 +46,6 @@ type Props = {
 type FormValues = {
   requestId: bigint;
   commitments: Record<string, number>;
-  tntExposureBps: number;
 };
 
 const addCommasToNumber = (value: number) => value.toLocaleString();
@@ -112,18 +111,24 @@ const ServiceRequestDetailModal: FC<Props> = ({
   const { data: stakeByAsset, isLoading: isLoadingStake } =
     useOperatorStakeByAsset(operatorAddress, assetsToQuery);
 
+  // Seed the commitment record from every requirement on the request — including
+  // the default-TNT one when present. The contract's unified `approveService`
+  // entrypoint accepts an explicit per-asset commitment array; sending the
+  // operator's actual slider value (rather than dropping it and relying on
+  // on-chain auto-fill at the minimum) is what lets operators commit above
+  // `minExposureBps` from this UI.
   const initialCommitments = useMemo(() => {
-    if (!hasCustomRequirements || !requirements || requirements.length === 0) {
-      return {};
-    }
-
     const commitments: Record<string, number> = {};
-    for (const req of requirements) {
-      const key = toAssetMapKey(req.asset.token);
-      commitments[key] = req.minExposureBps;
+    if (requirements && requirements.length > 0) {
+      for (const req of requirements) {
+        commitments[toAssetMapKey(req.asset.token)] = req.minExposureBps;
+      }
+    } else if (defaultTntRequirement) {
+      commitments[toAssetMapKey(defaultTntRequirement.asset.token)] =
+        defaultTntRequirement.minExposureBps;
     }
     return commitments;
-  }, [hasCustomRequirements, requirements]);
+  }, [requirements, defaultTntRequirement]);
 
   const derivedSimpleStakingPercent = useMemo(() => {
     if (!contractDetails || !operatorAddress) {
@@ -177,7 +182,6 @@ const ServiceRequestDetailModal: FC<Props> = ({
     defaultValues: {
       requestId: selectedRequest?.requestId ?? BigInt(0),
       commitments: {},
-      tntExposureBps: 0,
     },
   });
 
@@ -186,15 +190,6 @@ const ServiceRequestDetailModal: FC<Props> = ({
       setValue('commitments', initialCommitments);
     }
   }, [initialCommitments, setValue]);
-
-  // Initialize tntExposureBps from default TNT requirement
-  useEffect(() => {
-    if (defaultTntRequirement && !hasCustomRequirements) {
-      setValue('tntExposureBps', defaultTntRequirement.minExposureBps, {
-        shouldValidate: true,
-      });
-    }
-  }, [defaultTntRequirement, hasCustomRequirements, setValue]);
 
   // Close modal on successful transaction
   useEffect(() => {
@@ -216,52 +211,35 @@ const ServiceRequestDetailModal: FC<Props> = ({
 
   const buildSecurityCommitments = useCallback(
     (commitments: Record<string, number>): ContractSecurityCommitment[] => {
-      if (!requirements || requirements.length === 0) {
-        return [];
-      }
+      // Map every active requirement (custom set OR the default-TNT) into a
+      // per-asset commitment using the operator's slider value, falling back
+      // to the requirement's `minExposureBps` only if the slider is unset.
+      const sourceRequirements =
+        requirements && requirements.length > 0
+          ? requirements
+          : defaultTntRequirement
+            ? [defaultTntRequirement]
+            : [];
 
-      return requirements.map((req) => {
-        const key = toAssetMapKey(req.asset.token);
-        const exposureBps = commitments[key] ?? req.minExposureBps;
-
-        return {
-          asset: {
-            kind: req.asset.kind,
-            token: req.asset.token,
-          },
-          exposureBps,
-        };
-      });
+      return sourceRequirements.map((req) => ({
+        asset: { kind: req.asset.kind, token: req.asset.token },
+        exposureBps:
+          commitments[toAssetMapKey(req.asset.token)] ?? req.minExposureBps,
+      }));
     },
-    [requirements],
+    [requirements, defaultTntRequirement],
   );
 
   const handleFormSubmit = useCallback(
     (data: FormValues) => {
-      const formattedData: ApprovalConfirmationFormFields = {
+      const securityCommitments = buildSecurityCommitments(data.commitments);
+      return onApprove({
         requestId: Number(data.requestId),
-      };
-
-      if (hasCustomRequirements) {
-        formattedData.securityCommitments = buildSecurityCommitments(
-          data.commitments,
-        );
-      } else {
-        formattedData.stakingPercent = derivedSimpleStakingPercent;
-        if (defaultTntRequirement && data.tntExposureBps > 0) {
-          formattedData.tntExposureBps = data.tntExposureBps;
-        }
-      }
-
-      return onApprove(formattedData);
+        securityCommitments:
+          securityCommitments.length > 0 ? securityCommitments : undefined,
+      });
     },
-    [
-      buildSecurityCommitments,
-      defaultTntRequirement,
-      derivedSimpleStakingPercent,
-      hasCustomRequirements,
-      onApprove,
-    ],
+    [buildSecurityCommitments, onApprove],
   );
 
   const handleApproveClick = useCallback(() => {
@@ -338,114 +316,88 @@ const ServiceRequestDetailModal: FC<Props> = ({
 
           {!isLoadingRequirements &&
             !isLoadingStake &&
-            hasCustomRequirements &&
-            requirements !== undefined && (
-              <div className="space-y-4">
-                <Text
-                  variant="body2"
-                  className="text-muted-foreground text-center"
-                >
-                  Set your exposure percentage within the allowed bounds for
-                  each asset.
-                </Text>
+            (() => {
+              // Unified rendering: every requirement on the request — custom or
+              // the default-TNT one — becomes a single per-asset slider bound to
+              // `commitments.${tokenKey}`. The contract's unified
+              // `approveService(ApprovalParams)` accepts the resulting array
+              // directly, so the operator's slider value is no longer dropped
+              // for the default-TNT case.
+              const renderable =
+                requirements && requirements.length > 0
+                  ? requirements
+                  : defaultTntRequirement
+                    ? [defaultTntRequirement]
+                    : [];
 
-                {requirements.map((req) => {
-                  const key = toAssetMapKey(req.asset.token);
-
-                  return (
-                    <Controller
-                      key={key}
-                      name={`commitments.${key}`}
-                      control={control}
-                      defaultValue={req.minExposureBps}
-                      rules={{
-                        min: {
-                          value: req.minExposureBps,
-                          message: `Must be at least ${req.minExposureBps / 100}%`,
-                        },
-                        max: {
-                          value: req.maxExposureBps,
-                          message: `Cannot exceed ${req.maxExposureBps / 100}%`,
-                        },
-                      }}
-                      render={({ field, fieldState }) => (
-                        <ExposureCommitmentInput
-                          tokenAddress={req.asset.token}
-                          assetKind={req.asset.kind}
-                          metadata={req.metadata}
-                          minExposureBps={req.minExposureBps}
-                          maxExposureBps={req.maxExposureBps}
-                          value={field.value ?? req.minExposureBps}
-                          onChange={field.onChange}
-                          errorMessage={fieldState.error?.message}
-                          delegatedAmount={getStakeForAsset(req.asset.token)}
-                        />
-                      )}
-                    />
-                  );
-                })}
-              </div>
-            )}
-
-          {!isLoadingRequirements &&
-            !isLoadingStake &&
-            !hasCustomRequirements && (
-              <div className="space-y-4">
-                {defaultTntRequirement ? (
-                  <>
-                    <Text
-                      variant="body2"
-                      className="text-muted-foreground text-center"
-                    >
-                      Standard approval — set your TNT security commitment.
-                    </Text>
-
-                    <Controller
-                      name="tntExposureBps"
-                      control={control}
-                      defaultValue={defaultTntRequirement.minExposureBps}
-                      rules={{
-                        min: {
-                          value: defaultTntRequirement.minExposureBps,
-                          message: `Must be at least ${defaultTntRequirement.minExposureBps / 100}%`,
-                        },
-                        max: {
-                          value: defaultTntRequirement.maxExposureBps,
-                          message: `Cannot exceed ${defaultTntRequirement.maxExposureBps / 100}%`,
-                        },
-                      }}
-                      render={({ field, fieldState }) => (
-                        <ExposureCommitmentInput
-                          tokenAddress={defaultTntRequirement.asset.token}
-                          assetKind={defaultTntRequirement.asset.kind}
-                          metadata={defaultTntRequirement.metadata}
-                          minExposureBps={defaultTntRequirement.minExposureBps}
-                          maxExposureBps={defaultTntRequirement.maxExposureBps}
-                          value={
-                            field.value ?? defaultTntRequirement.minExposureBps
-                          }
-                          onChange={field.onChange}
-                          errorMessage={fieldState.error?.message}
-                          delegatedAmount={getStakeForAsset(
-                            defaultTntRequirement.asset.token,
-                          )}
-                          operatorExposureBps={
-                            derivedSimpleStakingPercent * 100
-                          }
-                        />
-                      )}
-                    />
-                  </>
-                ) : (
+              if (renderable.length === 0) {
+                return (
                   <Text
                     variant="body2"
                     className="text-center text-muted-foreground"
                   >
-                    No custom commitments required.
+                    No security commitments required for this request.
                   </Text>
-                )}
-              </div>
-            )}
+                );
+              }
+
+              return (
+                <div className="space-y-4">
+                  <Text
+                    variant="body2"
+                    className="text-muted-foreground text-center"
+                  >
+                    Set your exposure percentage within the allowed bounds for
+                    each asset.
+                  </Text>
+
+                  {renderable.map((req) => {
+                    const key = toAssetMapKey(req.asset.token);
+                    const isDefaultTnt =
+                      !hasCustomRequirements &&
+                      defaultTntRequirement !== null &&
+                      toAssetMapKey(defaultTntRequirement.asset.token) === key;
+
+                    return (
+                      <Controller
+                        key={key}
+                        name={`commitments.${key}`}
+                        control={control}
+                        defaultValue={req.minExposureBps}
+                        rules={{
+                          min: {
+                            value: req.minExposureBps,
+                            message: `Must be at least ${req.minExposureBps / 100}%`,
+                          },
+                          max: {
+                            value: req.maxExposureBps,
+                            message: `Cannot exceed ${req.maxExposureBps / 100}%`,
+                          },
+                        }}
+                        render={({ field, fieldState }) => (
+                          <ExposureCommitmentInput
+                            tokenAddress={req.asset.token}
+                            assetKind={req.asset.kind}
+                            metadata={req.metadata}
+                            minExposureBps={req.minExposureBps}
+                            maxExposureBps={req.maxExposureBps}
+                            value={field.value ?? req.minExposureBps}
+                            onChange={field.onChange}
+                            errorMessage={fieldState.error?.message}
+                            delegatedAmount={getStakeForAsset(req.asset.token)}
+                            operatorExposureBps={
+                              isDefaultTnt
+                                ? derivedSimpleStakingPercent * 100
+                                : undefined
+                            }
+                          />
+                        )}
+                      />
+                    );
+                  })}
+                </div>
+              );
+            })()}
         </form>
       </ModalBody>
 

--- a/apps/tangle-cloud/src/types/index.ts
+++ b/apps/tangle-cloud/src/types/index.ts
@@ -41,7 +41,7 @@ export const TangleDAppPagePath = {
 } as const;
 
 /**
- * Asset structure matching the contract's Asset struct.
+ * Asset structure matching the contract's `Types.Asset`.
  * - kind: 0 = Native token, 1 = ERC20 token
  * - token: The token address (zero address for native)
  */
@@ -51,8 +51,9 @@ export type ContractAsset = {
 };
 
 /**
- * Security commitment structure matching the contract's AssetSecurityCommitment struct.
- * Used when calling approveServiceWithCommitments.
+ * Security commitment matching the contract's `Types.AssetSecurityCommitment`.
+ * Threaded into `approveService(ApprovalParams)` as the operator's per-asset
+ * exposure decision against the request's `AssetSecurityRequirement`s.
  */
 export type ContractSecurityCommitment = {
   asset: ContractAsset;
@@ -61,17 +62,15 @@ export type ContractSecurityCommitment = {
 
 /**
  * Form fields for the approval confirmation modal.
- * Supports two approval modes:
- * 1. Simple approval: Only stakingPercent is provided
- * 2. Approval with commitments: securityCommitments array is provided
+ *
+ * Single approval mode under the unified `approveService(ApprovalParams)`
+ * entrypoint: the operator either supplies explicit `securityCommitments` or
+ * omits them. When omitted, the contract auto-fills at the requirement's
+ * `minExposureBps` for the default-TNT-only case and reverts otherwise.
  */
 export type ApprovalConfirmationFormFields = {
   requestId: number;
-  /** Simple approval mode: single percentage (0-100) for default TNT requirement */
-  stakingPercent?: number;
-  /** TNT exposure in basis points (0-10000), when set calls 3-arg approveService overload */
-  tntExposureBps?: number;
-  /** Commitments mode: per-asset exposure commitments matching contract format */
+  /** Per-asset exposure commitments. Omitted when the operator accepts on-chain auto-fill. */
   securityCommitments?: ContractSecurityCommitment[];
 };
 


### PR DESCRIPTION
## Summary

Closes the silent-data-drop bug in `PendingInstanceTable` introduced when the
contract collapsed five `approveServiceWith*` overloads into one
`approveService(ApprovalParams)` entrypoint (tnt-core #119). The form was
passing `stakingPercent` / `tntExposureBps` fields that `useServiceApproveTx`
no longer reads, so the operator's slider value for the default-TNT case
reached the contract as \"no commitment\" — the contract then auto-filled at
the requirement's `minExposureBps` regardless of what the operator typed.

## What changed

- `ApprovalConfirmationFormFields`: drop dead `stakingPercent` and
  `tntExposureBps`. The form now produces a single `securityCommitments[]`
  array — the only thing the unified contract entrypoint accepts.
- `ServiceRequestDetailModal`: collapse the two render branches (custom vs
  default-TNT) into one. Every requirement renders as a per-asset slider
  bound to `commitments.\${tokenKey}`. The default-TNT case keeps the
  operator-recommended-exposure marker via `derivedSimpleStakingPercent`.
- `useServiceApproveTx`: type-safe `TeeBackend` const so callers can't pass
  invalid backends (`Unset = 0` and `DirectTdx = 5` are rejected on-chain
  and thus unrepresentable in the type).

Net -45 LOC.

## Verification

- \`yarn nx run tangle-cloud:typecheck\` ✓
- \`yarn nx run tangle-cloud:lint\` ✓
- \`yarn prettier --check\` ✓ on every modified file
- \`yarn vitest run useServiceApproveTx.spec.tsx\` ✓ (4/4)

## Test plan

- [ ] Approve a request with the default TNT-only requirement; verify the
      contract receives `securityCommitments[0].exposureBps` matching the
      operator's slider (not auto-filled at min).
- [ ] Approve a request with custom multi-asset requirements; verify each
      slider value reaches the contract.
- [ ] Approve with no requirements (legacy path); verify empty
      `securityCommitments[]` is sent and the contract takes the
      `effectiveStakingPercent = 100` path.