### PR TITLE
chore(abi): sync tnt-core ABI through bindings v0.11.2

### DIFF
--- a/libs/tangle-shared-ui/src/abi/tangle.ts
+++ b/libs/tangle-shared-ui/src/abi/tangle.ts
@@ -1057,7 +1057,7 @@ const ABI = [
       },
     ],
     outputs: [],
-    stateMutability: 'nonpayable',
+    stateMutability: 'payable',
   },
   {
     type: 'function',
@@ -1113,6 +1113,19 @@ const ABI = [
         internalType: 'uint256',
       },
     ],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'expireServiceRequest',
+    inputs: [
+      {
+        name: 'requestId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+    outputs: [],
     stateMutability: 'nonpayable',
   },
   {
@@ -2459,6 +2472,11 @@ const ABI = [
             internalType: 'bool',
           },
           {
+            name: 'activated',
+            type: 'bool',
+            internalType: 'bool',
+          },
+          {
             name: 'confidentiality',
             type: 'uint8',
             internalType: 'enum Types.ConfidentialityPolicy',
@@ -2780,6 +2798,26 @@ const ABI = [
             name: 'disputeReason',
             type: 'string',
             internalType: 'string',
+          },
+          {
+            name: 'disputer',
+            type: 'address',
+            internalType: 'address',
+          },
+          {
+            name: 'disputeBond',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'disputedAt',
+            type: 'uint64',
+            internalType: 'uint64',
+          },
+          {
+            name: 'disputeDeadline',
+            type: 'uint64',
+            internalType: 'uint64',
           },
         ],
       },
@@ -3731,6 +3769,21 @@ const ABI = [
       },
       {
         name: 'maxSlashBps',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
+      {
+        name: 'disputeResolutionDeadline',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      {
+        name: 'disputeBond',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'maxPendingSlashesPerOperator',
         type: 'uint16',
         internalType: 'uint16',
       },


### PR DESCRIPTION
## Summary

Regenerates \`libs/tangle-shared-ui/src/abi/tangle.ts\` from tnt-core@abd065c. Pulls in two upstream merges that the dapp ABI was lagging on:

- **tnt-core #118** (slashing correctness, manager-hook reentrancy, lifecycle, EIP-712) — \`disputeSlash\` now payable, \`SlashProposal\` gains \`disputer\` / \`disputeBond\` / \`disputeDeadline\`, \`ServiceRequest\` gains \`activated\` flag.
- **tnt-core #122** (interface declaration of \`expireServiceRequest\`) — adds the permissionless cleanup entrypoint so off-chain consumers can drive refunds of stale unapproved requests after the grace window.

## Why now

The dapp was building against a stale ABI: existing dispute-slash calls compiled fine, but the contract's payable signature wasn't represented in TS, and \`expireServiceRequest\` simply didn't exist in our typed surface. tnt-core just merged both fixes; resyncing keeps the typed ABI honest.

## Diff

One file, +54/-1 lines. Generated entirely by \`yarn sync:tnt-core-assets\` then \`yarn prettier --write\`.

## Caveat: \`disputeSlash\` is now payable

\`useDisputeSlashTx\` calls \`disputeSlash(slashId, reason)\` without a \`value\`. The protocol's current \`disputeBond\` config is \`0\`, so the call path still works. If/when an admin sets a non-zero bond, the operator-side dispute flow will revert — a follow-up PR should:
- Read the active \`disputeBond\` from \`SlashConfig\`
- Pass \`{ value: disputeBond }\` on the operator path
- Skip the value when the caller has SLASH_ADMIN_ROLE

Filing this as a follow-up rather than fixing here so the ABI sync stays mechanical and auditable.

## Test plan

- [x] \`yarn typecheck\` clean (5 projects, 2 tasks)
- [x] Generated diff inspected: only the actual ABI surface changes are present (no spurious quote-style churn after prettier)
- [ ] Smoke-test slash dispute UI on a local devnet once #122 is merged + bindings v0.11.2 published