### PR TITLE
feat(local-env): deploy-cf subcommand for iframe blueprint apps

### DIFF
--- a/scripts/local-env/blueprint-ui-catalog.mjs
+++ b/scripts/local-env/blueprint-ui-catalog.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { createServer } from 'node:http';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { basename, dirname, resolve } from 'node:path';
@@ -941,8 +941,16 @@ const deployBlueprintApp = async ({ slug, hostname, repoPath, build }) => {
   await ensurePagesProject(slug);
 
   console.log(`── ${slug} — wrangler pages deploy`);
-  execSync(
-    `wrangler pages deploy ${distAbs} --project-name=${slug} --branch=main --commit-dirty=true`,
+  execFileSync(
+    'wrangler',
+    [
+      'pages',
+      'deploy',
+      distAbs,
+      `--project-name=${slug}`,
+      '--branch=main',
+      '--commit-dirty=true',
+    ],
     { cwd, stdio: 'inherit' },
   );
 

--- a/scripts/local-env/blueprint-ui-catalog.mjs
+++ b/scripts/local-env/blueprint-ui-catalog.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { execSync } from 'node:child_process';
 import { createServer } from 'node:http';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { basename, dirname, resolve } from 'node:path';
@@ -786,17 +787,234 @@ const serve = ({ prepareFirst = true } = {}) => {
   });
 };
 
+// ─── Cloudflare Pages deploy for iframe blueprint apps ─────────────────
+//
+// For every blueprint whose metadata declares `externalApp.mode === 'iframe'`
+// targeting a *.blueprint.tangle.tools|sh URL, build the UI bundle and
+// deploy it as a Cloudflare Pages project (idempotent). Reuses the same
+// per-repo `metadata/blueprint-metadata.json` convention as the rest of
+// this catalog. Run from the dapp root so wrangler picks up the global
+// CLOUDFLARE_API_TOKEN/ACCOUNT_ID env vars.
+//
+// We deploy on Pages rather than Workers Static Assets because the
+// account API token in use is Pages+DNS scoped only — Workers Custom
+// Domain attach requires Workers:Edit, which the current token lacks.
+// To migrate to Workers later: mint a CF token with Workers Scripts:Edit
+// + Workers Routes:Edit, swap deployBlueprintApp to use `wrangler deploy`
+// with [assets] directory in a generated wrangler.toml.
+
+const HEADERS_TEMPLATE = `/*
+  Content-Security-Policy: frame-ancestors https://cloud.tangle.tools https://app.tangle.tools https://apps.tangle.tools
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), bluetooth=(), accelerometer=(), gyroscope=(), magnetometer=(), midi=(), serial=()
+  Referrer-Policy: no-referrer
+  X-Content-Type-Options: nosniff
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  X-Frame-Options: SAMEORIGIN
+
+/index.html
+  Cache-Control: no-store
+`;
+
+const REDIRECTS_TEMPLATE = '/*    /index.html    200\n';
+
+// First UI subdir we find that has a buildable package.json. Convention,
+// not config — keeps blueprint repos free of CF-specific knobs.
+const UI_SUBDIRS = ['arena', 'ui', 'app', 'frontend', 'web'];
+const PREFERRED_BUILD_CMDS = ['build', 'cloud:build'];
+
+const findUiSubdir = (repoPath) => {
+  for (const sub of UI_SUBDIRS) {
+    const pkgPath = resolve(repoPath, sub, 'package.json');
+    if (!existsSync(pkgPath)) continue;
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+    if (!pkg.scripts) continue;
+    const script = PREFERRED_BUILD_CMDS.find((s) => pkg.scripts[s]);
+    if (script) {
+      return {
+        subdir: sub,
+        packageManager: pkg.packageManager?.split('@')[0] ?? 'pnpm',
+        script,
+      };
+    }
+  }
+  return null;
+};
+
+// Conventional Vite / React-Router output paths in priority order.
+const findDistPath = (cwd) => {
+  for (const candidate of ['build/client', 'dist', 'build']) {
+    if (existsSync(resolve(cwd, candidate, 'index.html'))) return candidate;
+  }
+  return null;
+};
+
+const cfApi = async (path, init = {}) => {
+  const token = process.env.CLOUDFLARE_API_TOKEN;
+  const account = process.env.CLOUDFLARE_ACCOUNT_ID;
+  if (!token || !account) {
+    throw new Error(
+      'CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID env vars required',
+    );
+  }
+  const url = path.startsWith('/zones')
+    ? `https://api.cloudflare.com/client/v4${path}`
+    : `https://api.cloudflare.com/client/v4/accounts/${account}${path}`;
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...init.headers,
+    },
+  });
+  return res.json();
+};
+
+const upsertCname = async (zoneId, hostname, target) => {
+  const list = await cfApi(`/zones/${zoneId}/dns_records?name=${hostname}`);
+  const sub = hostname.replace(/\.tangle\.tools$|\.tangle\.sh$/, '');
+  if ((list.result ?? []).length === 0) {
+    return cfApi(`/zones/${zoneId}/dns_records`, {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'CNAME',
+        name: sub,
+        content: target,
+        proxied: true,
+        comment: 'iframe blueprint app',
+      }),
+    });
+  }
+  const record = list.result[0];
+  if (record.content === target && record.type === 'CNAME') {
+    return { success: true, noop: true };
+  }
+  return cfApi(`/zones/${zoneId}/dns_records/${record.id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ type: 'CNAME', content: target, proxied: true }),
+  });
+};
+
+const ensurePagesProject = async (slug) => {
+  const existing = await cfApi(`/pages/projects/${slug}`);
+  if (existing.success) return existing.result;
+  const created = await cfApi(`/pages/projects`, {
+    method: 'POST',
+    body: JSON.stringify({ name: slug, production_branch: 'main' }),
+  });
+  if (!created.success) {
+    throw new Error(
+      `Failed to create Pages project ${slug}: ${JSON.stringify(created.errors)}`,
+    );
+  }
+  return created.result;
+};
+
+const ensurePagesCustomDomain = async (slug, hostname) => {
+  const list = await cfApi(`/pages/projects/${slug}/domains`);
+  if ((list.result ?? []).some((d) => d.name === hostname)) return;
+  await cfApi(`/pages/projects/${slug}/domains`, {
+    method: 'POST',
+    body: JSON.stringify({ name: hostname }),
+  });
+};
+
+const deployBlueprintApp = async ({ slug, hostname, repoPath, build }) => {
+  const cwd = resolve(repoPath, build.subdir);
+  console.log(`\n── ${slug} — building ${cwd}`);
+  execSync(`${build.packageManager} run ${build.script}`, {
+    cwd,
+    stdio: 'inherit',
+  });
+
+  const distRel = findDistPath(cwd);
+  if (!distRel) {
+    throw new Error(
+      `${slug}: no built dist (looked for build/client, dist, build)`,
+    );
+  }
+  const distAbs = resolve(cwd, distRel);
+
+  writeFileSync(resolve(distAbs, '_headers'), HEADERS_TEMPLATE);
+  writeFileSync(resolve(distAbs, '_redirects'), REDIRECTS_TEMPLATE);
+
+  await ensurePagesProject(slug);
+
+  console.log(`── ${slug} — wrangler pages deploy`);
+  execSync(
+    `wrangler pages deploy ${distAbs} --project-name=${slug} --branch=main --commit-dirty=true`,
+    { cwd, stdio: 'inherit' },
+  );
+
+  await ensurePagesCustomDomain(slug, hostname);
+
+  // CF Pages auto-suffixes the *.pages.dev slug if taken (e.g. agent-sandbox
+  // → agent-sandbox-5xi.pages.dev). Read the project's actual canonical
+  // subdomain back so the CNAME points at a real target.
+  const project = await cfApi(`/pages/projects/${slug}`);
+  const canonical = project.result.subdomain;
+
+  const zoneId = process.env.CLOUDFLARE_ZONE_ID;
+  if (zoneId) {
+    await upsertCname(zoneId, hostname, canonical);
+  } else {
+    console.warn(
+      `${slug}: CLOUDFLARE_ZONE_ID not set — skipping CNAME upsert (point ${hostname} at ${canonical} manually)`,
+    );
+  }
+
+  console.log(`✓ ${slug} → https://${hostname}/   (CF: ${canonical})`);
+};
+
+const deployBlueprintApps = async (filterSlugs) => {
+  const catalog = loadCatalog();
+  const targets = catalog
+    .map((item) => {
+      const ext = item.metadata?.blueprintUi?.externalApp;
+      if (!ext || ext.mode !== 'iframe') return null;
+      let host;
+      try {
+        host = new URL(ext.url).hostname;
+      } catch {
+        return null;
+      }
+      if (!/\.blueprint\.tangle\.(tools|sh)$/.test(host)) return null;
+      const slug = host.split('.')[0];
+      if (filterSlugs.length > 0 && !filterSlugs.includes(slug)) return null;
+      const build = findUiSubdir(item.repoPath);
+      if (!build) {
+        console.warn(`skipping ${slug}: no UI subdir with build script in ${item.repoPath}`);
+        return null;
+      }
+      return { slug, hostname: host, repoPath: item.repoPath, build };
+    })
+    .filter(Boolean);
+
+  if (targets.length === 0) {
+    console.log('No blueprints to deploy. Filter or metadata mismatch?');
+    return;
+  }
+  for (const t of targets) {
+    await deployBlueprintApp(t);
+  }
+  console.log(`\nDeployed ${targets.length} blueprint app(s).`);
+};
+
 const help = () => {
   console.log(`Usage: node scripts/local-env/blueprint-ui-catalog.mjs <command>
 
 Commands:
-  prepare  Copy repo metadata into the local generated catalog
-  seed     Register local blueprints, operators, one service, and signed metadata
-  serve    Serve generated metadata with CORS for tangle-cloud local dev
-  up       Run seed, then serve
+  prepare    Copy repo metadata into the local generated catalog
+  seed       Register local blueprints, operators, one service, and signed metadata
+  serve      Serve generated metadata with CORS for tangle-cloud local dev
+  up         Run seed, then serve
+  deploy-cf  Deploy iframe blueprint apps to Cloudflare (Workers Static Assets)
+             Optional: deploy-cf <slug>...   Restrict to specific apps
 
 Run after ./scripts/local-env/start-local-env.sh has deployed local contracts.
-Open tangle-cloud against Localhost 8545 and http://localhost:8080/v1/graphql.`);
+Open tangle-cloud against Localhost 8545 and http://localhost:8080/v1/graphql.
+
+deploy-cf requires CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_ZONE_ID.`);
 };
 
 try {
@@ -809,6 +1027,8 @@ try {
   } else if (command === 'up') {
     await seed();
     serve({ prepareFirst: false });
+  } else if (command === 'deploy-cf') {
+    await deployBlueprintApps(process.argv.slice(3));
   } else {
     help();
   }


### PR DESCRIPTION
Adds `deploy-cf [<slug>...]` to `scripts/local-env/blueprint-ui-catalog.mjs`. For every blueprint whose metadata declares `externalApp.mode === 'iframe'` on `*.blueprint.tangle.{tools,sh}`, builds and ships its UI to Cloudflare Pages with the iframe-safe header stack.

## Why this lives here

Reuses the **existing** `BLUEPRINTS` registry (12 entries already enumerated) and the **existing** per-repo `metadata/blueprint-metadata.json` convention used by `prepare` / `seed` / `serve`. No new registry. No new directory. One subcommand on the file that already knows about every blueprint.

## How it works

For each blueprint that opts in via `externalApp.mode = 'iframe'` (currently 2 of 12):

1. Discover UI subdir by convention (`arena`/`ui`/`app`/`frontend`/`web` with a build script)
2. Run the build
3. Drop `_headers` (CSP/Permissions-Policy/HSTS/XFO/etc.) and `_redirects` (SPA fallback)
4. `wrangler pages deploy` — creates the project if missing
5. Attach custom domain
6. Upsert CNAME pointing at the project's actual canonical `*.pages.dev` (handles CF's auto-suffix surprise — e.g. `agent-sandbox-5xi.pages.dev` when the unsuffixed slug is taken)

Idempotent. Re-running on a fully-deployed app is a clean no-op except for the new build artifacts.

## Adding the next blueprint

1. Set `blueprintUi.externalApp.url = "https://<slug>.blueprint.tangle.tools/"` and `mode: 'iframe'` in the blueprint repo's `metadata/blueprint-metadata.json`
2. `node scripts/local-env/blueprint-ui-catalog.mjs deploy-cf <slug>`

That's it. No new config in the dapp.

## Why Pages and not Workers (today)

The account API token in use is Pages+DNS scoped. Workers Custom Domain attach requires `Workers Scripts:Edit` + `Workers Routes:Edit`, which it lacks. The deploy function (`deployBlueprintApp`) is the single swap point when the token is upgraded — see comment block at the top of the new section. Strategically Workers is the better target; tactically Pages is what we can ship today.

## Verified

- `deploy-cf trading-arena`: builds + deploys (after `pnpm install` was needed in arena/), restores live URL ✓
- `deploy-cf agent-sandbox`: idempotent re-deploy, both subdomains return HTTP 200 with full security header stack ✓

## Run

```
CLOUDFLARE_API_TOKEN=… CLOUDFLARE_ACCOUNT_ID=… CLOUDFLARE_ZONE_ID=… \\
  node scripts/local-env/blueprint-ui-catalog.mjs deploy-cf [<slug>...]
```