### PR TITLE
feat(local-env): localhost iframe loop for blueprint dev

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/iframe/README.md
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/README.md
@@ -45,6 +45,37 @@ posts the result back.
 | `VITE_BLUEPRINT_IFRAME_PUBLISHERS` | `tangle,tangle-labs` (default) | Comma-separated publisher namespaces eligible for iframe rendering. Distinct from verified publishers. Adding entries is a governance call. |
 | `VITE_BLUEPRINT_IFRAME_HOST_SUFFIXES` | `.blueprint.tangle.tools,.blueprint.tangle.sh` | Wildcard host suffixes accepted as iframe sources. Each iframe app still needs a manifest entry; this just gates the URL shape. |
 
+## Local dev (running an iframe app from your machine)
+
+When the dapp is running on a local preview host (`localhost`, `127.0.0.1`,
+private IPv4, or `VITE_FORCE_LOCAL_CHAIN=true`), `localhost:<port>` is
+auto-accepted as an iframe-eligible host — no env-var fiddling required.
+
+End-to-end loop:
+
+```bash
+# In each blueprint repo, start its dev server.
+cd ~/code/ai-trading-blueprints/arena && pnpm dev    # serves :5173
+cd ~/code/ai-agent-sandbox-blueprint/ui && pnpm dev  # serves :1338
+
+# In the dapp, seed the local catalog with localhost iframe URLs.
+cd ~/code/dapp
+BLUEPRINT_UI_USE_LOCAL_IFRAMES=true \
+  yarn local:blueprint-ui-catalog
+
+# In a separate dapp shell, run the dapp with iframe mode on:
+VITE_BLUEPRINT_IFRAME_ENABLED=true \
+VITE_FORCE_LOCAL_CHAIN=true \
+  yarn nx serve tangle-cloud
+```
+
+Open the dapp at `localhost:4300`, navigate to any iframe-mode blueprint —
+the iframe loads from your local dev server, with HMR. Wallet flows still
+go through the parent dapp's wagmi stack via postMessage.
+
+The local URL map lives in `scripts/local-env/blueprint-ui-catalog.mjs`
+(`LOCAL_IFRAME_DEV_URLS`). Add an entry when a new blueprint gains a UI.
+
 ## Onboarding a new iframe-eligible app
 
 1. **Deploy the bundle** to a subdomain matching one of the allowed

--- a/apps/tangle-cloud/src/blueprintApps/policy.ts
+++ b/apps/tangle-cloud/src/blueprintApps/policy.ts
@@ -1,3 +1,4 @@
+import { isLocalPreviewHost } from '@tangle-network/tangle-shared-ui/utils/localPreview';
 import type { BlueprintPublisherVerification } from './types';
 
 const splitEnvList = (value: string | undefined): string[] =>
@@ -85,9 +86,15 @@ export const isIframeEligiblePublisher = (namespace?: string): boolean => {
   return iframeEligiblePublisherNamespaces.has(namespace.trim().toLowerCase());
 };
 
+// Local preview hostnames that we accept as iframe sources when the dapp
+// itself is running on a local preview host. Lets `pnpm dev` in a blueprint
+// repo pair with `yarn local:blueprint-ui-catalog` without env-var fiddling.
+const LOCAL_IFRAME_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0']);
+
 export const isIframeAllowedHost = (host: string): boolean => {
   const normalized = host.trim().toLowerCase();
   if (!normalized) return false;
+  if (LOCAL_IFRAME_HOSTS.has(normalized) && isLocalPreviewHost()) return true;
   if (trustedExternalAppHosts.includes(normalized)) return true;
   return trustedIframeHostSuffixes.some((suffix) =>
     normalized.endsWith(suffix),

--- a/scripts/local-env/blueprint-ui-catalog.mjs
+++ b/scripts/local-env/blueprint-ui-catalog.mjs
@@ -359,11 +359,39 @@ const generatedBlueprintSvg = (slug, metadata) => {
 `;
 };
 
+// Local dev ports for blueprint UIs. When BLUEPRINT_UI_USE_LOCAL_IFRAMES=true,
+// the catalog rewrites `externalApp.url` for these slugs so iframes load from
+// each blueprint's local dev server instead of the production CF deploy.
+// Add an entry when a new blueprint gains a UI bundle with a `dev` script.
+const LOCAL_IFRAME_DEV_URLS = {
+  'ai-agent-sandbox': 'http://localhost:1338/',
+  'ai-trading': 'http://localhost:5173/',
+};
+
+const useLocalIframes = process.env.BLUEPRINT_UI_USE_LOCAL_IFRAMES === 'true';
+
+const applyLocalIframeOverride = (slug, metadata) => {
+  if (!useLocalIframes) return metadata;
+  const local = LOCAL_IFRAME_DEV_URLS[slug];
+  const ext = metadata.blueprintUi?.externalApp;
+  if (!local || !ext || ext.mode !== 'iframe') return metadata;
+  return {
+    ...metadata,
+    blueprintUi: {
+      ...metadata.blueprintUi,
+      externalApp: { ...ext, url: local },
+    },
+  };
+};
+
 const loadCatalog = () =>
   BLUEPRINTS.map(([slug, repoPath]) => {
     const sourcePath = resolve(repoPath, 'metadata/blueprint-metadata.json');
     const sourceMetadata = JSON.parse(readFileSync(sourcePath, 'utf8'));
-    const metadata = withGeneratedImage(slug, sourceMetadata);
+    const metadata = applyLocalIframeOverride(
+      slug,
+      withGeneratedImage(slug, sourceMetadata),
+    );
     const metadataUri = `http://${PUBLIC_HOST}:${PUBLIC_PORT}/${slug}.json`;
     return {
       slug,


### PR DESCRIPTION
Lets the iframe pathway be tested end-to-end against locally-running blueprint dev servers. Two coordinated changes:

- **`isIframeAllowedHost`** accepts `localhost`/`127.0.0.1`/`0.0.0.0` when the **dapp itself** is on a local preview host. Production behaviour unchanged.
- **`BLUEPRINT_UI_USE_LOCAL_IFRAMES=true`** in the catalog seed rewrites `externalApp.url` to per-slug localhost ports.

End-to-end flow documented in `apps/tangle-cloud/src/blueprintApps/iframe/README.md`.