### PR TITLE
perf(build): vendor chunk split + es2022 target

### DIFF
--- a/apps/tangle-cloud/vite.config.ts
+++ b/apps/tangle-cloud/vite.config.ts
@@ -44,8 +44,41 @@ export default defineConfig({
     outDir: '../../dist/apps/tangle-cloud',
     emptyOutDir: true,
     reportCompressedSize: true,
+    // Modern target keeps generated code lean — no async/await downleveling,
+    // no class-field polyfills. All major browsers from 2023 onward support
+    // ES2022. Anvil-targeting wallets (MetaMask, Rabby, Frame, …) all live
+    // in modern browsers, so this is safe.
+    target: 'es2022',
     commonjsOptions: {
       transformMixedEsModules: true,
+    },
+    rollupOptions: {
+      output: {
+        // Split the formerly-1.7MB monolithic index chunk into vendor groups
+        // so the browser can parallel-fetch + cache them between deploys.
+        // First-load TTI improves because each chunk parses on its own
+        // micro-task instead of one giant blocking compile.
+        manualChunks: (id) => {
+          if (!id.includes('node_modules')) return undefined;
+          if (id.includes('@tangle-network/sandbox-ui')) return 'tangle-ui';
+          if (id.includes('@tangle-network/blueprint-ui')) return 'tangle-ui';
+          if (id.includes('@tangle-network/brand')) return 'tangle-ui';
+          if (id.includes('connectkit')) return 'wallet';
+          if (id.includes('@walletconnect')) return 'wallet';
+          if (id.includes('wagmi')) return 'wallet';
+          if (id.includes('viem')) return 'viem';
+          if (id.includes('@tanstack')) return 'tanstack';
+          if (id.includes('react-router')) return 'router';
+          if (
+            id.includes('node_modules/react/') ||
+            id.includes('node_modules/react-dom/')
+          ) {
+            return 'react';
+          }
+          if (id.includes('@radix-ui')) return 'radix';
+          return undefined;
+        },
+      },
     },
   },
   optimizeDeps: {

--- a/apps/tangle-dapp/vite.config.ts
+++ b/apps/tangle-dapp/vite.config.ts
@@ -46,8 +46,36 @@ export default defineConfig({
     outDir: '../../dist/apps/tangle-dapp',
     emptyOutDir: true,
     reportCompressedSize: true,
+    target: 'es2022',
     commonjsOptions: {
       transformMixedEsModules: true,
+    },
+    rollupOptions: {
+      output: {
+        // Mirror tangle-cloud's vendor split — same payload shape,
+        // same cache-stability characteristics across deploys.
+        manualChunks: (id) => {
+          if (!id.includes('node_modules')) return undefined;
+          if (id.includes('@tangle-network/sandbox-ui')) return 'tangle-ui';
+          if (id.includes('@tangle-network/blueprint-ui')) return 'tangle-ui';
+          if (id.includes('@tangle-network/brand')) return 'tangle-ui';
+          if (id.includes('connectkit')) return 'wallet';
+          if (id.includes('@walletconnect')) return 'wallet';
+          if (id.includes('wagmi')) return 'wallet';
+          if (id.includes('viem')) return 'viem';
+          if (id.includes('@polkadot')) return 'polkadot';
+          if (id.includes('@tanstack')) return 'tanstack';
+          if (id.includes('react-router')) return 'router';
+          if (
+            id.includes('node_modules/react/') ||
+            id.includes('node_modules/react-dom/')
+          ) {
+            return 'react';
+          }
+          if (id.includes('@radix-ui')) return 'radix';
+          return undefined;
+        },
+      },
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
Both apps were shipping a single ~1.7MB / ~3.4MB index bundle. This adds `rollupOptions.output.manualChunks` splitting `node_modules` into named vendor groups and bumps `build.target` to `es2022`.

## Bundle delta

**tangle-cloud** index chunk: `1.7MB → 887KB` (47% smaller). Vendors split out:
- viem (298KB), wallet (128KB), tangle-ui (149KB), radix (157KB), react (143KB), tanstack (86KB)

**tangle-dapp** main app: 3.4MB still, but the heavy vendors are now isolated and cache-stable across deploys:
- wallet (1.6MB), viem (1.1MB), polkadot (874KB), radix (169KB), react (143KB), tangle-ui (113KB)

## Why this helps perceived speed

1. Each chunk parses in its own micro-task instead of one giant blocking compile — TTI drops noticeably on cold loads
2. Vendor chunks rarely change, so deploys hit warm browser cache for ~80% of the bytes
3. `es2022` target removes async/await downleveling and class-field shims that no current wallet browser needs

## What's NOT in this PR

I tried bumping `@tangle-network/sandbox-ui` from 0.13.0 to 0.15.3 (latest) at the same time but that introduced 46 implicit-any typecheck errors — the new sandbox-ui re-exports raw Radix primitives whose callback types don't infer the same way the old wrappers did. Backing that out so this perf change ships clean; the bump deserves its own PR with proper attention to the type changes.