### PR TITLE
fix(netlify): trigger master deploys on actual source changes

### DIFF
--- a/apps/leaderboard/netlify.toml
+++ b/apps/leaderboard/netlify.toml
@@ -2,8 +2,13 @@
   publish = "dist/apps/leaderboard"
   command = "yarn nx build leaderboard"
 
-  # If the branch is not master, continue the build process
-  # If the branch is master, check if the project's CHANGELOG.md file has changed
-  # If the CHANGELOG.md file has changed, continue the build process,
-  # Otherwise, stop the build process
-  ignore = "[ \"$BRANCH\" != \"master\" ] && exit 1 || git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/leaderboard/CHANGELOG.md && exit 0 || exit 1"
+  # Trigger a master deploy whenever the app's own source, the shared
+  # libs it consumes, or the workspace dep manifest changes. The previous
+  # version gated on apps/leaderboard/CHANGELOG.md only, which silently
+  # cancelled every push that wasn't a release-PR — leaderboard had
+  # never deployed before we caught it. CHANGELOG.md is now implicitly
+  # covered (it's inside apps/leaderboard/), and any source/config/
+  # lockfile change also re-triggers.
+  #
+  # Non-master branches always build (gives PR-preview deploys).
+  ignore = "[ \"$BRANCH\" != \"master\" ] && exit 1 || git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/leaderboard/ libs/ package.json yarn.lock tsconfig.base.json nx.json && exit 0 || exit 1"

--- a/apps/tangle-cloud/netlify.toml
+++ b/apps/tangle-cloud/netlify.toml
@@ -2,6 +2,17 @@
   publish = "dist/apps/tangle-cloud"
   command = "yarn nx build tangle-cloud"
 
+  # Trigger a master deploy whenever the app's own source, the shared
+  # libs it consumes, or the workspace dep manifest changes. The previous
+  # version gated on apps/tangle-cloud/CHANGELOG.md only, which silently
+  # cancelled every push that wasn't a release-PR — a year of overhaul
+  # work piled up un-deployed before we caught it. CHANGELOG.md is now
+  # implicitly covered (it's inside apps/tangle-cloud/), and any source/
+  # config/lockfile change also re-triggers.
+  #
+  # Non-master branches always build (gives PR-preview deploys).
+  ignore = "[ \"$BRANCH\" != \"master\" ] && exit 1 || git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/tangle-cloud/ libs/ package.json yarn.lock tsconfig.base.json nx.json && exit 0 || exit 1"
+
 # ─── Per-context environment ───────────────────────────────────────────
 #
 # Vite reads VITE_* vars at build time and inlines them into the bundle,
@@ -27,12 +38,6 @@
 [context.branch-deploy.environment]
   # Same default for any non-master branch deploy (e.g. staging).
   VITE_BLUEPRINT_IFRAME_ENABLED = "true"
-
-  # If the branch is not master, continue the build process
-  # If the branch is master, check if the project's CHANGELOG.md file has changed
-  # If the CHANGELOG.md file has changed, continue the build process,
-  # Otherwise, stop the build process
-  ignore = "[ \"$BRANCH\" != \"master\" ] && exit 1 || git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/tangle-cloud/CHANGELOG.md && exit 0 || exit 1"
 
 # ─── Security headers ───────────────────────────────────────────────────
 #

--- a/apps/tangle-dapp/netlify.toml
+++ b/apps/tangle-dapp/netlify.toml
@@ -2,11 +2,16 @@
   publish = "dist/apps/tangle-dapp"
   command = "yarn nx build tangle-dapp"
 
-  # If the branch is not master, continue the build process
-  # If the branch is master, check if the project's CHANGELOG.md file has changed
-  # If the CHANGELOG.md file has changed, continue the build process,
-  # Otherwise, stop the build process
-  ignore = "[ \"$BRANCH\" != \"master\" ] && exit 1 || git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/tangle-dapp/CHANGELOG.md && exit 0 || exit 1"
+  # Trigger a master deploy whenever the app's own source, the shared
+  # libs it consumes, or the workspace dep manifest changes. The previous
+  # version gated on apps/tangle-dapp/CHANGELOG.md only, which silently
+  # cancelled every push that wasn't a release-PR — production was stuck
+  # on the August 2025 release until we caught it. CHANGELOG.md is now
+  # implicitly covered (it's inside apps/tangle-dapp/), and any source/
+  # config/lockfile change also re-triggers.
+  #
+  # Non-master branches always build (gives PR-preview deploys).
+  ignore = "[ \"$BRANCH\" != \"master\" ] && exit 1 || git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/tangle-dapp/ libs/ package.json yarn.lock tsconfig.base.json nx.json && exit 0 || exit 1"
 
 # ─── Cache headers ──────────────────────────────────────────────────────
 #


### PR DESCRIPTION
The previous `ignore` rule across all three apps gated master deploys on `apps/<app>/CHANGELOG.md` only. Result: every meaningful push since the last release-PR was silently cancelled by Netlify with 'Canceled build due to no content change'.

## Damage report

- **app.tangle.tools** — stuck on the v0.1.7 release from **August 2025**. ~25 PRs of iframe + perf + design overhaul + dep cleanup never reached production. Manually rebuilt today.
- **leaderboard.tangle.tools** — never had a successful deploy at all. Manually rebuilt today.
- **cloud.tangle.tools** — accidentally avoided the bug because in #3184 the `ignore` rule got pulled INTO the `[context.branch-deploy.environment]` table, parsing as just an env var named `ignore` instead of a build directive. So cloud deployed on every master push regardless. Lucky.

## What this PR ships

1. **tangle-cloud**: moves `ignore` back to `[build]` where it belongs, and uses the new rule below
2. **tangle-dapp + leaderboard**: replace CHANGELOG-only check with source-tree check

## New rule

```
ignore = "[ \"\$BRANCH\" != \"master\" ] && exit 1 || \\
  git diff --quiet \$CACHED_COMMIT_REF \$COMMIT_REF -- \\
    apps/<app>/ libs/ package.json yarn.lock tsconfig.base.json nx.json \\
  && exit 0 || exit 1"
```

Master builds when ANY of:
- `apps/<app>/` → own source (CHANGELOG.md inside, so release-PRs still trigger)
- `libs/` → shared libs the app consumes
- `package.json` → dep changes
- `yarn.lock` → catches lockfile-only fixes like #3191
- `tsconfig.base.json` + `nx.json` → build-graph config changes