### PR TITLE
chore(tnt-core-v0.13.0): regenerate ABIs + slashing UX polish

### DIFF
--- a/apps/tangle-cloud/src/pages/instances/Instances/UpdateBlueprintModel/ServiceRequestDetailModal.tsx
+++ b/apps/tangle-cloud/src/pages/instances/Instances/UpdateBlueprintModel/ServiceRequestDetailModal.tsx
@@ -16,6 +16,8 @@ import { type ServiceRequest } from '@tangle-network/tangle-shared-ui/data/graph
 import {
   useServiceRequestDetails,
   useTokenMetadata,
+  useExpireServiceRequestTx,
+  isServiceRequestExpired,
 } from '@tangle-network/tangle-shared-ui/data/services';
 import type { Blueprint } from '@tangle-network/tangle-shared-ui/types/blueprint';
 import { TxStatus } from '@tangle-network/tangle-shared-ui/hooks/useContractWrite';
@@ -74,6 +76,43 @@ const ServiceRequestDetailModal: FC<Props> = ({
     useServiceRequestDetails(selectedRequest?.requestId, {
       enabled: selectedRequest !== null,
     });
+
+  // Permissionless cleanup. Available once `now > createdAt + grace` and the
+  // request has not already been activated or rejected. The contract
+  // re-validates these conditions, but we gate the button to avoid wasting a
+  // user's gas on a guaranteed revert.
+  const {
+    execute: expireServiceRequest,
+    error: expireError,
+    reset: resetExpire,
+    isPending: isExpiring,
+    isSuccess: isExpireSuccess,
+  } = useExpireServiceRequestTx();
+
+  const canExpireRequest = useMemo(() => {
+    if (!contractDetails || !selectedRequest) {
+      return false;
+    }
+    if (contractDetails.rejected) {
+      return false;
+    }
+    return isServiceRequestExpired(contractDetails.createdAt);
+  }, [contractDetails, selectedRequest]);
+
+  const handleExpireRequest = useCallback(async () => {
+    if (!selectedRequest || !canExpireRequest) {
+      return;
+    }
+    await expireServiceRequest?.({ requestId: selectedRequest.requestId });
+  }, [canExpireRequest, expireServiceRequest, selectedRequest]);
+
+  // After a successful expire the request is gone — close the modal so the
+  // parent list refetches against an invalidated `serviceRequestDetails` cache.
+  useEffect(() => {
+    if (isExpireSuccess) {
+      onClose();
+    }
+  }, [isExpireSuccess, onClose]);
 
   const { data: tokenMetadata, isLoading: isLoadingToken } = useTokenMetadata(
     contractDetails?.paymentToken,
@@ -271,27 +310,78 @@ const ServiceRequestDetailModal: FC<Props> = ({
         />
       </ModalBody>
 
+      {expireError ? (
+        <div className="px-6 pt-2">
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 space-y-2">
+            <Text variant="body3" className="text-destructive">
+              {expireError.message ||
+                'Failed to expire the service request. Please try again.'}
+            </Text>
+            <button
+              type="button"
+              className="text-xs underline text-destructive"
+              onClick={resetExpire}
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      ) : null}
+
       {!viewOnly && (
-        <div className="flex justify-end gap-3 p-6 pt-4 shrink-0 bg-background">
+        <div className="flex flex-wrap justify-end gap-3 p-6 pt-4 shrink-0 bg-background">
+          {canExpireRequest ? (
+            <Button
+              variant="secondary"
+              onClick={() => void handleExpireRequest()}
+              isLoading={isExpiring}
+              isDisabled={
+                isExpiring || isApproving || isRejecting || !canExpireRequest
+              }
+              title="Refunds the requester and frees the operator candidates. Anyone can call this once the grace period has passed."
+            >
+              Expire request
+            </Button>
+          ) : null}
+
           <Button
             variant="secondary"
             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             onClick={onReject}
             isLoading={isRejecting}
-            isDisabled={isRejecting}
+            isDisabled={isRejecting || isExpiring}
           >
             Reject
           </Button>
 
-          <Button variant="primary" onClick={handleApproveClick}>
+          <Button
+            variant="primary"
+            onClick={handleApproveClick}
+            isDisabled={isExpiring}
+          >
             Approve
           </Button>
         </div>
       )}
 
       {viewOnly && (
-        <div className="flex justify-end gap-3 p-6 pt-4 shrink-0 bg-background">
-          <Button variant="secondary" onClick={onClose}>
+        <div className="flex flex-wrap justify-end gap-3 p-6 pt-4 shrink-0 bg-background">
+          {canExpireRequest ? (
+            <Button
+              variant="secondary"
+              onClick={() => void handleExpireRequest()}
+              isLoading={isExpiring}
+              isDisabled={isExpiring || !canExpireRequest}
+              title="Refunds the requester and frees the operator candidates. Anyone can call this once the grace period has passed."
+            >
+              Expire request
+            </Button>
+          ) : null}
+          <Button
+            variant="secondary"
+            onClick={onClose}
+            isDisabled={isExpiring}
+          >
             Close
           </Button>
         </div>

--- a/apps/tangle-cloud/src/pages/instances/Instances/UpdateBlueprintModel/ServiceRequestDetailModal.tsx
+++ b/apps/tangle-cloud/src/pages/instances/Instances/UpdateBlueprintModel/ServiceRequestDetailModal.tsx
@@ -377,11 +377,7 @@ const ServiceRequestDetailModal: FC<Props> = ({
               Expire request
             </Button>
           ) : null}
-          <Button
-            variant="secondary"
-            onClick={onClose}
-            isDisabled={isExpiring}
-          >
+          <Button variant="secondary" onClick={onClose} isDisabled={isExpiring}>
             Close
           </Button>
         </div>

--- a/apps/tangle-cloud/src/pages/operators/manage/components/SlashingParametersCard.tsx
+++ b/apps/tangle-cloud/src/pages/operators/manage/components/SlashingParametersCard.tsx
@@ -1,0 +1,159 @@
+/**
+ * Read-only summary of the protocol-level slashing parameters returned by
+ * `getSlashConfig`. Shipped with tnt-core v0.13.0 — exposes the fields that
+ * govern dispute lifecycle (disputeBond, disputeResolutionDeadline) and the
+ * caps that gate proposal flow (maxSlashBps, maxPendingSlashesPerOperator).
+ *
+ * Operators and slash proposers both benefit from seeing these up front so
+ * they don't waste a simulation on a guaranteed revert.
+ */
+
+import { Card } from '@tangle-network/sandbox-ui/primitives';
+import { formatUnits } from 'viem';
+import { Text } from '../../../../components/Text';
+
+const SECONDS_PER_HOUR = 60 * 60;
+const SECONDS_PER_DAY = SECONDS_PER_HOUR * 24;
+
+const formatDuration = (seconds: bigint): string => {
+  const total = Number(seconds);
+  if (!Number.isFinite(total) || total <= 0) {
+    return '—';
+  }
+
+  if (total >= SECONDS_PER_DAY) {
+    const days = total / SECONDS_PER_DAY;
+    const rounded = Math.round(days * 10) / 10;
+    return `${rounded.toLocaleString(undefined, {
+      maximumFractionDigits: 1,
+    })} day${rounded === 1 ? '' : 's'}`;
+  }
+
+  if (total >= SECONDS_PER_HOUR) {
+    const hours = total / SECONDS_PER_HOUR;
+    const rounded = Math.round(hours * 10) / 10;
+    return `${rounded.toLocaleString(undefined, {
+      maximumFractionDigits: 1,
+    })} hour${rounded === 1 ? '' : 's'}`;
+  }
+
+  return `${total.toLocaleString()} second${total === 1 ? '' : 's'}`;
+};
+
+// Trim trailing zeros so we don't show "0.000000000000000000 ETH".
+const formatEthAmount = (wei: bigint): string => {
+  const formatted = formatUnits(wei, 18);
+  if (!formatted.includes('.')) return formatted;
+  return formatted.replace(/\.?0+$/, '');
+};
+
+const formatBps = (bps: number): string => {
+  const percent = bps / 100;
+  return `${bps.toLocaleString()} bps (${percent.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  })}%)`;
+};
+
+export interface SlashingParametersCardProps {
+  /**
+   * Active SlashConfig from `getSlashConfig`. Undefined while the read is in
+   * flight; rendered as a skeleton in that case.
+   */
+  config:
+    | {
+        disputeWindow: bigint;
+        instantSlashEnabled: boolean;
+        maxSlashBps: number;
+        disputeResolutionDeadline: bigint;
+        disputeBond: bigint;
+        maxPendingSlashesPerOperator: number;
+      }
+    | undefined;
+  isLoading: boolean;
+}
+
+const SlashingParametersCard = ({
+  config,
+  isLoading,
+}: SlashingParametersCardProps) => {
+  if (isLoading || !config) {
+    return (
+      <Card className="p-4">
+        <Text variant="body3" className="text-muted-foreground">
+          Loading slashing parameters...
+        </Text>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-4 space-y-3">
+      <div>
+        <Text variant="body2" fw="bold">
+          Slashing parameters
+        </Text>
+        <Text variant="body3" className="text-muted-foreground">
+          Protocol-wide settings from the active SlashConfig. Proposals,
+          disputes, and execution all enforce these.
+        </Text>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-2">
+        <div>
+          <Text variant="body3" className="text-muted-foreground">
+            Maximum slash per proposal
+          </Text>
+          <Text variant="body2" fw="semibold">
+            {formatBps(config.maxSlashBps)}
+          </Text>
+        </div>
+        <div>
+          <Text variant="body3" className="text-muted-foreground">
+            Dispute window
+          </Text>
+          <Text variant="body2" fw="semibold">
+            {formatDuration(config.disputeWindow)}
+          </Text>
+        </div>
+        <div>
+          <Text variant="body3" className="text-muted-foreground">
+            Dispute resolution deadline
+          </Text>
+          <Text variant="body2" fw="semibold">
+            {formatDuration(config.disputeResolutionDeadline)}
+          </Text>
+        </div>
+        <div>
+          <Text variant="body3" className="text-muted-foreground">
+            Required dispute bond
+          </Text>
+          <Text variant="body2" fw="semibold">
+            {config.disputeBond > BigInt(0)
+              ? `${formatEthAmount(config.disputeBond)} ETH`
+              : 'None'}
+          </Text>
+        </div>
+        <div>
+          <Text variant="body3" className="text-muted-foreground">
+            Max pending slashes per operator
+          </Text>
+          <Text variant="body2" fw="semibold">
+            {config.maxPendingSlashesPerOperator > 0
+              ? config.maxPendingSlashesPerOperator.toLocaleString()
+              : 'Unlimited'}
+          </Text>
+        </div>
+        <div>
+          <Text variant="body3" className="text-muted-foreground">
+            Instant slash
+          </Text>
+          <Text variant="body2" fw="semibold">
+            {config.instantSlashEnabled ? 'Enabled' : 'Disabled'}
+          </Text>
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export default SlashingParametersCard;

--- a/apps/tangle-cloud/src/pages/operators/manage/components/modals/DisputeSlashModal.tsx
+++ b/apps/tangle-cloud/src/pages/operators/manage/components/modals/DisputeSlashModal.tsx
@@ -1,4 +1,5 @@
 import type { ChangeEvent } from 'react';
+import { formatUnits, zeroAddress } from 'viem';
 import {
   SlashActionPermissions,
   SlashDisputeEligibility,
@@ -24,6 +25,14 @@ import {
 const shortenHex = (value: string) =>
   value.length <= 12 ? value : `${value.slice(0, 6)}...${value.slice(-4)}`;
 
+// Trim trailing zeros so we don't show "0.000000000000000000 ETH" or
+// "1.500000000000000000 ETH" in the bond row.
+const formatEthAmount = (wei: bigint): string => {
+  const formatted = formatUnits(wei, 18);
+  if (!formatted.includes('.')) return formatted;
+  return formatted.replace(/\.?0+$/, '');
+};
+
 interface DisputeSlashModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -39,6 +48,17 @@ interface DisputeSlashModalProps {
   onConfirm: () => void;
   errorMessage: string | null;
   onDismissError: () => void;
+  /**
+   * msg.value the contract will require for disputeSlash. Read from the active
+   * SlashConfig and surfaced here so the user knows what bond they are posting
+   * before signing.
+   */
+  disputeBond: bigint;
+  /**
+   * Seconds remaining until the dispute resolution deadline. Only meaningful
+   * when the slash is already in `Disputed` status; null otherwise.
+   */
+  disputeResolutionSecondsRemaining: number | null;
 }
 
 const DisputeSlashModal = ({
@@ -56,7 +76,14 @@ const DisputeSlashModal = ({
   onConfirm,
   errorMessage,
   onDismissError,
+  disputeBond,
+  disputeResolutionSecondsRemaining,
 }: DisputeSlashModalProps) => {
+  const isAlreadyDisputed = selectedSlash?.status === 'Disputed';
+  const hasKnownDisputer =
+    !!selectedSlash &&
+    selectedSlash.disputer.toLowerCase() !== zeroAddress.toLowerCase();
+
   return (
     <Modal open={open} onOpenChange={onOpenChange}>
       <ModalContent>
@@ -130,6 +157,43 @@ const DisputeSlashModal = ({
               <Text variant="body3" className="font-mono break-all">
                 {selectedSlash?.evidence ?? '-'}
               </Text>
+              <Text variant="body3" className="text-muted-foreground">
+                Required Dispute Bond:
+              </Text>
+              <Text variant="body3">
+                {disputeBond > BigInt(0)
+                  ? `${formatEthAmount(disputeBond)} ETH (refunded if dispute upheld)`
+                  : 'No bond required'}
+              </Text>
+              {isAlreadyDisputed && hasKnownDisputer ? (
+                <>
+                  <Text variant="body3" className="text-muted-foreground">
+                    Disputer:
+                  </Text>
+                  <Text
+                    variant="body3"
+                    className="font-mono"
+                    title={selectedSlash?.disputer ?? undefined}
+                  >
+                    {selectedSlash
+                      ? shortenHex(selectedSlash.disputer)
+                      : '-'}
+                  </Text>
+                </>
+              ) : null}
+              {isAlreadyDisputed &&
+              disputeResolutionSecondsRemaining !== null ? (
+                <>
+                  <Text variant="body3" className="text-muted-foreground">
+                    Resolution Deadline:
+                  </Text>
+                  <Text variant="body3">
+                    {disputeResolutionSecondsRemaining > 0
+                      ? formatTimeRemaining(disputeResolutionSecondsRemaining)
+                      : 'Deadline passed'}
+                  </Text>
+                </>
+              ) : null}
             </div>
           </div>
           <div>

--- a/apps/tangle-cloud/src/pages/operators/manage/components/modals/DisputeSlashModal.tsx
+++ b/apps/tangle-cloud/src/pages/operators/manage/components/modals/DisputeSlashModal.tsx
@@ -175,9 +175,7 @@ const DisputeSlashModal = ({
                     className="font-mono"
                     title={selectedSlash?.disputer ?? undefined}
                   >
-                    {selectedSlash
-                      ? shortenHex(selectedSlash.disputer)
-                      : '-'}
+                    {selectedSlash ? shortenHex(selectedSlash.disputer) : '-'}
                   </Text>
                 </>
               ) : null}

--- a/apps/tangle-cloud/src/pages/operators/manage/components/modals/ProposeSlashModal.tsx
+++ b/apps/tangle-cloud/src/pages/operators/manage/components/modals/ProposeSlashModal.tsx
@@ -30,6 +30,13 @@ interface ProposeSlashModalProps {
   canSubmitPropose: boolean;
   isSubmitting: boolean;
   onConfirm: () => void;
+  /**
+   * Active SlashConfig.maxSlashBps cap (0..10_000). Used both as the upper
+   * bound in the input placeholder and to short-circuit out-of-range BPS
+   * before the user pays for a simulation. Undefined while the config is
+   * loading; in that case we fall back to 10_000.
+   */
+  maxSlashBps: number | undefined;
 }
 
 const ProposeSlashModal = ({
@@ -53,7 +60,18 @@ const ProposeSlashModal = ({
   canSubmitPropose,
   isSubmitting,
   onConfirm,
+  maxSlashBps,
 }: ProposeSlashModalProps) => {
+  // Hard ceiling defined by the contract; SlashConfig.maxSlashBps is the
+  // soft (admin-configurable) cap which is always <= 10_000.
+  const effectiveMaxBps =
+    maxSlashBps !== undefined && maxSlashBps > 0 ? maxSlashBps : 10_000;
+  const maxBpsLabel = effectiveMaxBps.toLocaleString();
+  const maxPercentLabel = (effectiveMaxBps / 100).toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  });
+
   return (
     <Modal open={open} onOpenChange={onOpenChange}>
       <ModalContent>
@@ -122,15 +140,24 @@ const ProposeSlashModal = ({
 
                 <div>
                   <Text variant="body3" className="mb-1">
-                    Slash BPS (1 - 10000)
+                    Slash BPS (1 - {maxBpsLabel})
                   </Text>
                   <Input
                     id="propose-slash-bps"
                     isControlled
                     value={proposeSlashBps}
                     onChange={setProposeSlashBps}
-                    placeholder="e.g. 500 (5%)"
+                    placeholder={`Up to ${maxBpsLabel} bps (${maxPercentLabel}%)`}
                   />
+                  {maxSlashBps !== undefined ? (
+                    <Text
+                      variant="body3"
+                      className="text-muted-foreground mt-1"
+                    >
+                      Protocol cap: {maxBpsLabel} bps ({maxPercentLabel}%).
+                      Proposals above the cap are rejected on-chain.
+                    </Text>
+                  ) : null}
                 </div>
 
                 <div>

--- a/apps/tangle-cloud/src/pages/operators/manage/hooks/useSlashProposalForm.ts
+++ b/apps/tangle-cloud/src/pages/operators/manage/hooks/useSlashProposalForm.ts
@@ -25,11 +25,19 @@ export interface UseSlashProposalFormResult {
 interface UseSlashProposalFormOptions {
   proposableServices: ProposableService[] | undefined;
   proposeStatus: 'idle' | 'pending' | 'success' | 'error';
+  /**
+   * Active SlashConfig.maxSlashBps cap. Slash proposals above this value are
+   * rejected on-chain, so we surface the violation client-side before the
+   * user pays for a simulation. Defaults to the contract hard ceiling
+   * (10_000) when the config is still loading.
+   */
+  maxSlashBps?: number;
 }
 
 const useSlashProposalForm = ({
   proposableServices,
   proposeStatus,
+  maxSlashBps,
 }: UseSlashProposalFormOptions): UseSlashProposalFormResult => {
   const [proposeServiceId, setProposeServiceId] = useState('');
   const [proposeOperator, setProposeOperator] = useState('');
@@ -76,6 +84,16 @@ const useSlashProposalForm = ({
       return 'Slash BPS must be an integer between 1 and 10000.';
     }
 
+    // Enforce the active SlashConfig.maxSlashBps cap once it has loaded so we
+    // fail fast in the UI rather than during simulation.
+    if (
+      maxSlashBps !== undefined &&
+      maxSlashBps > 0 &&
+      slashBps > maxSlashBps
+    ) {
+      return `Slash BPS exceeds protocol cap of ${maxSlashBps.toLocaleString()} bps.`;
+    }
+
     if (evidenceNormalization.error) {
       return evidenceNormalization.error;
     }
@@ -83,6 +101,7 @@ const useSlashProposalForm = ({
     return null;
   }, [
     evidenceNormalization.error,
+    maxSlashBps,
     proposeOperator,
     proposeServiceId,
     proposeSlashBps,

--- a/apps/tangle-cloud/src/pages/operators/manage/page.tsx
+++ b/apps/tangle-cloud/src/pages/operators/manage/page.tsx
@@ -393,6 +393,7 @@ const Page: FC = () => {
   } = useSlashProposalForm({
     proposableServices,
     proposeStatus,
+    maxSlashBps: slashConfig?.maxSlashBps,
   });
 
   const executableSlashIdSet = useMemo(() => {
@@ -1425,6 +1426,7 @@ const Page: FC = () => {
         canSubmitPropose={canSubmitPropose}
         isSubmitting={proposeStatus === 'pending'}
         onConfirm={() => void handleProposeSlash()}
+        maxSlashBps={slashConfigMaxSlashBps}
       />
 
       <DisputeMessageModal

--- a/apps/tangle-cloud/src/pages/operators/manage/page.tsx
+++ b/apps/tangle-cloud/src/pages/operators/manage/page.tsx
@@ -76,6 +76,7 @@ import useChainClock from './hooks/useChainClock';
 import useSlashProposalForm from './hooks/useSlashProposalForm';
 import useSlashActions from './hooks/useSlashActions';
 import SlashingSummaryCards from './components/SlashingSummaryCards';
+import SlashingParametersCard from './components/SlashingParametersCard';
 import SlashingTabsTable from './components/SlashingTabsTable';
 import ProposeSlashModal from './components/modals/ProposeSlashModal';
 import DisputeMessageModal from './components/modals/DisputeMessageModal';
@@ -334,7 +335,9 @@ const Page: FC = () => {
       enabled: isConnected,
       proposals: slashProposals,
     });
-  const { data: slashConfig } = useSlashConfig({ enabled: isConnected });
+  const { data: slashConfig, isLoading: loadingSlashConfig } = useSlashConfig({
+    enabled: isConnected,
+  });
 
   // Transaction hooks (registration)
   const { unregisterOperator, status: unregisterStatus } =
@@ -1228,6 +1231,11 @@ const Page: FC = () => {
         myActiveProposalCount={myActiveProposalCount}
         nearestPendingSlash={nearestPendingSlash}
         nearestPendingSlashEligibility={nearestPendingSlashEligibility}
+      />
+
+      <SlashingParametersCard
+        config={slashConfig}
+        isLoading={loadingSlashConfig}
       />
 
       {clockError ? (

--- a/apps/tangle-cloud/src/pages/operators/manage/page.tsx
+++ b/apps/tangle-cloud/src/pages/operators/manage/page.tsx
@@ -34,6 +34,7 @@ import {
   useServicesByOperator,
   useActiveServiceMemberships,
   useSlashProposals,
+  useSlashConfig,
   useDisputeSlashTx,
   useCancelSlashTx,
   useProposeSlashTx,
@@ -333,6 +334,7 @@ const Page: FC = () => {
       enabled: isConnected,
       proposals: slashProposals,
     });
+  const { data: slashConfig } = useSlashConfig({ enabled: isConnected });
 
   // Transaction hooks (registration)
   const { unregisterOperator, status: unregisterStatus } =
@@ -505,6 +507,22 @@ const Page: FC = () => {
     }
 
     return buildSlashTimeline(selectedSlash, nowUnixSeconds);
+  }, [selectedSlash, nowUnixSeconds]);
+
+  const disputeBond = slashConfig?.disputeBond ?? BigInt(0);
+  const slashConfigMaxSlashBps = slashConfig?.maxSlashBps;
+
+  // Only meaningful when the slash is already in `Disputed` state and we have
+  // an authoritative on-chain disputeDeadline. Returns null otherwise so the
+  // modal can decide not to render the row.
+  const selectedSlashDisputeResolutionSecondsRemaining = useMemo(() => {
+    if (!selectedSlash || selectedSlash.status !== 'Disputed') {
+      return null;
+    }
+    if (selectedSlash.disputeDeadline === BigInt(0)) {
+      return null;
+    }
+    return Number(selectedSlash.disputeDeadline) - nowUnixSeconds;
   }, [selectedSlash, nowUnixSeconds]);
 
   const nearestPendingSlash = useMemo(() => {
@@ -1435,6 +1453,10 @@ const Page: FC = () => {
         onConfirm={() => void handleDispute()}
         errorMessage={actionError.dispute}
         onDismissError={() => clearActionError('dispute')}
+        disputeBond={disputeBond}
+        disputeResolutionSecondsRemaining={
+          selectedSlashDisputeResolutionSecondsRemaining
+        }
       />
 
       <CancelSlashModal

--- a/libs/tangle-shared-ui/src/abi/blueprintServiceManager.ts
+++ b/libs/tangle-shared-ui/src/abi/blueprintServiceManager.ts
@@ -1,808 +1,827 @@
 // AUTO-GENERATED FROM tnt-core. DO NOT EDIT MANUALLY.
 const ABI = [
   {
-    type: 'function',
-    name: 'canJoin',
-    inputs: [
+    "type": "function",
+    "name": "canJoin",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'allowed',
-        type: 'bool',
-        internalType: 'bool',
-      },
+        "name": "allowed",
+        "type": "bool",
+        "internalType": "bool"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'canLeave',
-    inputs: [
+    "type": "function",
+    "name": "canLeave",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'allowed',
-        type: 'bool',
-        internalType: 'bool',
-      },
+        "name": "allowed",
+        "type": "bool",
+        "internalType": "bool"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getAggregationThreshold',
-    inputs: [
+    "type": "function",
+    "name": "forceRemoveAllowsBelowMin",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'jobIndex',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'thresholdBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-      {
-        name: 'thresholdType',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
+        "name": "ok",
+        "type": "bool",
+        "internalType": "bool"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getExitConfig',
-    inputs: [
+    "type": "function",
+    "name": "getAggregationThreshold",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "jobIndex",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'useDefault',
-        type: 'bool',
-        internalType: 'bool',
+        "name": "thresholdBps",
+        "type": "uint16",
+        "internalType": "uint16"
       },
       {
-        name: 'minCommitmentDuration',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'exitQueueDuration',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'forceExitAllowed',
-        type: 'bool',
-        internalType: 'bool',
-      },
+        "name": "thresholdType",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getHeartbeatInterval',
-    inputs: [
+    "type": "function",
+    "name": "getExitConfig",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'useDefault',
-        type: 'bool',
-        internalType: 'bool',
+        "name": "useDefault",
+        "type": "bool",
+        "internalType": "bool"
       },
       {
-        name: 'interval',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "minCommitmentDuration",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "exitQueueDuration",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "forceExitAllowed",
+        "type": "bool",
+        "internalType": "bool"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getHeartbeatThreshold',
-    inputs: [
+    "type": "function",
+    "name": "getHeartbeatInterval",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'useDefault',
-        type: 'bool',
-        internalType: 'bool',
+        "name": "useDefault",
+        "type": "bool",
+        "internalType": "bool"
       },
       {
-        name: 'threshold',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
+        "name": "interval",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getMinOperatorStake',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "getHeartbeatThreshold",
+    "inputs": [
       {
-        name: 'useDefault',
-        type: 'bool',
-        internalType: 'bool',
-      },
-      {
-        name: 'minStake',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    stateMutability: 'view',
+    "outputs": [
+      {
+        "name": "useDefault",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "threshold",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getNonPaymentTerminationPolicy',
-    inputs: [
+    "type": "function",
+    "name": "getMinOperatorStake",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "useDefault",
+        "type": "bool",
+        "internalType": "bool"
       },
+      {
+        "name": "minStake",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    outputs: [
-      {
-        name: 'useDefault',
-        type: 'bool',
-        internalType: 'bool',
-      },
-      {
-        name: 'graceIntervals',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getRequiredResultCount',
-    inputs: [
+    "type": "function",
+    "name": "getNonPaymentTerminationPolicy",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'jobIndex',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'required',
-        type: 'uint32',
-        internalType: 'uint32',
+        "name": "useDefault",
+        "type": "bool",
+        "internalType": "bool"
       },
+      {
+        "name": "graceIntervals",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getSlashingWindow',
-    inputs: [
+    "type": "function",
+    "name": "getRequiredResultCount",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "jobIndex",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'useDefault',
-        type: 'bool',
-        internalType: 'bool',
-      },
-      {
-        name: 'window',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "required",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'onAggregatedResult',
-    inputs: [
+    "type": "function",
+    "name": "getSlashingWindow",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'job',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
-      {
-        name: 'jobCallId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'output',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-      {
-        name: 'signerBitmap',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: 'aggregatedSignature',
-        type: 'uint256[2]',
-        internalType: 'uint256[2]',
-      },
-      {
-        name: 'aggregatedPubkey',
-        type: 'uint256[4]',
-        internalType: 'uint256[4]',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [
+      {
+        "name": "useDefault",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "window",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'onApprove',
-    inputs: [
+    "type": "function",
+    "name": "onAggregatedResult",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'requestId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "job",
+        "type": "uint8",
+        "internalType": "uint8"
       },
       {
-        name: 'stakingPercent',
-        type: 'uint8',
-        internalType: 'uint8',
+        "name": "jobCallId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "output",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "signerBitmap",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "aggregatedSignature",
+        "type": "uint256[2]",
+        "internalType": "uint256[2]"
+      },
+      {
+        "name": "aggregatedPubkey",
+        "type": "uint256[4]",
+        "internalType": "uint256[4]"
+      }
     ],
-    outputs: [],
-    stateMutability: 'payable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'onBlueprintCreated',
-    inputs: [
+    "type": "function",
+    "name": "onApprove",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'owner',
-        type: 'address',
-        internalType: 'address',
+        "name": "requestId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'tangleCore',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "stakingPercent",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
-    type: 'function',
-    name: 'onExitCanceled',
-    inputs: [
+    "type": "function",
+    "name": "onBlueprintCreated",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
       },
+      {
+        "name": "tangleCore",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'onExitScheduled',
-    inputs: [
+    "type": "function",
+    "name": "onExitCanceled",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'executeAfter',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'onJobCall',
-    inputs: [
+    "type": "function",
+    "name": "onExitScheduled",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'job',
-        type: 'uint8',
-        internalType: 'uint8',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'jobCallId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'inputs',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
+        "name": "executeAfter",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'payable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'onJobResult',
-    inputs: [
+    "type": "function",
+    "name": "onJobCall",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'job',
-        type: 'uint8',
-        internalType: 'uint8',
+        "name": "job",
+        "type": "uint8",
+        "internalType": "uint8"
       },
       {
-        name: 'jobCallId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "jobCallId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'inputs',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-      {
-        name: 'outputs',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
+        "name": "inputs",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
     ],
-    outputs: [],
-    stateMutability: 'payable',
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
-    type: 'function',
-    name: 'onOperatorJoined',
-    inputs: [
+    "type": "function",
+    "name": "onJobResult",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
+        "name": "job",
+        "type": "uint8",
+        "internalType": "uint8"
       },
       {
-        name: 'exposureBps',
-        type: 'uint16',
-        internalType: 'uint16',
+        "name": "jobCallId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "inputs",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "outputs",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
-    type: 'function',
-    name: 'onOperatorLeft',
-    inputs: [
+    "type": "function",
+    "name": "onOperatorJoined",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
+      {
+        "name": "exposureBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'onRegister',
-    inputs: [
+    "type": "function",
+    "name": "onOperatorLeft",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'registrationInputs',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'payable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'onReject',
-    inputs: [
+    "type": "function",
+    "name": "onRegister",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'requestId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "registrationInputs",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
-    type: 'function',
-    name: 'onRequest',
-    inputs: [
+    "type": "function",
+    "name": "onReject",
+    "inputs": [
       {
-        name: 'requestId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'requester',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'operators',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
-      {
-        name: 'requestInputs',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-      {
-        name: 'ttl',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'paymentAsset',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'paymentAmount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "requestId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'payable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'onServiceInitialized',
-    inputs: [
+    "type": "function",
+    "name": "onRequest",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "requestId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'requestId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "requester",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "operators",
+        "type": "address[]",
+        "internalType": "address[]"
       },
       {
-        name: 'owner',
-        type: 'address',
-        internalType: 'address',
+        "name": "requestInputs",
+        "type": "bytes",
+        "internalType": "bytes"
       },
       {
-        name: 'permittedCallers',
-        type: 'address[]',
-        internalType: 'address[]',
+        "name": "ttl",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'ttl',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "paymentAsset",
+        "type": "address",
+        "internalType": "address"
       },
+      {
+        "name": "paymentAmount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
-    type: 'function',
-    name: 'onServiceTermination',
-    inputs: [
+    "type": "function",
+    "name": "onServiceInitialized",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'owner',
-        type: 'address',
-        internalType: 'address',
+        "name": "requestId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "permittedCallers",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "ttl",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'onSlash',
-    inputs: [
+    "type": "function",
+    "name": "onServiceTermination",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'offender',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-      {
-        name: 'slashPercent',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'onUnappliedSlash',
-    inputs: [
+    "type": "function",
+    "name": "onSlash",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'offender',
-        type: 'bytes',
-        internalType: 'bytes',
+        "name": "offender",
+        "type": "bytes",
+        "internalType": "bytes"
       },
       {
-        name: 'slashPercent',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
+        "name": "slashPercent",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'onUnregister',
-    inputs: [
+    "type": "function",
+    "name": "onUnappliedSlash",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "offender",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "slashPercent",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'onUpdatePreferences',
-    inputs: [
+    "type": "function",
+    "name": "onUnregister",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'newPreferences',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'payable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'queryDeveloperPaymentAddress',
-    inputs: [
+    "type": "function",
+    "name": "onUpdatePreferences",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
-    ],
-    outputs: [
       {
-        name: 'developerPaymentAddress',
-        type: 'address',
-        internalType: 'address payable',
-      },
+        "name": "newPreferences",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
     ],
-    stateMutability: 'view',
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
-    type: 'function',
-    name: 'queryDisputeOrigin',
-    inputs: [
+    "type": "function",
+    "name": "queryDeveloperPaymentAddress",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'disputeOrigin',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "developerPaymentAddress",
+        "type": "address",
+        "internalType": "address payable"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'queryIsPaymentAssetAllowed',
-    inputs: [
+    "type": "function",
+    "name": "queryDisputeOrigin",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'asset',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'isAllowed',
-        type: 'bool',
-        internalType: 'bool',
-      },
+        "name": "disputeOrigin",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'querySlashingOrigin',
-    inputs: [
+    "type": "function",
+    "name": "queryIsPaymentAssetAllowed",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
-    ],
-    outputs: [
       {
-        name: 'slashingOrigin',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    stateMutability: 'view',
+    "outputs": [
+      {
+        "name": "isAllowed",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'requiresAggregation',
-    inputs: [
+    "type": "function",
+    "name": "querySlashingOrigin",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'jobIndex',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'required',
-        type: 'bool',
-        internalType: 'bool',
-      },
+        "name": "slashingOrigin",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
+  {
+    "type": "function",
+    "name": "requiresAggregation",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "jobIndex",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "required",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  }
 ] as const;
 
 export default ABI;

--- a/libs/tangle-shared-ui/src/abi/blueprintServiceManager.ts
+++ b/libs/tangle-shared-ui/src/abi/blueprintServiceManager.ts
@@ -1,827 +1,827 @@
 // AUTO-GENERATED FROM tnt-core. DO NOT EDIT MANUALLY.
 const ABI = [
   {
-    "type": "function",
-    "name": "canJoin",
-    "inputs": [
+    type: 'function',
+    name: 'canJoin',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "allowed",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: 'allowed',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "canLeave",
-    "inputs": [
+    type: 'function',
+    name: 'canLeave',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "allowed",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: 'allowed',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "forceRemoveAllowsBelowMin",
-    "inputs": [
+    type: 'function',
+    name: 'forceRemoveAllowsBelowMin',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "ok",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: 'ok',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getAggregationThreshold",
-    "inputs": [
+    type: 'function',
+    name: 'getAggregationThreshold',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "jobIndex",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
+        name: 'jobIndex',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "thresholdBps",
-        "type": "uint16",
-        "internalType": "uint16"
+        name: 'thresholdBps',
+        type: 'uint16',
+        internalType: 'uint16',
       },
       {
-        "name": "thresholdType",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
+        name: 'thresholdType',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getExitConfig",
-    "inputs": [
+    type: 'function',
+    name: 'getExitConfig',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "useDefault",
-        "type": "bool",
-        "internalType": "bool"
+        name: 'useDefault',
+        type: 'bool',
+        internalType: 'bool',
       },
       {
-        "name": "minCommitmentDuration",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'minCommitmentDuration',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "exitQueueDuration",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'exitQueueDuration',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "forceExitAllowed",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: 'forceExitAllowed',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getHeartbeatInterval",
-    "inputs": [
+    type: 'function',
+    name: 'getHeartbeatInterval',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "useDefault",
-        "type": "bool",
-        "internalType": "bool"
+        name: 'useDefault',
+        type: 'bool',
+        internalType: 'bool',
       },
       {
-        "name": "interval",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'interval',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getHeartbeatThreshold",
-    "inputs": [
+    type: 'function',
+    name: 'getHeartbeatThreshold',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "useDefault",
-        "type": "bool",
-        "internalType": "bool"
+        name: 'useDefault',
+        type: 'bool',
+        internalType: 'bool',
       },
       {
-        "name": "threshold",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
+        name: 'threshold',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getMinOperatorStake",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'getMinOperatorStake',
+    inputs: [],
+    outputs: [
       {
-        "name": "useDefault",
-        "type": "bool",
-        "internalType": "bool"
+        name: 'useDefault',
+        type: 'bool',
+        internalType: 'bool',
       },
       {
-        "name": "minStake",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'minStake',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getNonPaymentTerminationPolicy",
-    "inputs": [
+    type: 'function',
+    name: 'getNonPaymentTerminationPolicy',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "useDefault",
-        "type": "bool",
-        "internalType": "bool"
+        name: 'useDefault',
+        type: 'bool',
+        internalType: 'bool',
       },
       {
-        "name": "graceIntervals",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'graceIntervals',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getRequiredResultCount",
-    "inputs": [
+    type: 'function',
+    name: 'getRequiredResultCount',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "jobIndex",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
+        name: 'jobIndex',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "required",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
+        name: 'required',
+        type: 'uint32',
+        internalType: 'uint32',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getSlashingWindow",
-    "inputs": [
+    type: 'function',
+    name: 'getSlashingWindow',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "useDefault",
-        "type": "bool",
-        "internalType": "bool"
+        name: 'useDefault',
+        type: 'bool',
+        internalType: 'bool',
       },
       {
-        "name": "window",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'window',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "onAggregatedResult",
-    "inputs": [
+    type: 'function',
+    name: 'onAggregatedResult',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "job",
-        "type": "uint8",
-        "internalType": "uint8"
+        name: 'job',
+        type: 'uint8',
+        internalType: 'uint8',
       },
       {
-        "name": "jobCallId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'jobCallId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "output",
-        "type": "bytes",
-        "internalType": "bytes"
+        name: 'output',
+        type: 'bytes',
+        internalType: 'bytes',
       },
       {
-        "name": "signerBitmap",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'signerBitmap',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "aggregatedSignature",
-        "type": "uint256[2]",
-        "internalType": "uint256[2]"
+        name: 'aggregatedSignature',
+        type: 'uint256[2]',
+        internalType: 'uint256[2]',
       },
       {
-        "name": "aggregatedPubkey",
-        "type": "uint256[4]",
-        "internalType": "uint256[4]"
-      }
+        name: 'aggregatedPubkey',
+        type: 'uint256[4]',
+        internalType: 'uint256[4]',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "onApprove",
-    "inputs": [
+    type: 'function',
+    name: 'onApprove',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "requestId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'requestId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "stakingPercent",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
+        name: 'stakingPercent',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "payable"
+    outputs: [],
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "onBlueprintCreated",
-    "inputs": [
+    type: 'function',
+    name: 'onBlueprintCreated',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "owner",
-        "type": "address",
-        "internalType": "address"
+        name: 'owner',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "tangleCore",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'tangleCore',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "onExitCanceled",
-    "inputs": [
+    type: 'function',
+    name: 'onExitCanceled',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "onExitScheduled",
-    "inputs": [
+    type: 'function',
+    name: 'onExitScheduled',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "executeAfter",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'executeAfter',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "onJobCall",
-    "inputs": [
+    type: 'function',
+    name: 'onJobCall',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "job",
-        "type": "uint8",
-        "internalType": "uint8"
+        name: 'job',
+        type: 'uint8',
+        internalType: 'uint8',
       },
       {
-        "name": "jobCallId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'jobCallId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "inputs",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
+        name: 'inputs',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "payable"
+    outputs: [],
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "onJobResult",
-    "inputs": [
+    type: 'function',
+    name: 'onJobResult',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "job",
-        "type": "uint8",
-        "internalType": "uint8"
+        name: 'job',
+        type: 'uint8',
+        internalType: 'uint8',
       },
       {
-        "name": "jobCallId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'jobCallId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "inputs",
-        "type": "bytes",
-        "internalType": "bytes"
+        name: 'inputs',
+        type: 'bytes',
+        internalType: 'bytes',
       },
       {
-        "name": "outputs",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
+        name: 'outputs',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "payable"
+    outputs: [],
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "onOperatorJoined",
-    "inputs": [
+    type: 'function',
+    name: 'onOperatorJoined',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "exposureBps",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: 'exposureBps',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "onOperatorLeft",
-    "inputs": [
+    type: 'function',
+    name: 'onOperatorLeft',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "onRegister",
-    "inputs": [
+    type: 'function',
+    name: 'onRegister',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "registrationInputs",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
+        name: 'registrationInputs',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "payable"
+    outputs: [],
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "onReject",
-    "inputs": [
+    type: 'function',
+    name: 'onReject',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "requestId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'requestId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "onRequest",
-    "inputs": [
+    type: 'function',
+    name: 'onRequest',
+    inputs: [
       {
-        "name": "requestId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'requestId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "requester",
-        "type": "address",
-        "internalType": "address"
+        name: 'requester',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "operators",
-        "type": "address[]",
-        "internalType": "address[]"
+        name: 'operators',
+        type: 'address[]',
+        internalType: 'address[]',
       },
       {
-        "name": "requestInputs",
-        "type": "bytes",
-        "internalType": "bytes"
+        name: 'requestInputs',
+        type: 'bytes',
+        internalType: 'bytes',
       },
       {
-        "name": "ttl",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'ttl',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "paymentAsset",
-        "type": "address",
-        "internalType": "address"
+        name: 'paymentAsset',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "paymentAmount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'paymentAmount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "payable"
+    outputs: [],
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "onServiceInitialized",
-    "inputs": [
+    type: 'function',
+    name: 'onServiceInitialized',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "requestId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'requestId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "owner",
-        "type": "address",
-        "internalType": "address"
+        name: 'owner',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "permittedCallers",
-        "type": "address[]",
-        "internalType": "address[]"
+        name: 'permittedCallers',
+        type: 'address[]',
+        internalType: 'address[]',
       },
       {
-        "name": "ttl",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'ttl',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "onServiceTermination",
-    "inputs": [
+    type: 'function',
+    name: 'onServiceTermination',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "owner",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'owner',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "onSlash",
-    "inputs": [
+    type: 'function',
+    name: 'onSlash',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "offender",
-        "type": "bytes",
-        "internalType": "bytes"
+        name: 'offender',
+        type: 'bytes',
+        internalType: 'bytes',
       },
       {
-        "name": "slashPercent",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
+        name: 'slashPercent',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "onUnappliedSlash",
-    "inputs": [
+    type: 'function',
+    name: 'onUnappliedSlash',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "offender",
-        "type": "bytes",
-        "internalType": "bytes"
+        name: 'offender',
+        type: 'bytes',
+        internalType: 'bytes',
       },
       {
-        "name": "slashPercent",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
+        name: 'slashPercent',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "onUnregister",
-    "inputs": [
+    type: 'function',
+    name: 'onUnregister',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "onUpdatePreferences",
-    "inputs": [
+    type: 'function',
+    name: 'onUpdatePreferences',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "newPreferences",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
+        name: 'newPreferences',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "payable"
+    outputs: [],
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "queryDeveloperPaymentAddress",
-    "inputs": [
+    type: 'function',
+    name: 'queryDeveloperPaymentAddress',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "developerPaymentAddress",
-        "type": "address",
-        "internalType": "address payable"
-      }
+        name: 'developerPaymentAddress',
+        type: 'address',
+        internalType: 'address payable',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "queryDisputeOrigin",
-    "inputs": [
+    type: 'function',
+    name: 'queryDisputeOrigin',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "disputeOrigin",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'disputeOrigin',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "queryIsPaymentAssetAllowed",
-    "inputs": [
+    type: 'function',
+    name: 'queryIsPaymentAssetAllowed',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "asset",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'asset',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "isAllowed",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: 'isAllowed',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "querySlashingOrigin",
-    "inputs": [
+    type: 'function',
+    name: 'querySlashingOrigin',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "slashingOrigin",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'slashingOrigin',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "requiresAggregation",
-    "inputs": [
+    type: 'function',
+    name: 'requiresAggregation',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "jobIndex",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
+        name: 'jobIndex',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "required",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: 'required',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
-  }
+    stateMutability: 'view',
+  },
 ] as const;
 
 export default ABI;

--- a/libs/tangle-shared-ui/src/abi/multiAssetDelegation.ts
+++ b/libs/tangle-shared-ui/src/abi/multiAssetDelegation.ts
@@ -1,2854 +1,2854 @@
 // AUTO-GENERATED FROM tnt-core. DO NOT EDIT MANUALLY.
 const ABI = [
   {
-    "type": "function",
-    "name": "LOCK_ONE_MONTH",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'LOCK_ONE_MONTH',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "LOCK_SIX_MONTHS",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'LOCK_SIX_MONTHS',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "LOCK_THREE_MONTHS",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'LOCK_THREE_MONTHS',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "LOCK_TWO_MONTHS",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'LOCK_TWO_MONTHS',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "MULTIPLIER_NONE",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'MULTIPLIER_NONE',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: '',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "MULTIPLIER_ONE_MONTH",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'MULTIPLIER_ONE_MONTH',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: '',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "MULTIPLIER_SIX_MONTHS",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'MULTIPLIER_SIX_MONTHS',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: '',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "MULTIPLIER_THREE_MONTHS",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'MULTIPLIER_THREE_MONTHS',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: '',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "MULTIPLIER_TWO_MONTHS",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'MULTIPLIER_TWO_MONTHS',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: '',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "addBlueprintForOperator",
-    "inputs": [
+    type: 'function',
+    name: 'addBlueprintForOperator',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "addBlueprintToDelegation",
-    "inputs": [
+    type: 'function',
+    name: 'addBlueprintToDelegation',
+    inputs: [
       {
-        "name": "delegationIndex",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'delegationIndex',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "addSlasher",
-    "inputs": [
+    type: 'function',
+    name: 'addSlasher',
+    inputs: [
       {
-        "name": "slasher",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'slasher',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "advanceRound",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: 'function',
+    name: 'advanceRound',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "canDelegate",
-    "inputs": [
+    type: 'function',
+    name: 'canDelegate',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "delegator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'delegator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "cancelCommissionChange",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: 'function',
+    name: 'cancelCommissionChange',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "completeLeaving",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: 'function',
+    name: 'completeLeaving',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "currentRound",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'currentRound',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "delegate",
-    "inputs": [
+    type: 'function',
+    name: 'delegate',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "delegateWithOptions",
-    "inputs": [
+    type: 'function',
+    name: 'delegateWithOptions',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "selectionMode",
-        "type": "uint8",
-        "internalType": "enum Types.BlueprintSelectionMode"
+        name: 'selectionMode',
+        type: 'uint8',
+        internalType: 'enum Types.BlueprintSelectionMode',
       },
       {
-        "name": "blueprintIds",
-        "type": "uint64[]",
-        "internalType": "uint64[]"
-      }
+        name: 'blueprintIds',
+        type: 'uint64[]',
+        internalType: 'uint64[]',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "delegationBondLessDelay",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'delegationBondLessDelay',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "deposit",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "payable"
+    type: 'function',
+    name: 'deposit',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "depositAndDelegate",
-    "inputs": [
+    type: 'function',
+    name: 'depositAndDelegate',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "payable"
+    outputs: [],
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "depositAndDelegateWithOptions",
-    "inputs": [
+    type: 'function',
+    name: 'depositAndDelegateWithOptions',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "selectionMode",
-        "type": "uint8",
-        "internalType": "enum Types.BlueprintSelectionMode"
+        name: 'selectionMode',
+        type: 'uint8',
+        internalType: 'enum Types.BlueprintSelectionMode',
       },
       {
-        "name": "blueprintIds",
-        "type": "uint64[]",
-        "internalType": "uint64[]"
-      }
+        name: 'blueprintIds',
+        type: 'uint64[]',
+        internalType: 'uint64[]',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "payable"
+    outputs: [],
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "depositERC20",
-    "inputs": [
+    type: 'function',
+    name: 'depositERC20',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "depositERC20WithLock",
-    "inputs": [
+    type: 'function',
+    name: 'depositERC20WithLock',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "lockMultiplier",
-        "type": "uint8",
-        "internalType": "enum Types.LockMultiplier"
-      }
+        name: 'lockMultiplier',
+        type: 'uint8',
+        internalType: 'enum Types.LockMultiplier',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "depositWithLock",
-    "inputs": [
+    type: 'function',
+    name: 'depositWithLock',
+    inputs: [
       {
-        "name": "lockMultiplier",
-        "type": "uint8",
-        "internalType": "enum Types.LockMultiplier"
-      }
+        name: 'lockMultiplier',
+        type: 'uint8',
+        internalType: 'enum Types.LockMultiplier',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "payable"
+    outputs: [],
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "disableAsset",
-    "inputs": [
+    type: 'function',
+    name: 'disableAsset',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "enableAsset",
-    "inputs": [
+    type: 'function',
+    name: 'enableAsset',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "minOperatorStake",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'minOperatorStake',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "minDelegation",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'minDelegation',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "depositCap",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'depositCap',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "rewardMultiplierBps",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: 'rewardMultiplierBps',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "enableAssetWithAdapter",
-    "inputs": [
+    type: 'function',
+    name: 'enableAssetWithAdapter',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "adapter",
-        "type": "address",
-        "internalType": "address"
+        name: 'adapter',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "minOperatorStake",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'minOperatorStake',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "minDelegation",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'minDelegation',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "depositCap",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'depositCap',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "rewardMultiplierBps",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: 'rewardMultiplierBps',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "executeCommissionChange",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: 'function',
+    name: 'executeCommissionChange',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "executeDelegatorUnstake",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: 'function',
+    name: 'executeDelegatorUnstake',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "executeDelegatorUnstakeAndWithdraw",
-    "inputs": [
+    type: 'function',
+    name: 'executeDelegatorUnstakeAndWithdraw',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "shares",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'shares',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "requestedRound",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'requestedRound',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "receiver",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'receiver',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "nonpayable"
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "executeOperatorUnstake",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: 'function',
+    name: 'executeOperatorUnstake',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "executeWithdraw",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: 'function',
+    name: 'executeWithdraw',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "getAssetConfig",
-    "inputs": [
+    type: 'function',
+    name: 'getAssetConfig',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Types.AssetConfig",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct Types.AssetConfig',
+        components: [
           {
-            "name": "enabled",
-            "type": "bool",
-            "internalType": "bool"
+            name: 'enabled',
+            type: 'bool',
+            internalType: 'bool',
           },
           {
-            "name": "minOperatorStake",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'minOperatorStake',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "minDelegation",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'minDelegation',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "depositCap",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'depositCap',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "currentDeposits",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'currentDeposits',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "rewardMultiplierBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          }
-        ]
-      }
+            name: 'rewardMultiplierBps',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getDelegation",
-    "inputs": [
+    type: 'function',
+    name: 'getDelegation',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "internalType": "address"
+        name: 'delegator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getDelegationBlueprints",
-    "inputs": [
+    type: 'function',
+    name: 'getDelegationBlueprints',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "internalType": "address"
+        name: 'delegator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "idx",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'idx',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint64[]",
-        "internalType": "uint64[]"
-      }
+        name: '',
+        type: 'uint64[]',
+        internalType: 'uint64[]',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getDelegationMode",
-    "inputs": [
+    type: 'function',
+    name: 'getDelegationMode',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint8",
-        "internalType": "enum Types.DelegationMode"
-      }
+        name: '',
+        type: 'uint8',
+        internalType: 'enum Types.DelegationMode',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getDelegations",
-    "inputs": [
+    type: 'function',
+    name: 'getDelegations',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'delegator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple[]",
-        "internalType": "struct Types.BondInfoDelegator[]",
-        "components": [
+        name: '',
+        type: 'tuple[]',
+        internalType: 'struct Types.BondInfoDelegator[]',
+        components: [
           {
-            "name": "operator",
-            "type": "address",
-            "internalType": "address"
+            name: 'operator',
+            type: 'address',
+            internalType: 'address',
           },
           {
-            "name": "shares",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'shares',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "asset",
-            "type": "tuple",
-            "internalType": "struct Types.Asset",
-            "components": [
+            name: 'asset',
+            type: 'tuple',
+            internalType: 'struct Types.Asset',
+            components: [
               {
-                "name": "kind",
-                "type": "uint8",
-                "internalType": "enum Types.AssetKind"
+                name: 'kind',
+                type: 'uint8',
+                internalType: 'enum Types.AssetKind',
               },
               {
-                "name": "token",
-                "type": "address",
-                "internalType": "address"
-              }
-            ]
+                name: 'token',
+                type: 'address',
+                internalType: 'address',
+              },
+            ],
           },
           {
-            "name": "selectionMode",
-            "type": "uint8",
-            "internalType": "enum Types.BlueprintSelectionMode"
-          }
-        ]
-      }
+            name: 'selectionMode',
+            type: 'uint8',
+            internalType: 'enum Types.BlueprintSelectionMode',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getDeposit",
-    "inputs": [
+    type: 'function',
+    name: 'getDeposit',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "internalType": "address"
+        name: 'delegator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Types.Deposit",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct Types.Deposit',
+        components: [
           {
-            "name": "amount",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'amount',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "delegatedAmount",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
+            name: 'delegatedAmount',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getLocks",
-    "inputs": [
+    type: 'function',
+    name: 'getLocks',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "internalType": "address"
+        name: 'delegator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple[]",
-        "internalType": "struct Types.LockInfo[]",
-        "components": [
+        name: '',
+        type: 'tuple[]',
+        internalType: 'struct Types.LockInfo[]',
+        components: [
           {
-            "name": "amount",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'amount',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "multiplier",
-            "type": "uint8",
-            "internalType": "enum Types.LockMultiplier"
+            name: 'multiplier',
+            type: 'uint8',
+            internalType: 'enum Types.LockMultiplier',
           },
           {
-            "name": "expiryBlock",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
-        ]
-      }
+            name: 'expiryBlock',
+            type: 'uint64',
+            internalType: 'uint64',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorBlueprints",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorBlueprints',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256[]",
-        "internalType": "uint256[]"
-      }
+        name: '',
+        type: 'uint256[]',
+        internalType: 'uint256[]',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorDelegatedStake",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorDelegatedStake',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorDelegatedStakeForAsset",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorDelegatedStakeForAsset',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "asset",
-        "type": "tuple",
-        "internalType": "struct Types.Asset",
-        "components": [
+        name: 'asset',
+        type: 'tuple',
+        internalType: 'struct Types.Asset',
+        components: [
           {
-            "name": "kind",
-            "type": "uint8",
-            "internalType": "enum Types.AssetKind"
+            name: 'kind',
+            type: 'uint8',
+            internalType: 'enum Types.AssetKind',
           },
           {
-            "name": "token",
-            "type": "address",
-            "internalType": "address"
-          }
-        ]
-      }
+            name: 'token',
+            type: 'address',
+            internalType: 'address',
+          },
+        ],
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorDelegatorCount",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorDelegatorCount',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorDelegators",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorDelegators',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "address[]",
-        "internalType": "address[]"
-      }
+        name: '',
+        type: 'address[]',
+        internalType: 'address[]',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorMetadata",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorMetadata',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Types.OperatorMetadata",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct Types.OperatorMetadata',
+        components: [
           {
-            "name": "stake",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'stake',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "delegationCount",
-            "type": "uint32",
-            "internalType": "uint32"
+            name: 'delegationCount',
+            type: 'uint32',
+            internalType: 'uint32',
           },
           {
-            "name": "status",
-            "type": "uint8",
-            "internalType": "enum Types.OperatorStatus"
+            name: 'status',
+            type: 'uint8',
+            internalType: 'enum Types.OperatorStatus',
           },
           {
-            "name": "leavingRound",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
-        ]
-      }
+            name: 'leavingRound',
+            type: 'uint64',
+            internalType: 'uint64',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorRewardPool",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorRewardPool',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Types.OperatorRewardPool",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct Types.OperatorRewardPool',
+        components: [
           {
-            "name": "totalShares",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'totalShares',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "totalAssets",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
+            name: 'totalAssets',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorSelfStake",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorSelfStake',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorStake",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorStake',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorStakeForAsset",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorStakeForAsset',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "asset",
-        "type": "tuple",
-        "internalType": "struct Types.Asset",
-        "components": [
+        name: 'asset',
+        type: 'tuple',
+        internalType: 'struct Types.Asset',
+        components: [
           {
-            "name": "kind",
-            "type": "uint8",
-            "internalType": "enum Types.AssetKind"
+            name: 'kind',
+            type: 'uint8',
+            internalType: 'enum Types.AssetKind',
           },
           {
-            "name": "token",
-            "type": "address",
-            "internalType": "address"
-          }
-        ]
-      }
+            name: 'token',
+            type: 'address',
+            internalType: 'address',
+          },
+        ],
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getPendingCommissionChange",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'getPendingCommissionChange',
+    inputs: [],
+    outputs: [
       {
-        "name": "pendingBps",
-        "type": "uint16",
-        "internalType": "uint16"
+        name: 'pendingBps',
+        type: 'uint16',
+        internalType: 'uint16',
       },
       {
-        "name": "executeAfter",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'executeAfter',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getPendingUnstakes",
-    "inputs": [
+    type: 'function',
+    name: 'getPendingUnstakes',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'delegator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple[]",
-        "internalType": "struct Types.BondLessRequest[]",
-        "components": [
+        name: '',
+        type: 'tuple[]',
+        internalType: 'struct Types.BondLessRequest[]',
+        components: [
           {
-            "name": "operator",
-            "type": "address",
-            "internalType": "address"
+            name: 'operator',
+            type: 'address',
+            internalType: 'address',
           },
           {
-            "name": "asset",
-            "type": "tuple",
-            "internalType": "struct Types.Asset",
-            "components": [
+            name: 'asset',
+            type: 'tuple',
+            internalType: 'struct Types.Asset',
+            components: [
               {
-                "name": "kind",
-                "type": "uint8",
-                "internalType": "enum Types.AssetKind"
+                name: 'kind',
+                type: 'uint8',
+                internalType: 'enum Types.AssetKind',
               },
               {
-                "name": "token",
-                "type": "address",
-                "internalType": "address"
-              }
-            ]
+                name: 'token',
+                type: 'address',
+                internalType: 'address',
+              },
+            ],
           },
           {
-            "name": "shares",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'shares',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "requestedRound",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'requestedRound',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "selectionMode",
-            "type": "uint8",
-            "internalType": "enum Types.BlueprintSelectionMode"
+            name: 'selectionMode',
+            type: 'uint8',
+            internalType: 'enum Types.BlueprintSelectionMode',
           },
           {
-            "name": "slashFactorSnapshot",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
+            name: 'slashFactorSnapshot',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getPendingWithdrawals",
-    "inputs": [
+    type: 'function',
+    name: 'getPendingWithdrawals',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'delegator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple[]",
-        "internalType": "struct Types.WithdrawRequest[]",
-        "components": [
+        name: '',
+        type: 'tuple[]',
+        internalType: 'struct Types.WithdrawRequest[]',
+        components: [
           {
-            "name": "asset",
-            "type": "tuple",
-            "internalType": "struct Types.Asset",
-            "components": [
+            name: 'asset',
+            type: 'tuple',
+            internalType: 'struct Types.Asset',
+            components: [
               {
-                "name": "kind",
-                "type": "uint8",
-                "internalType": "enum Types.AssetKind"
+                name: 'kind',
+                type: 'uint8',
+                internalType: 'enum Types.AssetKind',
               },
               {
-                "name": "token",
-                "type": "address",
-                "internalType": "address"
-              }
-            ]
+                name: 'token',
+                type: 'address',
+                internalType: 'address',
+              },
+            ],
           },
           {
-            "name": "amount",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'amount',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "requestedRound",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
-        ]
-      }
+            name: 'requestedRound',
+            type: 'uint64',
+            internalType: 'uint64',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getSlashCount",
-    "inputs": [
+    type: 'function',
+    name: 'getSlashCount',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getSlashCountForBlueprint",
-    "inputs": [
+    type: 'function',
+    name: 'getSlashCountForBlueprint',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getSlashCountForService",
-    "inputs": [
+    type: 'function',
+    name: 'getSlashCountForService',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getSlashImpact",
-    "inputs": [
+    type: 'function',
+    name: 'getSlashImpact',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "slashIndex",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'slashIndex',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "delegator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'delegator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getSlashRecord",
-    "inputs": [
+    type: 'function',
+    name: 'getSlashRecord',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "slashIndex",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'slashIndex',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct SlashingManager.SlashRecord",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct SlashingManager.SlashRecord',
+        components: [
           {
-            "name": "round",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'round',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "serviceId",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'serviceId',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "blueprintId",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'blueprintId',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "assetHash",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: 'assetHash',
+            type: 'bytes32',
+            internalType: 'bytes32',
           },
           {
-            "name": "slashBps",
-            "type": "uint16",
-            "internalType": "uint16"
+            name: 'slashBps',
+            type: 'uint16',
+            internalType: 'uint16',
           },
           {
-            "name": "totalSlashed",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'totalSlashed',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "exchangeRateBefore",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'exchangeRateBefore',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "exchangeRateAfter",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'exchangeRateAfter',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "evidence",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          }
-        ]
-      }
+            name: 'evidence',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getTotalDelegation",
-    "inputs": [
+    type: 'function',
+    name: 'getTotalDelegation',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'delegator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "total",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'total',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "increaseStake",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "payable"
+    type: 'function',
+    name: 'increaseStake',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "increaseStakeWithAsset",
-    "inputs": [
+    type: 'function',
+    name: 'increaseStakeWithAsset',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "isOperator",
-    "inputs": [
+    type: 'function',
+    name: 'isOperator',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "isOperatorActive",
-    "inputs": [
+    type: 'function',
+    name: 'isOperatorActive',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "isSlasher",
-    "inputs": [
+    type: 'function',
+    name: 'isSlasher',
+    inputs: [
       {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "isWhitelisted",
-    "inputs": [
+    type: 'function',
+    name: 'isWhitelisted',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "delegator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'delegator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "leaveDelegatorsDelay",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'leaveDelegatorsDelay',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "leaveOperatorsDelay",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'leaveOperatorsDelay',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "meetsStakeRequirement",
-    "inputs": [
+    type: 'function',
+    name: 'meetsStakeRequirement',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "required",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'required',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "minOperatorStake",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'minOperatorStake',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "operatorAt",
-    "inputs": [
+    type: 'function',
+    name: 'operatorAt',
+    inputs: [
       {
-        "name": "index",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'index',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "operatorBondToken",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'operatorBondToken',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "operatorCommissionBps",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'operatorCommissionBps',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: '',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "operatorCount",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'operatorCount',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "pause",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: 'function',
+    name: 'pause',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "previewDelegatorUnstakeShares",
-    "inputs": [
+    type: 'function',
+    name: 'previewDelegatorUnstakeShares',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "registerAdapter",
-    "inputs": [
+    type: 'function',
+    name: 'registerAdapter',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "adapter",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'adapter',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "registerOperator",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "payable"
+    type: 'function',
+    name: 'registerOperator',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "registerOperatorWithAsset",
-    "inputs": [
+    type: 'function',
+    name: 'registerOperatorWithAsset',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "removeAdapter",
-    "inputs": [
+    type: 'function',
+    name: 'removeAdapter',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "removeBlueprintForOperator",
-    "inputs": [
+    type: 'function',
+    name: 'removeBlueprintForOperator',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "removeBlueprintFromDelegation",
-    "inputs": [
+    type: 'function',
+    name: 'removeBlueprintFromDelegation',
+    inputs: [
       {
-        "name": "delegationIndex",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'delegationIndex',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "removeSlasher",
-    "inputs": [
+    type: 'function',
+    name: 'removeSlasher',
+    inputs: [
       {
-        "name": "slasher",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'slasher',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "rescueTokens",
-    "inputs": [
+    type: 'function',
+    name: 'rescueTokens',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "to",
-        "type": "address",
-        "internalType": "address"
+        name: 'to',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "rewardsManager",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'rewardsManager',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "roundDuration",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'roundDuration',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "scheduleDelegatorUnstake",
-    "inputs": [
+    type: 'function',
+    name: 'scheduleDelegatorUnstake',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "scheduleOperatorUnstake",
-    "inputs": [
+    type: 'function',
+    name: 'scheduleOperatorUnstake',
+    inputs: [
       {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "scheduleWithdraw",
-    "inputs": [
+    type: 'function',
+    name: 'scheduleWithdraw',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "serviceFeeDistributor",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'serviceFeeDistributor',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "setDelays",
-    "inputs": [
+    type: 'function',
+    name: 'setDelays',
+    inputs: [
       {
-        "name": "delegationBondLessDelay",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'delegationBondLessDelay',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "leaveDelegatorsDelay",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'leaveDelegatorsDelay',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "leaveOperatorsDelay",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'leaveOperatorsDelay',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setDelegationMode",
-    "inputs": [
+    type: 'function',
+    name: 'setDelegationMode',
+    inputs: [
       {
-        "name": "mode",
-        "type": "uint8",
-        "internalType": "enum Types.DelegationMode"
-      }
+        name: 'mode',
+        type: 'uint8',
+        internalType: 'enum Types.DelegationMode',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setDelegationWhitelist",
-    "inputs": [
+    type: 'function',
+    name: 'setDelegationWhitelist',
+    inputs: [
       {
-        "name": "delegators",
-        "type": "address[]",
-        "internalType": "address[]"
+        name: 'delegators',
+        type: 'address[]',
+        internalType: 'address[]',
       },
       {
-        "name": "approved",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: 'approved',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setOperatorBondToken",
-    "inputs": [
+    type: 'function',
+    name: 'setOperatorBondToken',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setOperatorCommission",
-    "inputs": [
+    type: 'function',
+    name: 'setOperatorCommission',
+    inputs: [
       {
-        "name": "bps",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: 'bps',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setRequireAdapters",
-    "inputs": [
+    type: 'function',
+    name: 'setRequireAdapters',
+    inputs: [
       {
-        "name": "required",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: 'required',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setRewardsManager",
-    "inputs": [
+    type: 'function',
+    name: 'setRewardsManager',
+    inputs: [
       {
-        "name": "manager",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'manager',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setServiceFeeDistributor",
-    "inputs": [
+    type: 'function',
+    name: 'setServiceFeeDistributor',
+    inputs: [
       {
-        "name": "distributor",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'distributor',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setTangle",
-    "inputs": [
+    type: 'function',
+    name: 'setTangle',
+    inputs: [
       {
-        "name": "tangle",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'tangle',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "slash",
-    "inputs": [
+    type: 'function',
+    name: 'slash',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "slashBps",
-        "type": "uint16",
-        "internalType": "uint16"
+        name: 'slashBps',
+        type: 'uint16',
+        internalType: 'uint16',
       },
       {
-        "name": "evidence",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: 'evidence',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "actualSlashed",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'actualSlashed',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "nonpayable"
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "slashForBlueprint",
-    "inputs": [
+    type: 'function',
+    name: 'slashForBlueprint',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "slashBps",
-        "type": "uint16",
-        "internalType": "uint16"
+        name: 'slashBps',
+        type: 'uint16',
+        internalType: 'uint16',
       },
       {
-        "name": "evidence",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: 'evidence',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "actualSlashed",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'actualSlashed',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "nonpayable"
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "slashForService",
-    "inputs": [
+    type: 'function',
+    name: 'slashForService',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "commitments",
-        "type": "tuple[]",
-        "internalType": "struct Types.AssetSecurityCommitment[]",
-        "components": [
+        name: 'commitments',
+        type: 'tuple[]',
+        internalType: 'struct Types.AssetSecurityCommitment[]',
+        components: [
           {
-            "name": "asset",
-            "type": "tuple",
-            "internalType": "struct Types.Asset",
-            "components": [
+            name: 'asset',
+            type: 'tuple',
+            internalType: 'struct Types.Asset',
+            components: [
               {
-                "name": "kind",
-                "type": "uint8",
-                "internalType": "enum Types.AssetKind"
+                name: 'kind',
+                type: 'uint8',
+                internalType: 'enum Types.AssetKind',
               },
               {
-                "name": "token",
-                "type": "address",
-                "internalType": "address"
-              }
-            ]
+                name: 'token',
+                type: 'address',
+                internalType: 'address',
+              },
+            ],
           },
           {
-            "name": "exposureBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          }
-        ]
+            name: 'exposureBps',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+        ],
       },
       {
-        "name": "slashBps",
-        "type": "uint16",
-        "internalType": "uint16"
+        name: 'slashBps',
+        type: 'uint16',
+        internalType: 'uint16',
       },
       {
-        "name": "evidence",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: 'evidence',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "actualSlashed",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'actualSlashed',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "nonpayable"
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "snapshotOperator",
-    "inputs": [
+    type: 'function',
+    name: 'snapshotOperator',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "startLeaving",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: 'function',
+    name: 'startLeaving',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "undelegate",
-    "inputs": [
+    type: 'function',
+    name: 'undelegate',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "unpause",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: 'function',
+    name: 'unpause',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "event",
-    "name": "AdapterRegistered",
-    "inputs": [
+    type: 'event',
+    name: 'AdapterRegistered',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "adapter",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
+        name: 'adapter',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "AdapterRemoved",
-    "inputs": [
+    type: 'event',
+    name: 'AdapterRemoved',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "AssetDisabled",
-    "inputs": [
+    type: 'event',
+    name: 'AssetDisabled',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "AssetEnabled",
-    "inputs": [
+    type: 'event',
+    name: 'AssetEnabled',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "minOperatorStake",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'minOperatorStake',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "minDelegation",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'minDelegation',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "BlueprintAddedToDelegation",
-    "inputs": [
+    type: 'event',
+    name: 'BlueprintAddedToDelegation',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'delegator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "delegationIndex",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
+        name: 'delegationIndex',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "BlueprintRemovedFromDelegation",
-    "inputs": [
+    type: 'event',
+    name: 'BlueprintRemovedFromDelegation',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'delegator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "delegationIndex",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
+        name: 'delegationIndex',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "Delegated",
-    "inputs": [
+    type: 'event',
+    name: 'Delegated',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'delegator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "shares",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'shares',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "selectionMode",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "enum Types.BlueprintSelectionMode"
-      }
+        name: 'selectionMode',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'enum Types.BlueprintSelectionMode',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "DelegatorUnstakeExecuted",
-    "inputs": [
+    type: 'event',
+    name: 'DelegatorUnstakeExecuted',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'delegator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "shares",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'shares',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "DelegatorUnstakeScheduled",
-    "inputs": [
+    type: 'event',
+    name: 'DelegatorUnstakeScheduled',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'delegator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "shares",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'shares',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "estimatedAmount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'estimatedAmount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "readyRound",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
+        name: 'readyRound',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "Deposited",
-    "inputs": [
+    type: 'event',
+    name: 'Deposited',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'delegator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "lock",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "enum Types.LockMultiplier"
-      }
+        name: 'lock',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'enum Types.LockMultiplier',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "ExpiredLocksHarvested",
-    "inputs": [
+    type: 'event',
+    name: 'ExpiredLocksHarvested',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'delegator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "count",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'count',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "totalAmount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'totalAmount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorBlueprintAdded",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorBlueprintAdded',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorBlueprintRemoved",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorBlueprintRemoved',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorLeavingScheduled",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorLeavingScheduled',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "readyRound",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
+        name: 'readyRound',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorLeft",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorLeft',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorRegistered",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorRegistered',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "stake",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'stake',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorStakeIncreased",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorStakeIncreased',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorUnstakeExecuted",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorUnstakeExecuted',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorUnstakeScheduled",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorUnstakeScheduled',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "readyRound",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
+        name: 'readyRound',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "RequireAdaptersUpdated",
-    "inputs": [
+    type: 'event',
+    name: 'RequireAdaptersUpdated',
+    inputs: [
       {
-        "name": "required",
-        "type": "bool",
-        "indexed": false,
-        "internalType": "bool"
-      }
+        name: 'required',
+        type: 'bool',
+        indexed: false,
+        internalType: 'bool',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "RoundAdvanced",
-    "inputs": [
+    type: 'event',
+    name: 'RoundAdvanced',
+    inputs: [
       {
-        "name": "round",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
-      }
+        name: 'round',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "SlashRecorded",
-    "inputs": [
+    type: 'event',
+    name: 'SlashRecorded',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "slashId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'slashId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "assetHash",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
+        name: 'assetHash',
+        type: 'bytes32',
+        indexed: false,
+        internalType: 'bytes32',
       },
       {
-        "name": "slashBps",
-        "type": "uint16",
-        "indexed": false,
-        "internalType": "uint16"
+        name: 'slashBps',
+        type: 'uint16',
+        indexed: false,
+        internalType: 'uint16',
       },
       {
-        "name": "totalSlashed",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'totalSlashed',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "exchangeRateBefore",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'exchangeRateBefore',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "exchangeRateAfter",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'exchangeRateAfter',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "Slashed",
-    "inputs": [
+    type: 'event',
+    name: 'Slashed',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "assetHash",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
+        name: 'assetHash',
+        type: 'bytes32',
+        indexed: false,
+        internalType: 'bytes32',
       },
       {
-        "name": "slashBps",
-        "type": "uint16",
-        "indexed": false,
-        "internalType": "uint16"
+        name: 'slashBps',
+        type: 'uint16',
+        indexed: false,
+        internalType: 'uint16',
       },
       {
-        "name": "operatorSlashed",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'operatorSlashed',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "delegatorsSlashed",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'delegatorsSlashed',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "exchangeRateAfter",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'exchangeRateAfter',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "SlashedForService",
-    "inputs": [
+    type: 'event',
+    name: 'SlashedForService',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "totalSlashed",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'totalSlashed',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "commitmentCount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'commitmentCount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "WithdrawScheduled",
-    "inputs": [
+    type: 'event',
+    name: 'WithdrawScheduled',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'delegator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "readyRound",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
+        name: 'readyRound',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "Withdrawn",
-    "inputs": [
+    type: 'event',
+    name: 'Withdrawn',
+    inputs: [
       {
-        "name": "delegator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'delegator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
-  }
+    anonymous: false,
+  },
 ] as const;
 
 export default ABI;

--- a/libs/tangle-shared-ui/src/abi/multiAssetDelegation.ts
+++ b/libs/tangle-shared-ui/src/abi/multiAssetDelegation.ts
@@ -1,2854 +1,2854 @@
 // AUTO-GENERATED FROM tnt-core. DO NOT EDIT MANUALLY.
 const ABI = [
   {
-    type: 'function',
-    name: 'LOCK_ONE_MONTH',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "LOCK_ONE_MONTH",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'LOCK_SIX_MONTHS',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "LOCK_SIX_MONTHS",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'LOCK_THREE_MONTHS',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "LOCK_THREE_MONTHS",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'LOCK_TWO_MONTHS',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "LOCK_TWO_MONTHS",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'MULTIPLIER_NONE',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "MULTIPLIER_NONE",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'MULTIPLIER_ONE_MONTH',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "MULTIPLIER_ONE_MONTH",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'MULTIPLIER_SIX_MONTHS',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "MULTIPLIER_SIX_MONTHS",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'MULTIPLIER_THREE_MONTHS',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "MULTIPLIER_THREE_MONTHS",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'MULTIPLIER_TWO_MONTHS',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "MULTIPLIER_TWO_MONTHS",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'addBlueprintForOperator',
-    inputs: [
+    "type": "function",
+    "name": "addBlueprintForOperator",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'addBlueprintToDelegation',
-    inputs: [
+    "type": "function",
+    "name": "addBlueprintToDelegation",
+    "inputs": [
       {
-        name: 'delegationIndex',
-        type: 'uint256',
-        internalType: 'uint256',
+        "name": "delegationIndex",
+        "type": "uint256",
+        "internalType": "uint256"
       },
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'addSlasher',
-    inputs: [
+    "type": "function",
+    "name": "addSlasher",
+    "inputs": [
       {
-        name: 'slasher',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "slasher",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'advanceRound',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "type": "function",
+    "name": "advanceRound",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'canDelegate',
-    inputs: [
+    "type": "function",
+    "name": "canDelegate",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'delegator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "delegator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'bool',
-        internalType: 'bool',
-      },
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'cancelCommissionChange',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "type": "function",
+    "name": "cancelCommissionChange",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'completeLeaving',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "type": "function",
+    "name": "completeLeaving",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'currentRound',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "currentRound",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'delegate',
-    inputs: [
+    "type": "function",
+    "name": "delegate",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'amount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'delegateWithOptions',
-    inputs: [
+    "type": "function",
+    "name": "delegateWithOptions",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'amount',
-        type: 'uint256',
-        internalType: 'uint256',
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
       },
       {
-        name: 'selectionMode',
-        type: 'uint8',
-        internalType: 'enum Types.BlueprintSelectionMode',
+        "name": "selectionMode",
+        "type": "uint8",
+        "internalType": "enum Types.BlueprintSelectionMode"
       },
       {
-        name: 'blueprintIds',
-        type: 'uint64[]',
-        internalType: 'uint64[]',
-      },
+        "name": "blueprintIds",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'delegationBondLessDelay',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "delegationBondLessDelay",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'deposit',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'payable',
+    "type": "function",
+    "name": "deposit",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
-    type: 'function',
-    name: 'depositAndDelegate',
-    inputs: [
+    "type": "function",
+    "name": "depositAndDelegate",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'payable',
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
-    type: 'function',
-    name: 'depositAndDelegateWithOptions',
-    inputs: [
+    "type": "function",
+    "name": "depositAndDelegateWithOptions",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'amount',
-        type: 'uint256',
-        internalType: 'uint256',
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
       },
       {
-        name: 'selectionMode',
-        type: 'uint8',
-        internalType: 'enum Types.BlueprintSelectionMode',
+        "name": "selectionMode",
+        "type": "uint8",
+        "internalType": "enum Types.BlueprintSelectionMode"
       },
       {
-        name: 'blueprintIds',
-        type: 'uint64[]',
-        internalType: 'uint64[]',
-      },
+        "name": "blueprintIds",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      }
     ],
-    outputs: [],
-    stateMutability: 'payable',
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
-    type: 'function',
-    name: 'depositERC20',
-    inputs: [
+    "type": "function",
+    "name": "depositERC20",
+    "inputs": [
       {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'amount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'depositERC20WithLock',
-    inputs: [
+    "type": "function",
+    "name": "depositERC20WithLock",
+    "inputs": [
       {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'amount',
-        type: 'uint256',
-        internalType: 'uint256',
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
       },
       {
-        name: 'lockMultiplier',
-        type: 'uint8',
-        internalType: 'enum Types.LockMultiplier',
-      },
+        "name": "lockMultiplier",
+        "type": "uint8",
+        "internalType": "enum Types.LockMultiplier"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'depositWithLock',
-    inputs: [
+    "type": "function",
+    "name": "depositWithLock",
+    "inputs": [
       {
-        name: 'lockMultiplier',
-        type: 'uint8',
-        internalType: 'enum Types.LockMultiplier',
-      },
+        "name": "lockMultiplier",
+        "type": "uint8",
+        "internalType": "enum Types.LockMultiplier"
+      }
     ],
-    outputs: [],
-    stateMutability: 'payable',
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
-    type: 'function',
-    name: 'disableAsset',
-    inputs: [
+    "type": "function",
+    "name": "disableAsset",
+    "inputs": [
       {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'enableAsset',
-    inputs: [
+    "type": "function",
+    "name": "enableAsset",
+    "inputs": [
       {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'minOperatorStake',
-        type: 'uint256',
-        internalType: 'uint256',
+        "name": "minOperatorStake",
+        "type": "uint256",
+        "internalType": "uint256"
       },
       {
-        name: 'minDelegation',
-        type: 'uint256',
-        internalType: 'uint256',
+        "name": "minDelegation",
+        "type": "uint256",
+        "internalType": "uint256"
       },
       {
-        name: 'depositCap',
-        type: 'uint256',
-        internalType: 'uint256',
+        "name": "depositCap",
+        "type": "uint256",
+        "internalType": "uint256"
       },
       {
-        name: 'rewardMultiplierBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
+        "name": "rewardMultiplierBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'enableAssetWithAdapter',
-    inputs: [
+    "type": "function",
+    "name": "enableAssetWithAdapter",
+    "inputs": [
       {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'adapter',
-        type: 'address',
-        internalType: 'address',
+        "name": "adapter",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'minOperatorStake',
-        type: 'uint256',
-        internalType: 'uint256',
+        "name": "minOperatorStake",
+        "type": "uint256",
+        "internalType": "uint256"
       },
       {
-        name: 'minDelegation',
-        type: 'uint256',
-        internalType: 'uint256',
+        "name": "minDelegation",
+        "type": "uint256",
+        "internalType": "uint256"
       },
       {
-        name: 'depositCap',
-        type: 'uint256',
-        internalType: 'uint256',
+        "name": "depositCap",
+        "type": "uint256",
+        "internalType": "uint256"
       },
       {
-        name: 'rewardMultiplierBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
+        "name": "rewardMultiplierBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'executeCommissionChange',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "type": "function",
+    "name": "executeCommissionChange",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'executeDelegatorUnstake',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "type": "function",
+    "name": "executeDelegatorUnstake",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'executeDelegatorUnstakeAndWithdraw',
-    inputs: [
+    "type": "function",
+    "name": "executeDelegatorUnstakeAndWithdraw",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'shares',
-        type: 'uint256',
-        internalType: 'uint256',
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
       },
       {
-        name: 'requestedRound',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "requestedRound",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'receiver',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'amount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    stateMutability: 'nonpayable',
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'executeOperatorUnstake',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "type": "function",
+    "name": "executeOperatorUnstake",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'executeWithdraw',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "type": "function",
+    "name": "executeWithdraw",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'getAssetConfig',
-    inputs: [
+    "type": "function",
+    "name": "getAssetConfig",
+    "inputs": [
       {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct Types.AssetConfig',
-        components: [
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Types.AssetConfig",
+        "components": [
           {
-            name: 'enabled',
-            type: 'bool',
-            internalType: 'bool',
+            "name": "enabled",
+            "type": "bool",
+            "internalType": "bool"
           },
           {
-            name: 'minOperatorStake',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "minOperatorStake",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'minDelegation',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "minDelegation",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'depositCap',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "depositCap",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'currentDeposits',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "currentDeposits",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'rewardMultiplierBps',
-            type: 'uint16',
-            internalType: 'uint16',
-          },
-        ],
-      },
+            "name": "rewardMultiplierBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getDelegation',
-    inputs: [
+    "type": "function",
+    "name": "getDelegation",
+    "inputs": [
       {
-        name: 'delegator',
-        type: 'address',
-        internalType: 'address',
+        "name": "delegator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getDelegationBlueprints',
-    inputs: [
+    "type": "function",
+    "name": "getDelegationBlueprints",
+    "inputs": [
       {
-        name: 'delegator',
-        type: 'address',
-        internalType: 'address',
+        "name": "delegator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'idx',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "idx",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'uint64[]',
-        internalType: 'uint64[]',
-      },
+        "name": "",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getDelegationMode',
-    inputs: [
+    "type": "function",
+    "name": "getDelegationMode",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'uint8',
-        internalType: 'enum Types.DelegationMode',
-      },
+        "name": "",
+        "type": "uint8",
+        "internalType": "enum Types.DelegationMode"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getDelegations',
-    inputs: [
+    "type": "function",
+    "name": "getDelegations",
+    "inputs": [
       {
-        name: 'delegator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "delegator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple[]',
-        internalType: 'struct Types.BondInfoDelegator[]',
-        components: [
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct Types.BondInfoDelegator[]",
+        "components": [
           {
-            name: 'operator',
-            type: 'address',
-            internalType: 'address',
+            "name": "operator",
+            "type": "address",
+            "internalType": "address"
           },
           {
-            name: 'shares',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "shares",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'asset',
-            type: 'tuple',
-            internalType: 'struct Types.Asset',
-            components: [
+            "name": "asset",
+            "type": "tuple",
+            "internalType": "struct Types.Asset",
+            "components": [
               {
-                name: 'kind',
-                type: 'uint8',
-                internalType: 'enum Types.AssetKind',
+                "name": "kind",
+                "type": "uint8",
+                "internalType": "enum Types.AssetKind"
               },
               {
-                name: 'token',
-                type: 'address',
-                internalType: 'address',
-              },
-            ],
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
           },
           {
-            name: 'selectionMode',
-            type: 'uint8',
-            internalType: 'enum Types.BlueprintSelectionMode',
-          },
-        ],
-      },
+            "name": "selectionMode",
+            "type": "uint8",
+            "internalType": "enum Types.BlueprintSelectionMode"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getDeposit',
-    inputs: [
+    "type": "function",
+    "name": "getDeposit",
+    "inputs": [
       {
-        name: 'delegator',
-        type: 'address',
-        internalType: 'address',
+        "name": "delegator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct Types.Deposit',
-        components: [
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Types.Deposit",
+        "components": [
           {
-            name: 'amount',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "amount",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'delegatedAmount',
-            type: 'uint256',
-            internalType: 'uint256',
-          },
-        ],
-      },
+            "name": "delegatedAmount",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getLocks',
-    inputs: [
+    "type": "function",
+    "name": "getLocks",
+    "inputs": [
       {
-        name: 'delegator',
-        type: 'address',
-        internalType: 'address',
+        "name": "delegator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple[]',
-        internalType: 'struct Types.LockInfo[]',
-        components: [
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct Types.LockInfo[]",
+        "components": [
           {
-            name: 'amount',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "amount",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'multiplier',
-            type: 'uint8',
-            internalType: 'enum Types.LockMultiplier',
+            "name": "multiplier",
+            "type": "uint8",
+            "internalType": "enum Types.LockMultiplier"
           },
           {
-            name: 'expiryBlock',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-        ],
-      },
+            "name": "expiryBlock",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getOperatorBlueprints',
-    inputs: [
+    "type": "function",
+    "name": "getOperatorBlueprints",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'uint256[]',
-        internalType: 'uint256[]',
-      },
+        "name": "",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getOperatorDelegatedStake',
-    inputs: [
+    "type": "function",
+    "name": "getOperatorDelegatedStake",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getOperatorDelegatedStakeForAsset',
-    inputs: [
+    "type": "function",
+    "name": "getOperatorDelegatedStakeForAsset",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'asset',
-        type: 'tuple',
-        internalType: 'struct Types.Asset',
-        components: [
+        "name": "asset",
+        "type": "tuple",
+        "internalType": "struct Types.Asset",
+        "components": [
           {
-            name: 'kind',
-            type: 'uint8',
-            internalType: 'enum Types.AssetKind',
+            "name": "kind",
+            "type": "uint8",
+            "internalType": "enum Types.AssetKind"
           },
           {
-            name: 'token',
-            type: 'address',
-            internalType: 'address',
-          },
-        ],
-      },
+            "name": "token",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getOperatorDelegatorCount',
-    inputs: [
+    "type": "function",
+    "name": "getOperatorDelegatorCount",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getOperatorDelegators',
-    inputs: [
+    "type": "function",
+    "name": "getOperatorDelegators",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getOperatorMetadata',
-    inputs: [
+    "type": "function",
+    "name": "getOperatorMetadata",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct Types.OperatorMetadata',
-        components: [
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Types.OperatorMetadata",
+        "components": [
           {
-            name: 'stake',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "stake",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'delegationCount',
-            type: 'uint32',
-            internalType: 'uint32',
+            "name": "delegationCount",
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            name: 'status',
-            type: 'uint8',
-            internalType: 'enum Types.OperatorStatus',
+            "name": "status",
+            "type": "uint8",
+            "internalType": "enum Types.OperatorStatus"
           },
           {
-            name: 'leavingRound',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-        ],
-      },
+            "name": "leavingRound",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getOperatorRewardPool',
-    inputs: [
+    "type": "function",
+    "name": "getOperatorRewardPool",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct Types.OperatorRewardPool',
-        components: [
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Types.OperatorRewardPool",
+        "components": [
           {
-            name: 'totalShares',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "totalShares",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'totalAssets',
-            type: 'uint256',
-            internalType: 'uint256',
-          },
-        ],
-      },
+            "name": "totalAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getOperatorSelfStake',
-    inputs: [
+    "type": "function",
+    "name": "getOperatorSelfStake",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getOperatorStake',
-    inputs: [
+    "type": "function",
+    "name": "getOperatorStake",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getOperatorStakeForAsset',
-    inputs: [
+    "type": "function",
+    "name": "getOperatorStakeForAsset",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'asset',
-        type: 'tuple',
-        internalType: 'struct Types.Asset',
-        components: [
+        "name": "asset",
+        "type": "tuple",
+        "internalType": "struct Types.Asset",
+        "components": [
           {
-            name: 'kind',
-            type: 'uint8',
-            internalType: 'enum Types.AssetKind',
-          },
-          {
-            name: 'token',
-            type: 'address',
-            internalType: 'address',
-          },
-        ],
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getPendingCommissionChange',
-    inputs: [],
-    outputs: [
-      {
-        name: 'pendingBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-      {
-        name: 'executeAfter',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getPendingUnstakes',
-    inputs: [
-      {
-        name: 'delegator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple[]',
-        internalType: 'struct Types.BondLessRequest[]',
-        components: [
-          {
-            name: 'operator',
-            type: 'address',
-            internalType: 'address',
+            "name": "kind",
+            "type": "uint8",
+            "internalType": "enum Types.AssetKind"
           },
           {
-            name: 'asset',
-            type: 'tuple',
-            internalType: 'struct Types.Asset',
-            components: [
+            "name": "token",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPendingCommissionChange",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "pendingBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "executeAfter",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPendingUnstakes",
+    "inputs": [
+      {
+        "name": "delegator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct Types.BondLessRequest[]",
+        "components": [
+          {
+            "name": "operator",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "asset",
+            "type": "tuple",
+            "internalType": "struct Types.Asset",
+            "components": [
               {
-                name: 'kind',
-                type: 'uint8',
-                internalType: 'enum Types.AssetKind',
-              },
-              {
-                name: 'token',
-                type: 'address',
-                internalType: 'address',
-              },
-            ],
-          },
-          {
-            name: 'shares',
-            type: 'uint256',
-            internalType: 'uint256',
-          },
-          {
-            name: 'requestedRound',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-          {
-            name: 'selectionMode',
-            type: 'uint8',
-            internalType: 'enum Types.BlueprintSelectionMode',
-          },
-          {
-            name: 'slashFactorSnapshot',
-            type: 'uint256',
-            internalType: 'uint256',
-          },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getPendingWithdrawals',
-    inputs: [
-      {
-        name: 'delegator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple[]',
-        internalType: 'struct Types.WithdrawRequest[]',
-        components: [
-          {
-            name: 'asset',
-            type: 'tuple',
-            internalType: 'struct Types.Asset',
-            components: [
-              {
-                name: 'kind',
-                type: 'uint8',
-                internalType: 'enum Types.AssetKind',
+                "name": "kind",
+                "type": "uint8",
+                "internalType": "enum Types.AssetKind"
               },
               {
-                name: 'token',
-                type: 'address',
-                internalType: 'address',
-              },
-            ],
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
           },
           {
-            name: 'amount',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "shares",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'requestedRound',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getSlashCount',
-    inputs: [
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getSlashCountForBlueprint',
-    inputs: [
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getSlashCountForService',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getSlashImpact',
-    inputs: [
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'slashIndex',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'delegator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getSlashRecord',
-    inputs: [
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'slashIndex',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct SlashingManager.SlashRecord',
-        components: [
-          {
-            name: 'round',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "requestedRound",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'serviceId',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "selectionMode",
+            "type": "uint8",
+            "internalType": "enum Types.BlueprintSelectionMode"
           },
           {
-            name: 'blueprintId',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
+            "name": "slashFactorSnapshot",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPendingWithdrawals",
+    "inputs": [
+      {
+        "name": "delegator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct Types.WithdrawRequest[]",
+        "components": [
           {
-            name: 'assetHash',
-            type: 'bytes32',
-            internalType: 'bytes32',
-          },
-          {
-            name: 'slashBps',
-            type: 'uint16',
-            internalType: 'uint16',
-          },
-          {
-            name: 'totalSlashed',
-            type: 'uint256',
-            internalType: 'uint256',
-          },
-          {
-            name: 'exchangeRateBefore',
-            type: 'uint256',
-            internalType: 'uint256',
-          },
-          {
-            name: 'exchangeRateAfter',
-            type: 'uint256',
-            internalType: 'uint256',
-          },
-          {
-            name: 'evidence',
-            type: 'bytes32',
-            internalType: 'bytes32',
-          },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getTotalDelegation',
-    inputs: [
-      {
-        name: 'delegator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: 'total',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'increaseStake',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'payable',
-  },
-  {
-    type: 'function',
-    name: 'increaseStakeWithAsset',
-    inputs: [
-      {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'isOperator',
-    inputs: [
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'bool',
-        internalType: 'bool',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'isOperatorActive',
-    inputs: [
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'bool',
-        internalType: 'bool',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'isSlasher',
-    inputs: [
-      {
-        name: 'account',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'bool',
-        internalType: 'bool',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'isWhitelisted',
-    inputs: [
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'delegator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'bool',
-        internalType: 'bool',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'leaveDelegatorsDelay',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'leaveOperatorsDelay',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'meetsStakeRequirement',
-    inputs: [
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'required',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'bool',
-        internalType: 'bool',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'minOperatorStake',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'operatorAt',
-    inputs: [
-      {
-        name: 'index',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'operatorBondToken',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'operatorCommissionBps',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'operatorCount',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'pause',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'previewDelegatorUnstakeShares',
-    inputs: [
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'registerAdapter',
-    inputs: [
-      {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'adapter',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'registerOperator',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'payable',
-  },
-  {
-    type: 'function',
-    name: 'registerOperatorWithAsset',
-    inputs: [
-      {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'removeAdapter',
-    inputs: [
-      {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'removeBlueprintForOperator',
-    inputs: [
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'removeBlueprintFromDelegation',
-    inputs: [
-      {
-        name: 'delegationIndex',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'removeSlasher',
-    inputs: [
-      {
-        name: 'slasher',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'rescueTokens',
-    inputs: [
-      {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'to',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'rewardsManager',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'roundDuration',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'scheduleDelegatorUnstake',
-    inputs: [
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'scheduleOperatorUnstake',
-    inputs: [
-      {
-        name: 'amount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'scheduleWithdraw',
-    inputs: [
-      {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'serviceFeeDistributor',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'setDelays',
-    inputs: [
-      {
-        name: 'delegationBondLessDelay',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'leaveDelegatorsDelay',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'leaveOperatorsDelay',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setDelegationMode',
-    inputs: [
-      {
-        name: 'mode',
-        type: 'uint8',
-        internalType: 'enum Types.DelegationMode',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setDelegationWhitelist',
-    inputs: [
-      {
-        name: 'delegators',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
-      {
-        name: 'approved',
-        type: 'bool',
-        internalType: 'bool',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setOperatorBondToken',
-    inputs: [
-      {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setOperatorCommission',
-    inputs: [
-      {
-        name: 'bps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setRequireAdapters',
-    inputs: [
-      {
-        name: 'required',
-        type: 'bool',
-        internalType: 'bool',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setRewardsManager',
-    inputs: [
-      {
-        name: 'manager',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setServiceFeeDistributor',
-    inputs: [
-      {
-        name: 'distributor',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setTangle',
-    inputs: [
-      {
-        name: 'tangle',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'slash',
-    inputs: [
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'slashBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-      {
-        name: 'evidence',
-        type: 'bytes32',
-        internalType: 'bytes32',
-      },
-    ],
-    outputs: [
-      {
-        name: 'actualSlashed',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'slashForBlueprint',
-    inputs: [
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'slashBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-      {
-        name: 'evidence',
-        type: 'bytes32',
-        internalType: 'bytes32',
-      },
-    ],
-    outputs: [
-      {
-        name: 'actualSlashed',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'slashForService',
-    inputs: [
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'commitments',
-        type: 'tuple[]',
-        internalType: 'struct Types.AssetSecurityCommitment[]',
-        components: [
-          {
-            name: 'asset',
-            type: 'tuple',
-            internalType: 'struct Types.Asset',
-            components: [
+            "name": "asset",
+            "type": "tuple",
+            "internalType": "struct Types.Asset",
+            "components": [
               {
-                name: 'kind',
-                type: 'uint8',
-                internalType: 'enum Types.AssetKind',
+                "name": "kind",
+                "type": "uint8",
+                "internalType": "enum Types.AssetKind"
               },
               {
-                name: 'token',
-                type: 'address',
-                internalType: 'address',
-              },
-            ],
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
           },
           {
-            name: 'exposureBps',
-            type: 'uint16',
-            internalType: 'uint16',
+            "name": "amount",
+            "type": "uint256",
+            "internalType": "uint256"
           },
-        ],
-      },
-      {
-        name: 'slashBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-      {
-        name: 'evidence',
-        type: 'bytes32',
-        internalType: 'bytes32',
-      },
+          {
+            "name": "requestedRound",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
     ],
-    outputs: [
-      {
-        name: 'actualSlashed',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'nonpayable',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'snapshotOperator',
-    inputs: [
+    "type": "function",
+    "name": "getSlashCount",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'startLeaving',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'undelegate',
-    inputs: [
+    "outputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'unpause',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'event',
-    name: 'AdapterRegistered',
-    inputs: [
+    "type": "function",
+    "name": "getSlashCountForBlueprint",
+    "inputs": [
       {
-        name: 'token',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'adapter',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'AdapterRemoved',
-    inputs: [
+    "type": "function",
+    "name": "getSlashCountForService",
+    "inputs": [
       {
-        name: 'token',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'AssetDisabled',
-    inputs: [
+    "type": "function",
+    "name": "getSlashImpact",
+    "inputs": [
       {
-        name: 'token',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
+      {
+        "name": "slashIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "delegator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'AssetEnabled',
-    inputs: [
+    "type": "function",
+    "name": "getSlashRecord",
+    "inputs": [
       {
-        name: 'token',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'minOperatorStake',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'minDelegation',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
+        "name": "slashIndex",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    anonymous: false,
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct SlashingManager.SlashRecord",
+        "components": [
+          {
+            "name": "round",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "serviceId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blueprintId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "assetHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "slashBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "totalSlashed",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "exchangeRateBefore",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "exchangeRateAfter",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "evidence",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'BlueprintAddedToDelegation',
-    inputs: [
+    "type": "function",
+    "name": "getTotalDelegation",
+    "inputs": [
       {
-        name: 'delegator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'delegationIndex',
-        type: 'uint256',
-        indexed: true,
-        internalType: 'uint256',
-      },
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: false,
-        internalType: 'uint64',
-      },
+        "name": "delegator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [
+      {
+        "name": "total",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'BlueprintRemovedFromDelegation',
-    inputs: [
-      {
-        name: 'delegator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'delegationIndex',
-        type: 'uint256',
-        indexed: true,
-        internalType: 'uint256',
-      },
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: false,
-        internalType: 'uint64',
-      },
-    ],
-    anonymous: false,
+    "type": "function",
+    "name": "increaseStake",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
-    type: 'event',
-    name: 'Delegated',
-    inputs: [
+    "type": "function",
+    "name": "increaseStakeWithAsset",
+    "inputs": [
       {
-        name: 'delegator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'token',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'shares',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'selectionMode',
-        type: 'uint8',
-        indexed: false,
-        internalType: 'enum Types.BlueprintSelectionMode',
-      },
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'DelegatorUnstakeExecuted',
-    inputs: [
+    "type": "function",
+    "name": "isOperator",
+    "inputs": [
       {
-        name: 'delegator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'token',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'shares',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'DelegatorUnstakeScheduled',
-    inputs: [
+    "type": "function",
+    "name": "isOperatorActive",
+    "inputs": [
       {
-        name: 'delegator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'token',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'shares',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'estimatedAmount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'readyRound',
-        type: 'uint64',
-        indexed: false,
-        internalType: 'uint64',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'Deposited',
-    inputs: [
+    "type": "function",
+    "name": "isSlasher",
+    "inputs": [
       {
-        name: 'delegator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'token',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'lock',
-        type: 'uint8',
-        indexed: false,
-        internalType: 'enum Types.LockMultiplier',
-      },
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'ExpiredLocksHarvested',
-    inputs: [
+    "type": "function",
+    "name": "isWhitelisted",
+    "inputs": [
       {
-        name: 'delegator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'token',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'count',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'totalAmount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
+        "name": "delegator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'OperatorBlueprintAdded',
-    inputs: [
+    "type": "function",
+    "name": "leaveDelegatorsDelay",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    anonymous: false,
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'OperatorBlueprintRemoved',
-    inputs: [
+    "type": "function",
+    "name": "leaveOperatorsDelay",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    anonymous: false,
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'OperatorLeavingScheduled',
-    inputs: [
+    "type": "function",
+    "name": "meetsStakeRequirement",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'readyRound',
-        type: 'uint64',
-        indexed: false,
-        internalType: 'uint64',
-      },
+        "name": "required",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    anonymous: false,
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'OperatorLeft',
-    inputs: [
+    "type": "function",
+    "name": "minOperatorStake",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    anonymous: false,
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'OperatorRegistered',
-    inputs: [
+    "type": "function",
+    "name": "operatorAt",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'stake',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
+        "name": "index",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    anonymous: false,
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'OperatorStakeIncreased',
-    inputs: [
+    "type": "function",
+    "name": "operatorBondToken",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'OperatorUnstakeExecuted',
-    inputs: [
+    "type": "function",
+    "name": "operatorCommissionBps",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    anonymous: false,
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'OperatorUnstakeScheduled',
-    inputs: [
+    "type": "function",
+    "name": "operatorCount",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'readyRound',
-        type: 'uint64',
-        indexed: false,
-        internalType: 'uint64',
-      },
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    anonymous: false,
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'RequireAdaptersUpdated',
-    inputs: [
-      {
-        name: 'required',
-        type: 'bool',
-        indexed: false,
-        internalType: 'bool',
-      },
-    ],
-    anonymous: false,
+    "type": "function",
+    "name": "pause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'RoundAdvanced',
-    inputs: [
+    "type": "function",
+    "name": "previewDelegatorUnstakeShares",
+    "inputs": [
       {
-        name: 'round',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    anonymous: false,
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'SlashRecorded',
-    inputs: [
+    "type": "function",
+    "name": "registerAdapter",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'slashId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'assetHash',
-        type: 'bytes32',
-        indexed: false,
-        internalType: 'bytes32',
-      },
-      {
-        name: 'slashBps',
-        type: 'uint16',
-        indexed: false,
-        internalType: 'uint16',
-      },
-      {
-        name: 'totalSlashed',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'exchangeRateBefore',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'exchangeRateAfter',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
+        "name": "adapter",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'Slashed',
-    inputs: [
-      {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'assetHash',
-        type: 'bytes32',
-        indexed: false,
-        internalType: 'bytes32',
-      },
-      {
-        name: 'slashBps',
-        type: 'uint16',
-        indexed: false,
-        internalType: 'uint16',
-      },
-      {
-        name: 'operatorSlashed',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'delegatorsSlashed',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'exchangeRateAfter',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-    ],
-    anonymous: false,
+    "type": "function",
+    "name": "registerOperator",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
-    type: 'event',
-    name: 'SlashedForService',
-    inputs: [
+    "type": "function",
+    "name": "registerOperatorWithAsset",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'totalSlashed',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'commitmentCount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'WithdrawScheduled',
-    inputs: [
+    "type": "function",
+    "name": "removeAdapter",
+    "inputs": [
       {
-        name: 'delegator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'token',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'readyRound',
-        type: 'uint64',
-        indexed: false,
-        internalType: 'uint64',
-      },
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'Withdrawn',
-    inputs: [
+    "type": "function",
+    "name": "removeBlueprintForOperator",
+    "inputs": [
       {
-        name: 'delegator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'token',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
+  {
+    "type": "function",
+    "name": "removeBlueprintFromDelegation",
+    "inputs": [
+      {
+        "name": "delegationIndex",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "removeSlasher",
+    "inputs": [
+      {
+        "name": "slasher",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "rescueTokens",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "rewardsManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "roundDuration",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "scheduleDelegatorUnstake",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "scheduleOperatorUnstake",
+    "inputs": [
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "scheduleWithdraw",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "serviceFeeDistributor",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setDelays",
+    "inputs": [
+      {
+        "name": "delegationBondLessDelay",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "leaveDelegatorsDelay",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "leaveOperatorsDelay",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setDelegationMode",
+    "inputs": [
+      {
+        "name": "mode",
+        "type": "uint8",
+        "internalType": "enum Types.DelegationMode"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setDelegationWhitelist",
+    "inputs": [
+      {
+        "name": "delegators",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "approved",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setOperatorBondToken",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setOperatorCommission",
+    "inputs": [
+      {
+        "name": "bps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setRequireAdapters",
+    "inputs": [
+      {
+        "name": "required",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setRewardsManager",
+    "inputs": [
+      {
+        "name": "manager",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setServiceFeeDistributor",
+    "inputs": [
+      {
+        "name": "distributor",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setTangle",
+    "inputs": [
+      {
+        "name": "tangle",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "slash",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "slashBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "evidence",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "actualSlashed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "slashForBlueprint",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "slashBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "evidence",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "actualSlashed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "slashForService",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "commitments",
+        "type": "tuple[]",
+        "internalType": "struct Types.AssetSecurityCommitment[]",
+        "components": [
+          {
+            "name": "asset",
+            "type": "tuple",
+            "internalType": "struct Types.Asset",
+            "components": [
+              {
+                "name": "kind",
+                "type": "uint8",
+                "internalType": "enum Types.AssetKind"
+              },
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
+          },
+          {
+            "name": "exposureBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          }
+        ]
+      },
+      {
+        "name": "slashBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "evidence",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "actualSlashed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "snapshotOperator",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "startLeaving",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "undelegate",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unpause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "AdapterRegistered",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "adapter",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AdapterRemoved",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AssetDisabled",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AssetEnabled",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "minOperatorStake",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "minDelegation",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BlueprintAddedToDelegation",
+    "inputs": [
+      {
+        "name": "delegator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "delegationIndex",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BlueprintRemovedFromDelegation",
+    "inputs": [
+      {
+        "name": "delegator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "delegationIndex",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Delegated",
+    "inputs": [
+      {
+        "name": "delegator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "selectionMode",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum Types.BlueprintSelectionMode"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DelegatorUnstakeExecuted",
+    "inputs": [
+      {
+        "name": "delegator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DelegatorUnstakeScheduled",
+    "inputs": [
+      {
+        "name": "delegator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "estimatedAmount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "readyRound",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Deposited",
+    "inputs": [
+      {
+        "name": "delegator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "lock",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum Types.LockMultiplier"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ExpiredLocksHarvested",
+    "inputs": [
+      {
+        "name": "delegator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "count",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "totalAmount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OperatorBlueprintAdded",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OperatorBlueprintRemoved",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OperatorLeavingScheduled",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "readyRound",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OperatorLeft",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OperatorRegistered",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "stake",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OperatorStakeIncreased",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OperatorUnstakeExecuted",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OperatorUnstakeScheduled",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "readyRound",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RequireAdaptersUpdated",
+    "inputs": [
+      {
+        "name": "required",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RoundAdvanced",
+    "inputs": [
+      {
+        "name": "round",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SlashRecorded",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "slashId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "assetHash",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "slashBps",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "totalSlashed",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "exchangeRateBefore",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "exchangeRateAfter",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Slashed",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "assetHash",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "slashBps",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "operatorSlashed",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "delegatorsSlashed",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "exchangeRateAfter",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SlashedForService",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "totalSlashed",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "commitmentCount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WithdrawScheduled",
+    "inputs": [
+      {
+        "name": "delegator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "readyRound",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Withdrawn",
+    "inputs": [
+      {
+        "name": "delegator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  }
 ] as const;
 
 export default ABI;

--- a/libs/tangle-shared-ui/src/abi/operatorStatusRegistry.ts
+++ b/libs/tangle-shared-ui/src/abi/operatorStatusRegistry.ts
@@ -1,1616 +1,1616 @@
 // AUTO-GENERATED FROM tnt-core. DO NOT EDIT MANUALLY.
 const ABI = [
   {
-    "type": "constructor",
-    "inputs": [
+    type: 'constructor',
+    inputs: [
       {
-        "name": "_tangleCore",
-        "type": "address",
-        "internalType": "address"
+        name: '_tangleCore',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "initialOwner",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'initialOwner',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "nonpayable"
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "DEFAULT_HEARTBEAT_INTERVAL",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'DEFAULT_HEARTBEAT_INTERVAL',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "DEFAULT_MAX_MISSED_HEARTBEATS",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'DEFAULT_MAX_MISSED_HEARTBEATS',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
+        name: '',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "DOMAIN_SEPARATOR",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'DOMAIN_SEPARATOR',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "HEARTBEAT_MAX_AGE",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'HEARTBEAT_MAX_AGE',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "HEARTBEAT_TYPEHASH",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'HEARTBEAT_TYPEHASH',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "MAX_METRIC_DEFINITIONS",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'MAX_METRIC_DEFINITIONS',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "MAX_METRIC_NAME_LENGTH",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'MAX_METRIC_NAME_LENGTH',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "MAX_PAGE_SIZE",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'MAX_PAGE_SIZE',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "SLASH_ALERT_COOLDOWN",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'SLASH_ALERT_COOLDOWN',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "acceptOwnership",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: 'function',
+    name: 'acceptOwnership',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "addMetricDefinition",
-    "inputs": [
+    type: 'function',
+    name: 'addMetricDefinition',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "name",
-        "type": "string",
-        "internalType": "string"
+        name: 'name',
+        type: 'string',
+        internalType: 'string',
       },
       {
-        "name": "minValue",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'minValue',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "maxValue",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'maxValue',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "required",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: 'required',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "checkOperatorStatus",
-    "inputs": [
+    type: 'function',
+    name: 'checkOperatorStatus',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "checkOperatorsStatus",
-    "inputs": [
+    type: 'function',
+    name: 'checkOperatorsStatus',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operators",
-        "type": "address[]",
-        "internalType": "address[]"
-      }
+        name: 'operators',
+        type: 'address[]',
+        internalType: 'address[]',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "configureHeartbeat",
-    "inputs": [
+    type: 'function',
+    name: 'configureHeartbeat',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "interval",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'interval',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "maxMissed",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
+        name: 'maxMissed',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "decodeMetricPairs",
-    "inputs": [
+    type: 'function',
+    name: 'decodeMetricPairs',
+    inputs: [
       {
-        "name": "payload",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
+        name: 'payload',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "pairs",
-        "type": "tuple[]",
-        "internalType": "struct IOperatorStatusRegistry.MetricPair[]",
-        "components": [
+        name: 'pairs',
+        type: 'tuple[]',
+        internalType: 'struct IOperatorStatusRegistry.MetricPair[]',
+        components: [
           {
-            "name": "name",
-            "type": "string",
-            "internalType": "string"
+            name: 'name',
+            type: 'string',
+            internalType: 'string',
           },
           {
-            "name": "value",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
+            name: 'value',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+        ],
+      },
     ],
-    "stateMutability": "pure"
+    stateMutability: 'pure',
   },
   {
-    "type": "function",
-    "name": "deregisterOperator",
-    "inputs": [
+    type: 'function',
+    name: 'deregisterOperator',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "enableCustomMetrics",
-    "inputs": [
+    type: 'function',
+    name: 'enableCustomMetrics',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "enabled",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: 'enabled',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "getAllOperatorCount",
-    "inputs": [
+    type: 'function',
+    name: 'getAllOperatorCount',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getHeartbeatConfig",
-    "inputs": [
+    type: 'function',
+    name: 'getHeartbeatConfig',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct IOperatorStatusRegistry.HeartbeatConfig",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct IOperatorStatusRegistry.HeartbeatConfig',
+        components: [
           {
-            "name": "interval",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'interval',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "maxMissed",
-            "type": "uint8",
-            "internalType": "uint8"
+            name: 'maxMissed',
+            type: 'uint8',
+            internalType: 'uint8',
           },
           {
-            "name": "customMetrics",
-            "type": "bool",
-            "internalType": "bool"
-          }
-        ]
-      }
+            name: 'customMetrics',
+            type: 'bool',
+            internalType: 'bool',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getLastCriticalHeartbeat",
-    "inputs": [
+    type: 'function',
+    name: 'getLastCriticalHeartbeat',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getLastHeartbeat",
-    "inputs": [
+    type: 'function',
+    name: 'getLastHeartbeat',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getMetricDefinitions",
-    "inputs": [
+    type: 'function',
+    name: 'getMetricDefinitions',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple[]",
-        "internalType": "struct IOperatorStatusRegistry.MetricDefinition[]",
-        "components": [
+        name: '',
+        type: 'tuple[]',
+        internalType: 'struct IOperatorStatusRegistry.MetricDefinition[]',
+        components: [
           {
-            "name": "name",
-            "type": "string",
-            "internalType": "string"
+            name: 'name',
+            type: 'string',
+            internalType: 'string',
           },
           {
-            "name": "minValue",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'minValue',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "maxValue",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'maxValue',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "required",
-            "type": "bool",
-            "internalType": "bool"
-          }
-        ]
-      }
+            name: 'required',
+            type: 'bool',
+            internalType: 'bool',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getMetricValue",
-    "inputs": [
+    type: 'function',
+    name: 'getMetricValue',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "metricName",
-        "type": "string",
-        "internalType": "string"
-      }
+        name: 'metricName',
+        type: 'string',
+        internalType: 'string',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOnlineOperatorCount",
-    "inputs": [
+    type: 'function',
+    name: 'getOnlineOperatorCount',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOnlineOperators",
-    "inputs": [
+    type: 'function',
+    name: 'getOnlineOperators',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "address[]",
-        "internalType": "address[]"
-      }
+        name: '',
+        type: 'address[]',
+        internalType: 'address[]',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorState",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorState',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct IOperatorStatusRegistry.OperatorState",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct IOperatorStatusRegistry.OperatorState',
+        components: [
           {
-            "name": "lastHeartbeat",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'lastHeartbeat',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "consecutiveBeats",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'consecutiveBeats',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "missedBeats",
-            "type": "uint8",
-            "internalType": "uint8"
+            name: 'missedBeats',
+            type: 'uint8',
+            internalType: 'uint8',
           },
           {
-            "name": "status",
-            "type": "uint8",
-            "internalType": "enum IOperatorStatusRegistry.StatusCode"
+            name: 'status',
+            type: 'uint8',
+            internalType: 'enum IOperatorStatusRegistry.StatusCode',
           },
           {
-            "name": "lastMetricsHash",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          }
-        ]
-      }
+            name: 'lastMetricsHash',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorStatus",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorStatus',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint8",
-        "internalType": "enum IOperatorStatusRegistry.StatusCode"
-      }
+        name: '',
+        type: 'uint8',
+        internalType: 'enum IOperatorStatusRegistry.StatusCode',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getSlashableOperators",
-    "inputs": [
+    type: 'function',
+    name: 'getSlashableOperators',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "operators",
-        "type": "address[]",
-        "internalType": "address[]"
-      }
+        name: 'operators',
+        type: 'address[]',
+        internalType: 'address[]',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getSlashableOperatorsPaginated",
-    "inputs": [
+    type: 'function',
+    name: 'getSlashableOperatorsPaginated',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "offset",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'offset',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "limit",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'limit',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "operators",
-        "type": "address[]",
-        "internalType": "address[]"
+        name: 'operators',
+        type: 'address[]',
+        internalType: 'address[]',
       },
       {
-        "name": "total",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'total',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "goOffline",
-    "inputs": [
+    type: 'function',
+    name: 'goOffline',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "goOnline",
-    "inputs": [
+    type: 'function',
+    name: 'goOnline',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "heartbeatConfigs",
-    "inputs": [
+    type: 'function',
+    name: 'heartbeatConfigs',
+    inputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "interval",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'interval',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "maxMissed",
-        "type": "uint8",
-        "internalType": "uint8"
+        name: 'maxMissed',
+        type: 'uint8',
+        internalType: 'uint8',
       },
       {
-        "name": "customMetrics",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: 'customMetrics',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "isHeartbeatCurrent",
-    "inputs": [
+    type: 'function',
+    name: 'isHeartbeatCurrent',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "isOnline",
-    "inputs": [
+    type: 'function',
+    name: 'isOnline',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "isRegisteredOperator",
-    "inputs": [
+    type: 'function',
+    name: 'isRegisteredOperator',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "metricValues",
-    "inputs": [
+    type: 'function',
+    name: 'metricValues',
+    inputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
+        name: '',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "",
-        "type": "string",
-        "internalType": "string"
-      }
+        name: '',
+        type: 'string',
+        internalType: 'string',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "metricsRecorder",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'metricsRecorder',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "operatorStates",
-    "inputs": [
+    type: 'function',
+    name: 'operatorStates',
+    inputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "lastHeartbeat",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'lastHeartbeat',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "consecutiveBeats",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'consecutiveBeats',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "missedBeats",
-        "type": "uint8",
-        "internalType": "uint8"
+        name: 'missedBeats',
+        type: 'uint8',
+        internalType: 'uint8',
       },
       {
-        "name": "status",
-        "type": "uint8",
-        "internalType": "enum IOperatorStatusRegistry.StatusCode"
+        name: 'status',
+        type: 'uint8',
+        internalType: 'enum IOperatorStatusRegistry.StatusCode',
       },
       {
-        "name": "lastMetricsHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: 'lastMetricsHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "owner",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'owner',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "pendingOwner",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'pendingOwner',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "registerOperator",
-    "inputs": [
+    type: 'function',
+    name: 'registerOperator',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "registerServiceOwner",
-    "inputs": [
+    type: 'function',
+    name: 'registerServiceOwner',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "owner",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'owner',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "removeInactiveOperator",
-    "inputs": [
+    type: 'function',
+    name: 'removeInactiveOperator',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "renounceOwnership",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: 'function',
+    name: 'renounceOwnership',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "reportForSlashing",
-    "inputs": [
+    type: 'function',
+    name: 'reportForSlashing',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "reason",
-        "type": "string",
-        "internalType": "string"
-      }
+        name: 'reason',
+        type: 'string',
+        internalType: 'string',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "serviceMetrics",
-    "inputs": [
+    type: 'function',
+    name: 'serviceMetrics',
+    inputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "name",
-        "type": "string",
-        "internalType": "string"
+        name: 'name',
+        type: 'string',
+        internalType: 'string',
       },
       {
-        "name": "minValue",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'minValue',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "maxValue",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'maxValue',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "required",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: 'required',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "serviceOwners",
-    "inputs": [
+    type: 'function',
+    name: 'serviceOwners',
+    inputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "setMetricDefinitions",
-    "inputs": [
+    type: 'function',
+    name: 'setMetricDefinitions',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "definitions",
-        "type": "tuple[]",
-        "internalType": "struct IOperatorStatusRegistry.MetricDefinition[]",
-        "components": [
+        name: 'definitions',
+        type: 'tuple[]',
+        internalType: 'struct IOperatorStatusRegistry.MetricDefinition[]',
+        components: [
           {
-            "name": "name",
-            "type": "string",
-            "internalType": "string"
+            name: 'name',
+            type: 'string',
+            internalType: 'string',
           },
           {
-            "name": "minValue",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'minValue',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "maxValue",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'maxValue',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "required",
-            "type": "bool",
-            "internalType": "bool"
-          }
-        ]
-      }
+            name: 'required',
+            type: 'bool',
+            internalType: 'bool',
+          },
+        ],
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setMetricsRecorder",
-    "inputs": [
+    type: 'function',
+    name: 'setMetricsRecorder',
+    inputs: [
       {
-        "name": "recorder",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'recorder',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setSlashingOracle",
-    "inputs": [
+    type: 'function',
+    name: 'setSlashingOracle',
+    inputs: [
       {
-        "name": "oracle",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'oracle',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "slashingOracle",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'slashingOracle',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "submitHeartbeat",
-    "inputs": [
+    type: 'function',
+    name: 'submitHeartbeat',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "statusCode",
-        "type": "uint8",
-        "internalType": "uint8"
+        name: 'statusCode',
+        type: 'uint8',
+        internalType: 'uint8',
       },
       {
-        "name": "metrics",
-        "type": "bytes",
-        "internalType": "bytes"
+        name: 'metrics',
+        type: 'bytes',
+        internalType: 'bytes',
       },
       {
-        "name": "timestamp",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'timestamp',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "signature",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
+        name: 'signature',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "submitHeartbeatDirect",
-    "inputs": [
+    type: 'function',
+    name: 'submitHeartbeatDirect',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "statusCode",
-        "type": "uint8",
-        "internalType": "uint8"
+        name: 'statusCode',
+        type: 'uint8',
+        internalType: 'uint8',
       },
       {
-        "name": "metrics",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
+        name: 'metrics',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "tangleCore",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'tangleCore',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "transferOwnership",
-    "inputs": [
+    type: 'function',
+    name: 'transferOwnership',
+    inputs: [
       {
-        "name": "newOwner",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'newOwner',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "validateAndStoreMetrics",
-    "inputs": [
+    type: 'function',
+    name: 'validateAndStoreMetrics',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "pairs",
-        "type": "tuple[]",
-        "internalType": "struct IOperatorStatusRegistry.MetricPair[]",
-        "components": [
+        name: 'pairs',
+        type: 'tuple[]',
+        internalType: 'struct IOperatorStatusRegistry.MetricPair[]',
+        components: [
           {
-            "name": "name",
-            "type": "string",
-            "internalType": "string"
+            name: 'name',
+            type: 'string',
+            internalType: 'string',
           },
           {
-            "name": "value",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
+            name: 'value',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+        ],
       },
       {
-        "name": "pairsLen",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'pairsLen',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "event",
-    "name": "HeartbeatConfigUpdated",
-    "inputs": [
+    type: 'event',
+    name: 'HeartbeatConfigUpdated',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "interval",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
+        name: 'interval',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
       },
       {
-        "name": "maxMissed",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      }
+        name: 'maxMissed',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'uint8',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "HeartbeatReceived",
-    "inputs": [
+    type: 'event',
+    name: 'HeartbeatReceived',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "statusCode",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
+        name: 'statusCode',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'uint8',
       },
       {
-        "name": "timestamp",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'timestamp',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "MetricReported",
-    "inputs": [
+    type: 'event',
+    name: 'MetricReported',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "metricName",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
+        name: 'metricName',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
       },
       {
-        "name": "value",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'value',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "MetricViolation",
-    "inputs": [
+    type: 'event',
+    name: 'MetricViolation',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "metricName",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
+        name: 'metricName',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
       },
       {
-        "name": "reason",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
-      }
+        name: 'reason',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorCameOnline",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorCameOnline',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorDeregistered",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorDeregistered',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorRegistered",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorRegistered',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorWentOffline",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorWentOffline',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "missedBeats",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      }
+        name: 'missedBeats',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'uint8',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OwnershipTransferStarted",
-    "inputs": [
+    type: 'event',
+    name: 'OwnershipTransferStarted',
+    inputs: [
       {
-        "name": "previousOwner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'previousOwner',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "newOwner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
+        name: 'newOwner',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OwnershipTransferred",
-    "inputs": [
+    type: 'event',
+    name: 'OwnershipTransferred',
+    inputs: [
       {
-        "name": "previousOwner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'previousOwner',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "newOwner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
+        name: 'newOwner',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "SlashingTriggered",
-    "inputs": [
+    type: 'event',
+    name: 'SlashingTriggered',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "reason",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
-      }
+        name: 'reason',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "StatusChanged",
-    "inputs": [
+    type: 'event',
+    name: 'StatusChanged',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "oldStatus",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "enum IOperatorStatusRegistry.StatusCode"
+        name: 'oldStatus',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'enum IOperatorStatusRegistry.StatusCode',
       },
       {
-        "name": "newStatus",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "enum IOperatorStatusRegistry.StatusCode"
-      }
+        name: 'newStatus',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'enum IOperatorStatusRegistry.StatusCode',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "error",
-    "name": "ECDSAInvalidSignature",
-    "inputs": []
+    type: 'error',
+    name: 'ECDSAInvalidSignature',
+    inputs: [],
   },
   {
-    "type": "error",
-    "name": "ECDSAInvalidSignatureLength",
-    "inputs": [
+    type: 'error',
+    name: 'ECDSAInvalidSignatureLength',
+    inputs: [
       {
-        "name": "length",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
+        name: 'length',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
   },
   {
-    "type": "error",
-    "name": "ECDSAInvalidSignatureS",
-    "inputs": [
+    type: 'error',
+    name: 'ECDSAInvalidSignatureS',
+    inputs: [
       {
-        "name": "s",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
+        name: 's',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
   },
   {
-    "type": "error",
-    "name": "HeartbeatFromFuture",
-    "inputs": [
+    type: 'error',
+    name: 'HeartbeatFromFuture',
+    inputs: [
       {
-        "name": "signed",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'signed',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "now_",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
-    ]
+        name: 'now_',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
   },
   {
-    "type": "error",
-    "name": "HeartbeatStale",
-    "inputs": [
+    type: 'error',
+    name: 'HeartbeatStale',
+    inputs: [
       {
-        "name": "signed",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'signed',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "now_",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
-    ]
+        name: 'now_',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
   },
   {
-    "type": "error",
-    "name": "OwnableInvalidOwner",
-    "inputs": [
+    type: 'error',
+    name: 'OwnableInvalidOwner',
+    inputs: [
       {
-        "name": "owner",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
+        name: 'owner',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
   },
   {
-    "type": "error",
-    "name": "OwnableUnauthorizedAccount",
-    "inputs": [
+    type: 'error',
+    name: 'OwnableUnauthorizedAccount',
+    inputs: [
       {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  }
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+  },
 ] as const;
 
 export default ABI;

--- a/libs/tangle-shared-ui/src/abi/operatorStatusRegistry.ts
+++ b/libs/tangle-shared-ui/src/abi/operatorStatusRegistry.ts
@@ -1,1247 +1,1616 @@
 // AUTO-GENERATED FROM tnt-core. DO NOT EDIT MANUALLY.
 const ABI = [
   {
-    type: 'constructor',
-    inputs: [
+    "type": "constructor",
+    "inputs": [
       {
-        name: '_tangleCore',
-        type: 'address',
-        internalType: 'address',
+        "name": "_tangleCore",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'initialOwner',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "initialOwner",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    stateMutability: 'nonpayable',
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'DEFAULT_HEARTBEAT_INTERVAL',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "DEFAULT_HEARTBEAT_INTERVAL",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'DEFAULT_MAX_MISSED_HEARTBEATS',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "DEFAULT_MAX_MISSED_HEARTBEATS",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'DOMAIN_SEPARATOR',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "DOMAIN_SEPARATOR",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'bytes32',
-        internalType: 'bytes32',
-      },
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'HEARTBEAT_TYPEHASH',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "HEARTBEAT_MAX_AGE",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'bytes32',
-        internalType: 'bytes32',
-      },
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'SLASH_ALERT_COOLDOWN',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "HEARTBEAT_TYPEHASH",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'acceptOwnership',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "type": "function",
+    "name": "MAX_METRIC_DEFINITIONS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'addMetricDefinition',
-    inputs: [
+    "type": "function",
+    "name": "MAX_METRIC_NAME_LENGTH",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'name',
-        type: 'string',
-        internalType: 'string',
-      },
-      {
-        name: 'minValue',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: 'maxValue',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: 'required',
-        type: 'bool',
-        internalType: 'bool',
-      },
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'checkOperatorStatus',
-    inputs: [
+    "type": "function",
+    "name": "MAX_PAGE_SIZE",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'checkOperatorsStatus',
-    inputs: [
+    "type": "function",
+    "name": "SLASH_ALERT_COOLDOWN",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operators',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'configureHeartbeat',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'interval',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'maxMissed',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "type": "function",
+    "name": "acceptOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'decodeMetricPairs',
-    inputs: [
+    "type": "function",
+    "name": "addMetricDefinition",
+    "inputs": [
       {
-        name: 'payload',
-        type: 'bytes',
-        internalType: 'bytes',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
-    ],
-    outputs: [
       {
-        name: 'pairs',
-        type: 'tuple[]',
-        internalType: 'struct OperatorStatusRegistry.MetricPair[]',
-        components: [
+        "name": "name",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "minValue",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxValue",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "required",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "checkOperatorStatus",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "checkOperatorsStatus",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "operators",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "configureHeartbeat",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "interval",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "maxMissed",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "decodeMetricPairs",
+    "inputs": [
+      {
+        "name": "payload",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "pairs",
+        "type": "tuple[]",
+        "internalType": "struct IOperatorStatusRegistry.MetricPair[]",
+        "components": [
           {
-            name: 'name',
-            type: 'string',
-            internalType: 'string',
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
           },
           {
-            name: 'value',
-            type: 'uint256',
-            internalType: 'uint256',
-          },
-        ],
-      },
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
     ],
-    stateMutability: 'pure',
+    "stateMutability": "pure"
   },
   {
-    type: 'function',
-    name: 'enableCustomMetrics',
-    inputs: [
+    "type": "function",
+    "name": "deregisterOperator",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'enabled',
-        type: 'bool',
-        internalType: 'bool',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'getHeartbeatConfig',
-    inputs: [
+    "type": "function",
+    "name": "enableCustomMetrics",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
-    ],
-    outputs: [
       {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct OperatorStatusRegistry.HeartbeatConfig',
-        components: [
+        "name": "enabled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getAllOperatorCount",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getHeartbeatConfig",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IOperatorStatusRegistry.HeartbeatConfig",
+        "components": [
           {
-            name: 'interval',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-          {
-            name: 'maxMissed',
-            type: 'uint8',
-            internalType: 'uint8',
-          },
-          {
-            name: 'customMetrics',
-            type: 'bool',
-            internalType: 'bool',
-          },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getLastCriticalHeartbeat',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getLastHeartbeat',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getMetricDefinitions',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple[]',
-        internalType: 'struct OperatorStatusRegistry.MetricDefinition[]',
-        components: [
-          {
-            name: 'name',
-            type: 'string',
-            internalType: 'string',
+            "name": "interval",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'minValue',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "maxMissed",
+            "type": "uint8",
+            "internalType": "uint8"
           },
           {
-            name: 'maxValue',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "customMetrics",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getLastCriticalHeartbeat",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getLastHeartbeat",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMetricDefinitions",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct IOperatorStatusRegistry.MetricDefinition[]",
+        "components": [
+          {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
           },
           {
-            name: 'required',
-            type: 'bool',
-            internalType: 'bool',
-          },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getMetricValue',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'metricName',
-        type: 'string',
-        internalType: 'string',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getOnlineOperatorCount',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getOnlineOperators',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getOperatorState',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct OperatorStatusRegistry.OperatorState',
-        components: [
-          {
-            name: 'lastHeartbeat',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "minValue",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'consecutiveBeats',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "maxValue",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'missedBeats',
-            type: 'uint8',
-            internalType: 'uint8',
+            "name": "required",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMetricValue",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "metricName",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getOnlineOperatorCount",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getOnlineOperators",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getOperatorState",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IOperatorStatusRegistry.OperatorState",
+        "components": [
+          {
+            "name": "lastHeartbeat",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'status',
-            type: 'uint8',
-            internalType: 'enum IOperatorStatusRegistry.StatusCode',
+            "name": "consecutiveBeats",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'lastMetricsHash',
-            type: 'bytes32',
-            internalType: 'bytes32',
+            "name": "missedBeats",
+            "type": "uint8",
+            "internalType": "uint8"
           },
-        ],
-      },
+          {
+            "name": "status",
+            "type": "uint8",
+            "internalType": "enum IOperatorStatusRegistry.StatusCode"
+          },
+          {
+            "name": "lastMetricsHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getOperatorStatus',
-    inputs: [
+    "type": "function",
+    "name": "getOperatorStatus",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'uint8',
-        internalType: 'enum IOperatorStatusRegistry.StatusCode',
-      },
+        "name": "",
+        "type": "uint8",
+        "internalType": "enum IOperatorStatusRegistry.StatusCode"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getSlashableOperators',
-    inputs: [
+    "type": "function",
+    "name": "getSlashableOperators",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'operators',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
+        "name": "operators",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'goOffline',
-    inputs: [
+    "type": "function",
+    "name": "getSlashableOperatorsPaginated",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "offset",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "limit",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [
+      {
+        "name": "operators",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "total",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'goOnline',
-    inputs: [
+    "type": "function",
+    "name": "goOffline",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'heartbeatConfigs',
-    inputs: [
+    "type": "function",
+    "name": "goOnline",
+    "inputs": [
       {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
-      {
-        name: 'interval',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'maxMissed',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
-      {
-        name: 'customMetrics',
-        type: 'bool',
-        internalType: 'bool',
-      },
-    ],
-    stateMutability: 'view',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'isHeartbeatCurrent',
-    inputs: [
+    "type": "function",
+    "name": "heartbeatConfigs",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'bool',
-        internalType: 'bool',
+        "name": "interval",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "maxMissed",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "customMetrics",
+        "type": "bool",
+        "internalType": "bool"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'isOnline',
-    inputs: [
+    "type": "function",
+    "name": "isHeartbeatCurrent",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'bool',
-        internalType: 'bool',
-      },
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'metricValues',
-    inputs: [
+    "type": "function",
+    "name": "isOnline",
+    "inputs": [
       {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: '',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: '',
-        type: 'string',
-        internalType: 'string',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'metricsRecorder',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "isRegisteredOperator",
+    "inputs": [
       {
-        name: '',
-        type: 'address',
-        internalType: 'address',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    stateMutability: 'view',
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'operatorStates',
-    inputs: [
+    "type": "function",
+    "name": "metricValues",
+    "inputs": [
       {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: '',
-        type: 'address',
-        internalType: 'address',
+        "name": "",
+        "type": "address",
+        "internalType": "address"
       },
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'lastHeartbeat',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: 'consecutiveBeats',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'missedBeats',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
-      {
-        name: 'status',
-        type: 'uint8',
-        internalType: 'enum IOperatorStatusRegistry.StatusCode',
-      },
-      {
-        name: 'lastMetricsHash',
-        type: 'bytes32',
-        internalType: 'bytes32',
-      },
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'owner',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "metricsRecorder",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'pendingOwner',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "operatorStates",
+    "inputs": [
       {
-        name: '',
-        type: 'address',
-        internalType: 'address',
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    stateMutability: 'view',
+    "outputs": [
+      {
+        "name": "lastHeartbeat",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "consecutiveBeats",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "missedBeats",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "status",
+        "type": "uint8",
+        "internalType": "enum IOperatorStatusRegistry.StatusCode"
+      },
+      {
+        "name": "lastMetricsHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'registerServiceOwner',
-    inputs: [
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'owner',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'renounceOwnership',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "type": "function",
+    "name": "pendingOwner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'reportForSlashing',
-    inputs: [
+    "type": "function",
+    "name": "registerOperator",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'reason',
-        type: 'string',
-        internalType: 'string',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'serviceMetrics',
-    inputs: [
+    "type": "function",
+    "name": "registerServiceOwner",
+    "inputs": [
       {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
-      {
-        name: 'name',
-        type: 'string',
-        internalType: 'string',
-      },
-      {
-        name: 'minValue',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: 'maxValue',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: 'required',
-        type: 'bool',
-        internalType: 'bool',
-      },
-    ],
-    stateMutability: 'view',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'serviceOwners',
-    inputs: [
+    "type": "function",
+    "name": "removeInactiveOperator",
+    "inputs": [
       {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
-    ],
-    outputs: [
       {
-        name: '',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    stateMutability: 'view',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'setMetricsRecorder',
-    inputs: [
-      {
-        name: 'recorder',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'setSlashingOracle',
-    inputs: [
+    "type": "function",
+    "name": "reportForSlashing",
+    "inputs": [
       {
-        name: 'oracle',
-        type: 'address',
-        internalType: 'address',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "reason",
+        "type": "string",
+        "internalType": "string"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'slashingOracle',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "serviceMetrics",
+    "inputs": [
       {
-        name: '',
-        type: 'address',
-        internalType: 'address',
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    stateMutability: 'view',
+    "outputs": [
+      {
+        "name": "name",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "minValue",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxValue",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "required",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'submitHeartbeat',
-    inputs: [
+    "type": "function",
+    "name": "serviceOwners",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'statusCode',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
-      {
-        name: 'metrics',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-      {
-        name: 'signature',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'submitHeartbeatDirect',
-    inputs: [
+    "type": "function",
+    "name": "setMetricDefinitions",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'statusCode',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
-      {
-        name: 'metrics',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
+        "name": "definitions",
+        "type": "tuple[]",
+        "internalType": "struct IOperatorStatusRegistry.MetricDefinition[]",
+        "components": [
+          {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "minValue",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxValue",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "required",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'tangleCore',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "setMetricsRecorder",
+    "inputs": [
       {
-        name: '',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "recorder",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    stateMutability: 'view',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'transferOwnership',
-    inputs: [
+    "type": "function",
+    "name": "setSlashingOracle",
+    "inputs": [
       {
-        name: 'newOwner',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "oracle",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'HeartbeatConfigUpdated',
-    inputs: [
+    "type": "function",
+    "name": "slashingOracle",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'interval',
-        type: 'uint64',
-        indexed: false,
-        internalType: 'uint64',
-      },
-      {
-        name: 'maxMissed',
-        type: 'uint8',
-        indexed: false,
-        internalType: 'uint8',
-      },
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'HeartbeatReceived',
-    inputs: [
+    "type": "function",
+    "name": "submitHeartbeat",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "statusCode",
+        "type": "uint8",
+        "internalType": "uint8"
       },
       {
-        name: 'statusCode',
-        type: 'uint8',
-        indexed: false,
-        internalType: 'uint8',
+        "name": "metrics",
+        "type": "bytes",
+        "internalType": "bytes"
       },
       {
-        name: 'timestamp',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
+        "name": "timestamp",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "signature",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'MetricReported',
-    inputs: [
+    "type": "function",
+    "name": "submitHeartbeatDirect",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'metricName',
-        type: 'string',
-        indexed: false,
-        internalType: 'string',
+        "name": "statusCode",
+        "type": "uint8",
+        "internalType": "uint8"
       },
       {
-        name: 'value',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
+        "name": "metrics",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'OperatorCameOnline',
-    inputs: [
+    "type": "function",
+    "name": "tangleCore",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'OperatorWentOffline',
-    inputs: [
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'missedBeats',
-        type: 'uint8',
-        indexed: false,
-        internalType: 'uint8',
-      },
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'OwnershipTransferStarted',
-    inputs: [
+    "type": "function",
+    "name": "validateAndStoreMetrics",
+    "inputs": [
       {
-        name: 'previousOwner',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'newOwner',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
+      {
+        "name": "pairs",
+        "type": "tuple[]",
+        "internalType": "struct IOperatorStatusRegistry.MetricPair[]",
+        "components": [
+          {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      },
+      {
+        "name": "pairsLen",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'OwnershipTransferred',
-    inputs: [
+    "type": "event",
+    "name": "HeartbeatConfigUpdated",
+    "inputs": [
       {
-        name: 'previousOwner',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
       },
       {
-        name: 'newOwner',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "interval",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
       },
+      {
+        "name": "maxMissed",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
     ],
-    anonymous: false,
+    "anonymous": false
   },
   {
-    type: 'event',
-    name: 'SlashingTriggered',
-    inputs: [
+    "type": "event",
+    "name": "HeartbeatReceived",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
       },
       {
-        name: 'reason',
-        type: 'string',
-        indexed: false,
-        internalType: 'string',
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
       },
+      {
+        "name": "statusCode",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
     ],
-    anonymous: false,
+    "anonymous": false
   },
   {
-    type: 'event',
-    name: 'StatusChanged',
-    inputs: [
+    "type": "event",
+    "name": "MetricReported",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
       },
       {
-        name: 'oldStatus',
-        type: 'uint8',
-        indexed: false,
-        internalType: 'enum IOperatorStatusRegistry.StatusCode',
+        "name": "metricName",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
       },
       {
-        name: 'newStatus',
-        type: 'uint8',
-        indexed: false,
-        internalType: 'enum IOperatorStatusRegistry.StatusCode',
-      },
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
     ],
-    anonymous: false,
+    "anonymous": false
   },
   {
-    type: 'error',
-    name: 'ECDSAInvalidSignature',
-    inputs: [],
+    "type": "event",
+    "name": "MetricViolation",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "metricName",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "reason",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
   },
   {
-    type: 'error',
-    name: 'ECDSAInvalidSignatureLength',
-    inputs: [
+    "type": "event",
+    "name": "OperatorCameOnline",
+    "inputs": [
       {
-        name: 'length',
-        type: 'uint256',
-        internalType: 'uint256',
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
       },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
     ],
+    "anonymous": false
   },
   {
-    type: 'error',
-    name: 'ECDSAInvalidSignatureS',
-    inputs: [
+    "type": "event",
+    "name": "OperatorDeregistered",
+    "inputs": [
       {
-        name: 's',
-        type: 'bytes32',
-        internalType: 'bytes32',
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
       },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
     ],
+    "anonymous": false
   },
   {
-    type: 'error',
-    name: 'OwnableInvalidOwner',
-    inputs: [
+    "type": "event",
+    "name": "OperatorRegistered",
+    "inputs": [
       {
-        name: 'owner',
-        type: 'address',
-        internalType: 'address',
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
       },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
     ],
+    "anonymous": false
   },
   {
-    type: 'error',
-    name: 'OwnableUnauthorizedAccount',
-    inputs: [
+    "type": "event",
+    "name": "OperatorWentOffline",
+    "inputs": [
       {
-        name: 'account',
-        type: 'address',
-        internalType: 'address',
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
       },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "missedBeats",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
     ],
+    "anonymous": false
   },
+  {
+    "type": "event",
+    "name": "OwnershipTransferStarted",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SlashingTriggered",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "reason",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "StatusChanged",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "oldStatus",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum IOperatorStatusRegistry.StatusCode"
+      },
+      {
+        "name": "newStatus",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum IOperatorStatusRegistry.StatusCode"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignature",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignatureLength",
+    "inputs": [
+      {
+        "name": "length",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignatureS",
+    "inputs": [
+      {
+        "name": "s",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "HeartbeatFromFuture",
+    "inputs": [
+      {
+        "name": "signed",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "now_",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "HeartbeatStale",
+    "inputs": [
+      {
+        "name": "signed",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "now_",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  }
 ] as const;
 
 export default ABI;

--- a/libs/tangle-shared-ui/src/abi/tangle.ts
+++ b/libs/tangle-shared-ui/src/abi/tangle.ts
@@ -1,5169 +1,5169 @@
 // AUTO-GENERATED FROM tnt-core. DO NOT EDIT MANUALLY.
 const ABI = [
   {
-    "type": "function",
-    "name": "addPermittedCaller",
-    "inputs": [
+    type: 'function',
+    name: 'addPermittedCaller',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "caller",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'caller',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "approveService",
-    "inputs": [
+    type: 'function',
+    name: 'approveService',
+    inputs: [
       {
-        "name": "params",
-        "type": "tuple",
-        "internalType": "struct Types.ApprovalParams",
-        "components": [
+        name: 'params',
+        type: 'tuple',
+        internalType: 'struct Types.ApprovalParams',
+        components: [
           {
-            "name": "requestId",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'requestId',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "securityCommitments",
-            "type": "tuple[]",
-            "internalType": "struct Types.AssetSecurityCommitment[]",
-            "components": [
+            name: 'securityCommitments',
+            type: 'tuple[]',
+            internalType: 'struct Types.AssetSecurityCommitment[]',
+            components: [
               {
-                "name": "asset",
-                "type": "tuple",
-                "internalType": "struct Types.Asset",
-                "components": [
+                name: 'asset',
+                type: 'tuple',
+                internalType: 'struct Types.Asset',
+                components: [
                   {
-                    "name": "kind",
-                    "type": "uint8",
-                    "internalType": "enum Types.AssetKind"
+                    name: 'kind',
+                    type: 'uint8',
+                    internalType: 'enum Types.AssetKind',
                   },
                   {
-                    "name": "token",
-                    "type": "address",
-                    "internalType": "address"
-                  }
-                ]
+                    name: 'token',
+                    type: 'address',
+                    internalType: 'address',
+                  },
+                ],
               },
               {
-                "name": "exposureBps",
-                "type": "uint16",
-                "internalType": "uint16"
-              }
-            ]
+                name: 'exposureBps',
+                type: 'uint16',
+                internalType: 'uint16',
+              },
+            ],
           },
           {
-            "name": "blsPubkey",
-            "type": "uint256[4]",
-            "internalType": "uint256[4]"
+            name: 'blsPubkey',
+            type: 'uint256[4]',
+            internalType: 'uint256[4]',
           },
           {
-            "name": "blsPopSignature",
-            "type": "uint256[2]",
-            "internalType": "uint256[2]"
+            name: 'blsPopSignature',
+            type: 'uint256[2]',
+            internalType: 'uint256[2]',
           },
           {
-            "name": "teeCommitments",
-            "type": "tuple[]",
-            "internalType": "struct Types.TeeAttestationCommitment[]",
-            "components": [
+            name: 'teeCommitments',
+            type: 'tuple[]',
+            internalType: 'struct Types.TeeAttestationCommitment[]',
+            components: [
               {
-                "name": "backend",
-                "type": "uint8",
-                "internalType": "enum Types.TeeBackend"
+                name: 'backend',
+                type: 'uint8',
+                internalType: 'enum Types.TeeBackend',
               },
               {
-                "name": "expectedMeasurement",
-                "type": "bytes32",
-                "internalType": "bytes32"
+                name: 'expectedMeasurement',
+                type: 'bytes32',
+                internalType: 'bytes32',
               },
               {
-                "name": "nonceBinding",
-                "type": "bytes32",
-                "internalType": "bytes32"
+                name: 'nonceBinding',
+                type: 'bytes32',
+                internalType: 'bytes32',
               },
               {
-                "name": "expiresAt",
-                "type": "uint64",
-                "internalType": "uint64"
-              }
-            ]
-          }
-        ]
-      }
+                name: 'expiresAt',
+                type: 'uint64',
+                internalType: 'uint64',
+              },
+            ],
+          },
+        ],
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "billSubscription",
-    "inputs": [
+    type: 'function',
+    name: 'billSubscription',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "billSubscriptionBatch",
-    "inputs": [
+    type: 'function',
+    name: 'billSubscriptionBatch',
+    inputs: [
       {
-        "name": "serviceIds",
-        "type": "uint64[]",
-        "internalType": "uint64[]"
-      }
+        name: 'serviceIds',
+        type: 'uint64[]',
+        internalType: 'uint64[]',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "totalBilled",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'totalBilled',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "billedCount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'billedCount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "nonpayable"
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "blsPopMessage",
-    "inputs": [
+    type: 'function',
+    name: 'blsPopMessage',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "blsPubkey",
-        "type": "uint256[4]",
-        "internalType": "uint256[4]"
-      }
+        name: 'blsPubkey',
+        type: 'uint256[4]',
+        internalType: 'uint256[4]',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
+        name: '',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "blueprintCount",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'blueprintCount',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "blueprintMasterRevision",
-    "inputs": [
+    type: 'function',
+    name: 'blueprintMasterRevision',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
+        name: '',
+        type: 'uint32',
+        internalType: 'uint32',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "blueprintMetadata",
-    "inputs": [
+    type: 'function',
+    name: 'blueprintMetadata',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "metadata",
-        "type": "tuple",
-        "internalType": "struct Types.BlueprintMetadata",
-        "components": [
+        name: 'metadata',
+        type: 'tuple',
+        internalType: 'struct Types.BlueprintMetadata',
+        components: [
           {
-            "name": "name",
-            "type": "string",
-            "internalType": "string"
+            name: 'name',
+            type: 'string',
+            internalType: 'string',
           },
           {
-            "name": "description",
-            "type": "string",
-            "internalType": "string"
+            name: 'description',
+            type: 'string',
+            internalType: 'string',
           },
           {
-            "name": "author",
-            "type": "string",
-            "internalType": "string"
+            name: 'author',
+            type: 'string',
+            internalType: 'string',
           },
           {
-            "name": "category",
-            "type": "string",
-            "internalType": "string"
+            name: 'category',
+            type: 'string',
+            internalType: 'string',
           },
           {
-            "name": "codeRepository",
-            "type": "string",
-            "internalType": "string"
+            name: 'codeRepository',
+            type: 'string',
+            internalType: 'string',
           },
           {
-            "name": "logo",
-            "type": "string",
-            "internalType": "string"
+            name: 'logo',
+            type: 'string',
+            internalType: 'string',
           },
           {
-            "name": "website",
-            "type": "string",
-            "internalType": "string"
+            name: 'website',
+            type: 'string',
+            internalType: 'string',
           },
           {
-            "name": "license",
-            "type": "string",
-            "internalType": "string"
+            name: 'license',
+            type: 'string',
+            internalType: 'string',
           },
           {
-            "name": "profilingData",
-            "type": "string",
-            "internalType": "string"
-          }
-        ]
+            name: 'profilingData',
+            type: 'string',
+            internalType: 'string',
+          },
+        ],
       },
       {
-        "name": "metadataUri",
-        "type": "string",
-        "internalType": "string"
+        name: 'metadataUri',
+        type: 'string',
+        internalType: 'string',
       },
       {
-        "name": "metadataHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: 'metadataHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "blueprintOperatorCount",
-    "inputs": [
+    type: 'function',
+    name: 'blueprintOperatorCount',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "blueprintSources",
-    "inputs": [
+    type: 'function',
+    name: 'blueprintSources',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "sources",
-        "type": "tuple[]",
-        "internalType": "struct Types.BlueprintSource[]",
-        "components": [
+        name: 'sources',
+        type: 'tuple[]',
+        internalType: 'struct Types.BlueprintSource[]',
+        components: [
           {
-            "name": "kind",
-            "type": "uint8",
-            "internalType": "enum Types.BlueprintSourceKind"
+            name: 'kind',
+            type: 'uint8',
+            internalType: 'enum Types.BlueprintSourceKind',
           },
           {
-            "name": "container",
-            "type": "tuple",
-            "internalType": "struct Types.ImageRegistrySource",
-            "components": [
+            name: 'container',
+            type: 'tuple',
+            internalType: 'struct Types.ImageRegistrySource',
+            components: [
               {
-                "name": "registry",
-                "type": "string",
-                "internalType": "string"
+                name: 'registry',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "image",
-                "type": "string",
-                "internalType": "string"
+                name: 'image',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "tag",
-                "type": "string",
-                "internalType": "string"
-              }
-            ]
+                name: 'tag',
+                type: 'string',
+                internalType: 'string',
+              },
+            ],
           },
           {
-            "name": "wasm",
-            "type": "tuple",
-            "internalType": "struct Types.WasmSource",
-            "components": [
+            name: 'wasm',
+            type: 'tuple',
+            internalType: 'struct Types.WasmSource',
+            components: [
               {
-                "name": "runtime",
-                "type": "uint8",
-                "internalType": "enum Types.WasmRuntime"
+                name: 'runtime',
+                type: 'uint8',
+                internalType: 'enum Types.WasmRuntime',
               },
               {
-                "name": "fetcher",
-                "type": "uint8",
-                "internalType": "enum Types.BlueprintFetcherKind"
+                name: 'fetcher',
+                type: 'uint8',
+                internalType: 'enum Types.BlueprintFetcherKind',
               },
               {
-                "name": "artifactUri",
-                "type": "string",
-                "internalType": "string"
+                name: 'artifactUri',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "entrypoint",
-                "type": "string",
-                "internalType": "string"
-              }
-            ]
+                name: 'entrypoint',
+                type: 'string',
+                internalType: 'string',
+              },
+            ],
           },
           {
-            "name": "native",
-            "type": "tuple",
-            "internalType": "struct Types.NativeSource",
-            "components": [
+            name: 'native',
+            type: 'tuple',
+            internalType: 'struct Types.NativeSource',
+            components: [
               {
-                "name": "fetcher",
-                "type": "uint8",
-                "internalType": "enum Types.BlueprintFetcherKind"
+                name: 'fetcher',
+                type: 'uint8',
+                internalType: 'enum Types.BlueprintFetcherKind',
               },
               {
-                "name": "artifactUri",
-                "type": "string",
-                "internalType": "string"
+                name: 'artifactUri',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "entrypoint",
-                "type": "string",
-                "internalType": "string"
-              }
-            ]
+                name: 'entrypoint',
+                type: 'string',
+                internalType: 'string',
+              },
+            ],
           },
           {
-            "name": "testing",
-            "type": "tuple",
-            "internalType": "struct Types.TestingSource",
-            "components": [
+            name: 'testing',
+            type: 'tuple',
+            internalType: 'struct Types.TestingSource',
+            components: [
               {
-                "name": "cargoPackage",
-                "type": "string",
-                "internalType": "string"
+                name: 'cargoPackage',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "cargoBin",
-                "type": "string",
-                "internalType": "string"
+                name: 'cargoBin',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "basePath",
-                "type": "string",
-                "internalType": "string"
-              }
-            ]
+                name: 'basePath',
+                type: 'string',
+                internalType: 'string',
+              },
+            ],
           },
           {
-            "name": "binaries",
-            "type": "tuple[]",
-            "internalType": "struct Types.BlueprintBinary[]",
-            "components": [
+            name: 'binaries',
+            type: 'tuple[]',
+            internalType: 'struct Types.BlueprintBinary[]',
+            components: [
               {
-                "name": "arch",
-                "type": "uint8",
-                "internalType": "enum Types.BlueprintArchitecture"
+                name: 'arch',
+                type: 'uint8',
+                internalType: 'enum Types.BlueprintArchitecture',
               },
               {
-                "name": "os",
-                "type": "uint8",
-                "internalType": "enum Types.BlueprintOperatingSystem"
+                name: 'os',
+                type: 'uint8',
+                internalType: 'enum Types.BlueprintOperatingSystem',
               },
               {
-                "name": "name",
-                "type": "string",
-                "internalType": "string"
+                name: 'name',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "sha256",
-                "type": "bytes32",
-                "internalType": "bytes32"
-              }
-            ]
-          }
-        ]
-      }
+                name: 'sha256',
+                type: 'bytes32',
+                internalType: 'bytes32',
+              },
+            ],
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "blueprintSupportedMemberships",
-    "inputs": [
+    type: 'function',
+    name: 'blueprintSupportedMemberships',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "memberships",
-        "type": "uint8[]",
-        "internalType": "enum Types.MembershipModel[]"
-      }
+        name: 'memberships',
+        type: 'uint8[]',
+        internalType: 'enum Types.MembershipModel[]',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "canScheduleExit",
-    "inputs": [
+    type: 'function',
+    name: 'canScheduleExit',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "canExit",
-        "type": "bool",
-        "internalType": "bool"
+        name: 'canExit',
+        type: 'bool',
+        internalType: 'bool',
       },
       {
-        "name": "reason",
-        "type": "string",
-        "internalType": "string"
-      }
+        name: 'reason',
+        type: 'string',
+        internalType: 'string',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "cancelExit",
-    "inputs": [
+    type: 'function',
+    name: 'cancelExit',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "cancelSlash",
-    "inputs": [
+    type: 'function',
+    name: 'cancelSlash',
+    inputs: [
       {
-        "name": "slashId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'slashId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "reason",
-        "type": "string",
-        "internalType": "string"
-      }
+        name: 'reason',
+        type: 'string',
+        internalType: 'string',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "claimRewards",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: 'function',
+    name: 'claimRewards',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "claimRewards",
-    "inputs": [
+    type: 'function',
+    name: 'claimRewards',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "claimRewardsAll",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: 'function',
+    name: 'claimRewardsAll',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "claimRewardsBatch",
-    "inputs": [
+    type: 'function',
+    name: 'claimRewardsBatch',
+    inputs: [
       {
-        "name": "tokens",
-        "type": "address[]",
-        "internalType": "address[]"
-      }
+        name: 'tokens',
+        type: 'address[]',
+        internalType: 'address[]',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "createBlueprint",
-    "inputs": [
+    type: 'function',
+    name: 'createBlueprint',
+    inputs: [
       {
-        "name": "definition",
-        "type": "tuple",
-        "internalType": "struct Types.BlueprintDefinition",
-        "components": [
+        name: 'definition',
+        type: 'tuple',
+        internalType: 'struct Types.BlueprintDefinition',
+        components: [
           {
-            "name": "metadataUri",
-            "type": "string",
-            "internalType": "string"
+            name: 'metadataUri',
+            type: 'string',
+            internalType: 'string',
           },
           {
-            "name": "metadataHash",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: 'metadataHash',
+            type: 'bytes32',
+            internalType: 'bytes32',
           },
           {
-            "name": "manager",
-            "type": "address",
-            "internalType": "address"
+            name: 'manager',
+            type: 'address',
+            internalType: 'address',
           },
           {
-            "name": "masterManagerRevision",
-            "type": "uint32",
-            "internalType": "uint32"
+            name: 'masterManagerRevision',
+            type: 'uint32',
+            internalType: 'uint32',
           },
           {
-            "name": "hasConfig",
-            "type": "bool",
-            "internalType": "bool"
+            name: 'hasConfig',
+            type: 'bool',
+            internalType: 'bool',
           },
           {
-            "name": "config",
-            "type": "tuple",
-            "internalType": "struct Types.BlueprintConfig",
-            "components": [
+            name: 'config',
+            type: 'tuple',
+            internalType: 'struct Types.BlueprintConfig',
+            components: [
               {
-                "name": "membership",
-                "type": "uint8",
-                "internalType": "enum Types.MembershipModel"
+                name: 'membership',
+                type: 'uint8',
+                internalType: 'enum Types.MembershipModel',
               },
               {
-                "name": "pricing",
-                "type": "uint8",
-                "internalType": "enum Types.PricingModel"
+                name: 'pricing',
+                type: 'uint8',
+                internalType: 'enum Types.PricingModel',
               },
               {
-                "name": "minOperators",
-                "type": "uint32",
-                "internalType": "uint32"
+                name: 'minOperators',
+                type: 'uint32',
+                internalType: 'uint32',
               },
               {
-                "name": "maxOperators",
-                "type": "uint32",
-                "internalType": "uint32"
+                name: 'maxOperators',
+                type: 'uint32',
+                internalType: 'uint32',
               },
               {
-                "name": "subscriptionRate",
-                "type": "uint256",
-                "internalType": "uint256"
+                name: 'subscriptionRate',
+                type: 'uint256',
+                internalType: 'uint256',
               },
               {
-                "name": "subscriptionInterval",
-                "type": "uint64",
-                "internalType": "uint64"
+                name: 'subscriptionInterval',
+                type: 'uint64',
+                internalType: 'uint64',
               },
               {
-                "name": "eventRate",
-                "type": "uint256",
-                "internalType": "uint256"
-              }
-            ]
+                name: 'eventRate',
+                type: 'uint256',
+                internalType: 'uint256',
+              },
+            ],
           },
           {
-            "name": "metadata",
-            "type": "tuple",
-            "internalType": "struct Types.BlueprintMetadata",
-            "components": [
+            name: 'metadata',
+            type: 'tuple',
+            internalType: 'struct Types.BlueprintMetadata',
+            components: [
               {
-                "name": "name",
-                "type": "string",
-                "internalType": "string"
+                name: 'name',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "description",
-                "type": "string",
-                "internalType": "string"
+                name: 'description',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "author",
-                "type": "string",
-                "internalType": "string"
+                name: 'author',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "category",
-                "type": "string",
-                "internalType": "string"
+                name: 'category',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "codeRepository",
-                "type": "string",
-                "internalType": "string"
+                name: 'codeRepository',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "logo",
-                "type": "string",
-                "internalType": "string"
+                name: 'logo',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "website",
-                "type": "string",
-                "internalType": "string"
+                name: 'website',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "license",
-                "type": "string",
-                "internalType": "string"
+                name: 'license',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "profilingData",
-                "type": "string",
-                "internalType": "string"
-              }
-            ]
+                name: 'profilingData',
+                type: 'string',
+                internalType: 'string',
+              },
+            ],
           },
           {
-            "name": "jobs",
-            "type": "tuple[]",
-            "internalType": "struct Types.JobDefinition[]",
-            "components": [
+            name: 'jobs',
+            type: 'tuple[]',
+            internalType: 'struct Types.JobDefinition[]',
+            components: [
               {
-                "name": "name",
-                "type": "string",
-                "internalType": "string"
+                name: 'name',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "description",
-                "type": "string",
-                "internalType": "string"
+                name: 'description',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "metadataUri",
-                "type": "string",
-                "internalType": "string"
+                name: 'metadataUri',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "paramsSchema",
-                "type": "bytes",
-                "internalType": "bytes"
+                name: 'paramsSchema',
+                type: 'bytes',
+                internalType: 'bytes',
               },
               {
-                "name": "resultSchema",
-                "type": "bytes",
-                "internalType": "bytes"
-              }
-            ]
+                name: 'resultSchema',
+                type: 'bytes',
+                internalType: 'bytes',
+              },
+            ],
           },
           {
-            "name": "registrationSchema",
-            "type": "bytes",
-            "internalType": "bytes"
+            name: 'registrationSchema',
+            type: 'bytes',
+            internalType: 'bytes',
           },
           {
-            "name": "requestSchema",
-            "type": "bytes",
-            "internalType": "bytes"
+            name: 'requestSchema',
+            type: 'bytes',
+            internalType: 'bytes',
           },
           {
-            "name": "sources",
-            "type": "tuple[]",
-            "internalType": "struct Types.BlueprintSource[]",
-            "components": [
+            name: 'sources',
+            type: 'tuple[]',
+            internalType: 'struct Types.BlueprintSource[]',
+            components: [
               {
-                "name": "kind",
-                "type": "uint8",
-                "internalType": "enum Types.BlueprintSourceKind"
+                name: 'kind',
+                type: 'uint8',
+                internalType: 'enum Types.BlueprintSourceKind',
               },
               {
-                "name": "container",
-                "type": "tuple",
-                "internalType": "struct Types.ImageRegistrySource",
-                "components": [
+                name: 'container',
+                type: 'tuple',
+                internalType: 'struct Types.ImageRegistrySource',
+                components: [
                   {
-                    "name": "registry",
-                    "type": "string",
-                    "internalType": "string"
+                    name: 'registry',
+                    type: 'string',
+                    internalType: 'string',
                   },
                   {
-                    "name": "image",
-                    "type": "string",
-                    "internalType": "string"
+                    name: 'image',
+                    type: 'string',
+                    internalType: 'string',
                   },
                   {
-                    "name": "tag",
-                    "type": "string",
-                    "internalType": "string"
-                  }
-                ]
+                    name: 'tag',
+                    type: 'string',
+                    internalType: 'string',
+                  },
+                ],
               },
               {
-                "name": "wasm",
-                "type": "tuple",
-                "internalType": "struct Types.WasmSource",
-                "components": [
+                name: 'wasm',
+                type: 'tuple',
+                internalType: 'struct Types.WasmSource',
+                components: [
                   {
-                    "name": "runtime",
-                    "type": "uint8",
-                    "internalType": "enum Types.WasmRuntime"
+                    name: 'runtime',
+                    type: 'uint8',
+                    internalType: 'enum Types.WasmRuntime',
                   },
                   {
-                    "name": "fetcher",
-                    "type": "uint8",
-                    "internalType": "enum Types.BlueprintFetcherKind"
+                    name: 'fetcher',
+                    type: 'uint8',
+                    internalType: 'enum Types.BlueprintFetcherKind',
                   },
                   {
-                    "name": "artifactUri",
-                    "type": "string",
-                    "internalType": "string"
+                    name: 'artifactUri',
+                    type: 'string',
+                    internalType: 'string',
                   },
                   {
-                    "name": "entrypoint",
-                    "type": "string",
-                    "internalType": "string"
-                  }
-                ]
+                    name: 'entrypoint',
+                    type: 'string',
+                    internalType: 'string',
+                  },
+                ],
               },
               {
-                "name": "native",
-                "type": "tuple",
-                "internalType": "struct Types.NativeSource",
-                "components": [
+                name: 'native',
+                type: 'tuple',
+                internalType: 'struct Types.NativeSource',
+                components: [
                   {
-                    "name": "fetcher",
-                    "type": "uint8",
-                    "internalType": "enum Types.BlueprintFetcherKind"
+                    name: 'fetcher',
+                    type: 'uint8',
+                    internalType: 'enum Types.BlueprintFetcherKind',
                   },
                   {
-                    "name": "artifactUri",
-                    "type": "string",
-                    "internalType": "string"
+                    name: 'artifactUri',
+                    type: 'string',
+                    internalType: 'string',
                   },
                   {
-                    "name": "entrypoint",
-                    "type": "string",
-                    "internalType": "string"
-                  }
-                ]
+                    name: 'entrypoint',
+                    type: 'string',
+                    internalType: 'string',
+                  },
+                ],
               },
               {
-                "name": "testing",
-                "type": "tuple",
-                "internalType": "struct Types.TestingSource",
-                "components": [
+                name: 'testing',
+                type: 'tuple',
+                internalType: 'struct Types.TestingSource',
+                components: [
                   {
-                    "name": "cargoPackage",
-                    "type": "string",
-                    "internalType": "string"
+                    name: 'cargoPackage',
+                    type: 'string',
+                    internalType: 'string',
                   },
                   {
-                    "name": "cargoBin",
-                    "type": "string",
-                    "internalType": "string"
+                    name: 'cargoBin',
+                    type: 'string',
+                    internalType: 'string',
                   },
                   {
-                    "name": "basePath",
-                    "type": "string",
-                    "internalType": "string"
-                  }
-                ]
+                    name: 'basePath',
+                    type: 'string',
+                    internalType: 'string',
+                  },
+                ],
               },
               {
-                "name": "binaries",
-                "type": "tuple[]",
-                "internalType": "struct Types.BlueprintBinary[]",
-                "components": [
+                name: 'binaries',
+                type: 'tuple[]',
+                internalType: 'struct Types.BlueprintBinary[]',
+                components: [
                   {
-                    "name": "arch",
-                    "type": "uint8",
-                    "internalType": "enum Types.BlueprintArchitecture"
+                    name: 'arch',
+                    type: 'uint8',
+                    internalType: 'enum Types.BlueprintArchitecture',
                   },
                   {
-                    "name": "os",
-                    "type": "uint8",
-                    "internalType": "enum Types.BlueprintOperatingSystem"
+                    name: 'os',
+                    type: 'uint8',
+                    internalType: 'enum Types.BlueprintOperatingSystem',
                   },
                   {
-                    "name": "name",
-                    "type": "string",
-                    "internalType": "string"
+                    name: 'name',
+                    type: 'string',
+                    internalType: 'string',
                   },
                   {
-                    "name": "sha256",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  }
-                ]
-              }
-            ]
+                    name: 'sha256',
+                    type: 'bytes32',
+                    internalType: 'bytes32',
+                  },
+                ],
+              },
+            ],
           },
           {
-            "name": "supportedMemberships",
-            "type": "uint8[]",
-            "internalType": "enum Types.MembershipModel[]"
-          }
-        ]
-      }
+            name: 'supportedMemberships',
+            type: 'uint8[]',
+            internalType: 'enum Types.MembershipModel[]',
+          },
+        ],
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "nonpayable"
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "createServiceFromQuotes",
-    "inputs": [
+    type: 'function',
+    name: 'createServiceFromQuotes',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "quotes",
-        "type": "tuple[]",
-        "internalType": "struct Types.SignedQuote[]",
-        "components": [
+        name: 'quotes',
+        type: 'tuple[]',
+        internalType: 'struct Types.SignedQuote[]',
+        components: [
           {
-            "name": "details",
-            "type": "tuple",
-            "internalType": "struct Types.QuoteDetails",
-            "components": [
+            name: 'details',
+            type: 'tuple',
+            internalType: 'struct Types.QuoteDetails',
+            components: [
               {
-                "name": "requester",
-                "type": "address",
-                "internalType": "address"
+                name: 'requester',
+                type: 'address',
+                internalType: 'address',
               },
               {
-                "name": "blueprintId",
-                "type": "uint64",
-                "internalType": "uint64"
+                name: 'blueprintId',
+                type: 'uint64',
+                internalType: 'uint64',
               },
               {
-                "name": "ttlBlocks",
-                "type": "uint64",
-                "internalType": "uint64"
+                name: 'ttlBlocks',
+                type: 'uint64',
+                internalType: 'uint64',
               },
               {
-                "name": "totalCost",
-                "type": "uint256",
-                "internalType": "uint256"
+                name: 'totalCost',
+                type: 'uint256',
+                internalType: 'uint256',
               },
               {
-                "name": "timestamp",
-                "type": "uint64",
-                "internalType": "uint64"
+                name: 'timestamp',
+                type: 'uint64',
+                internalType: 'uint64',
               },
               {
-                "name": "expiry",
-                "type": "uint64",
-                "internalType": "uint64"
+                name: 'expiry',
+                type: 'uint64',
+                internalType: 'uint64',
               },
               {
-                "name": "confidentiality",
-                "type": "uint8",
-                "internalType": "enum Types.ConfidentialityPolicy"
+                name: 'confidentiality',
+                type: 'uint8',
+                internalType: 'enum Types.ConfidentialityPolicy',
               },
               {
-                "name": "securityCommitments",
-                "type": "tuple[]",
-                "internalType": "struct Types.AssetSecurityCommitment[]",
-                "components": [
+                name: 'securityCommitments',
+                type: 'tuple[]',
+                internalType: 'struct Types.AssetSecurityCommitment[]',
+                components: [
                   {
-                    "name": "asset",
-                    "type": "tuple",
-                    "internalType": "struct Types.Asset",
-                    "components": [
+                    name: 'asset',
+                    type: 'tuple',
+                    internalType: 'struct Types.Asset',
+                    components: [
                       {
-                        "name": "kind",
-                        "type": "uint8",
-                        "internalType": "enum Types.AssetKind"
+                        name: 'kind',
+                        type: 'uint8',
+                        internalType: 'enum Types.AssetKind',
                       },
                       {
-                        "name": "token",
-                        "type": "address",
-                        "internalType": "address"
-                      }
-                    ]
+                        name: 'token',
+                        type: 'address',
+                        internalType: 'address',
+                      },
+                    ],
                   },
                   {
-                    "name": "exposureBps",
-                    "type": "uint16",
-                    "internalType": "uint16"
-                  }
-                ]
+                    name: 'exposureBps',
+                    type: 'uint16',
+                    internalType: 'uint16',
+                  },
+                ],
               },
               {
-                "name": "resourceCommitments",
-                "type": "tuple[]",
-                "internalType": "struct Types.ResourceCommitment[]",
-                "components": [
+                name: 'resourceCommitments',
+                type: 'tuple[]',
+                internalType: 'struct Types.ResourceCommitment[]',
+                components: [
                   {
-                    "name": "kind",
-                    "type": "uint8",
-                    "internalType": "uint8"
+                    name: 'kind',
+                    type: 'uint8',
+                    internalType: 'uint8',
                   },
                   {
-                    "name": "count",
-                    "type": "uint64",
-                    "internalType": "uint64"
-                  }
-                ]
-              }
-            ]
+                    name: 'count',
+                    type: 'uint64',
+                    internalType: 'uint64',
+                  },
+                ],
+              },
+            ],
           },
           {
-            "name": "signature",
-            "type": "bytes",
-            "internalType": "bytes"
+            name: 'signature',
+            type: 'bytes',
+            internalType: 'bytes',
           },
           {
-            "name": "operator",
-            "type": "address",
-            "internalType": "address"
-          }
-        ]
+            name: 'operator',
+            type: 'address',
+            internalType: 'address',
+          },
+        ],
       },
       {
-        "name": "config",
-        "type": "bytes",
-        "internalType": "bytes"
+        name: 'config',
+        type: 'bytes',
+        internalType: 'bytes',
       },
       {
-        "name": "permittedCallers",
-        "type": "address[]",
-        "internalType": "address[]"
+        name: 'permittedCallers',
+        type: 'address[]',
+        internalType: 'address[]',
       },
       {
-        "name": "ttl",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'ttl',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "payable"
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "deactivateBlueprint",
-    "inputs": [
+    type: 'function',
+    name: 'deactivateBlueprint',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "defaultTntMinExposureBps",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'defaultTntMinExposureBps',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: '',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "disputeSlash",
-    "inputs": [
+    type: 'function',
+    name: 'disputeSlash',
+    inputs: [
       {
-        "name": "slashId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'slashId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "reason",
-        "type": "string",
-        "internalType": "string"
-      }
+        name: 'reason',
+        type: 'string',
+        internalType: 'string',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "payable"
+    outputs: [],
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "executeExit",
-    "inputs": [
+    type: 'function',
+    name: 'executeExit',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "executeSlash",
-    "inputs": [
+    type: 'function',
+    name: 'executeSlash',
+    inputs: [
       {
-        "name": "slashId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'slashId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "actualSlashed",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'actualSlashed',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "nonpayable"
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "executeSlashBatch",
-    "inputs": [
+    type: 'function',
+    name: 'executeSlashBatch',
+    inputs: [
       {
-        "name": "slashIds",
-        "type": "uint64[]",
-        "internalType": "uint64[]"
-      }
+        name: 'slashIds',
+        type: 'uint64[]',
+        internalType: 'uint64[]',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "totalSlashed",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'totalSlashed',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "executedCount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'executedCount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "nonpayable"
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "expireServiceRequest",
-    "inputs": [
+    type: 'function',
+    name: 'expireServiceRequest',
+    inputs: [
       {
-        "name": "requestId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'requestId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "extendServiceFromQuotes",
-    "inputs": [
+    type: 'function',
+    name: 'extendServiceFromQuotes',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "quotes",
-        "type": "tuple[]",
-        "internalType": "struct Types.SignedQuote[]",
-        "components": [
+        name: 'quotes',
+        type: 'tuple[]',
+        internalType: 'struct Types.SignedQuote[]',
+        components: [
           {
-            "name": "details",
-            "type": "tuple",
-            "internalType": "struct Types.QuoteDetails",
-            "components": [
+            name: 'details',
+            type: 'tuple',
+            internalType: 'struct Types.QuoteDetails',
+            components: [
               {
-                "name": "requester",
-                "type": "address",
-                "internalType": "address"
+                name: 'requester',
+                type: 'address',
+                internalType: 'address',
               },
               {
-                "name": "blueprintId",
-                "type": "uint64",
-                "internalType": "uint64"
+                name: 'blueprintId',
+                type: 'uint64',
+                internalType: 'uint64',
               },
               {
-                "name": "ttlBlocks",
-                "type": "uint64",
-                "internalType": "uint64"
+                name: 'ttlBlocks',
+                type: 'uint64',
+                internalType: 'uint64',
               },
               {
-                "name": "totalCost",
-                "type": "uint256",
-                "internalType": "uint256"
+                name: 'totalCost',
+                type: 'uint256',
+                internalType: 'uint256',
               },
               {
-                "name": "timestamp",
-                "type": "uint64",
-                "internalType": "uint64"
+                name: 'timestamp',
+                type: 'uint64',
+                internalType: 'uint64',
               },
               {
-                "name": "expiry",
-                "type": "uint64",
-                "internalType": "uint64"
+                name: 'expiry',
+                type: 'uint64',
+                internalType: 'uint64',
               },
               {
-                "name": "confidentiality",
-                "type": "uint8",
-                "internalType": "enum Types.ConfidentialityPolicy"
+                name: 'confidentiality',
+                type: 'uint8',
+                internalType: 'enum Types.ConfidentialityPolicy',
               },
               {
-                "name": "securityCommitments",
-                "type": "tuple[]",
-                "internalType": "struct Types.AssetSecurityCommitment[]",
-                "components": [
+                name: 'securityCommitments',
+                type: 'tuple[]',
+                internalType: 'struct Types.AssetSecurityCommitment[]',
+                components: [
                   {
-                    "name": "asset",
-                    "type": "tuple",
-                    "internalType": "struct Types.Asset",
-                    "components": [
+                    name: 'asset',
+                    type: 'tuple',
+                    internalType: 'struct Types.Asset',
+                    components: [
                       {
-                        "name": "kind",
-                        "type": "uint8",
-                        "internalType": "enum Types.AssetKind"
+                        name: 'kind',
+                        type: 'uint8',
+                        internalType: 'enum Types.AssetKind',
                       },
                       {
-                        "name": "token",
-                        "type": "address",
-                        "internalType": "address"
-                      }
-                    ]
+                        name: 'token',
+                        type: 'address',
+                        internalType: 'address',
+                      },
+                    ],
                   },
                   {
-                    "name": "exposureBps",
-                    "type": "uint16",
-                    "internalType": "uint16"
-                  }
-                ]
+                    name: 'exposureBps',
+                    type: 'uint16',
+                    internalType: 'uint16',
+                  },
+                ],
               },
               {
-                "name": "resourceCommitments",
-                "type": "tuple[]",
-                "internalType": "struct Types.ResourceCommitment[]",
-                "components": [
+                name: 'resourceCommitments',
+                type: 'tuple[]',
+                internalType: 'struct Types.ResourceCommitment[]',
+                components: [
                   {
-                    "name": "kind",
-                    "type": "uint8",
-                    "internalType": "uint8"
+                    name: 'kind',
+                    type: 'uint8',
+                    internalType: 'uint8',
                   },
                   {
-                    "name": "count",
-                    "type": "uint64",
-                    "internalType": "uint64"
-                  }
-                ]
-              }
-            ]
+                    name: 'count',
+                    type: 'uint64',
+                    internalType: 'uint64',
+                  },
+                ],
+              },
+            ],
           },
           {
-            "name": "signature",
-            "type": "bytes",
-            "internalType": "bytes"
+            name: 'signature',
+            type: 'bytes',
+            internalType: 'bytes',
           },
           {
-            "name": "operator",
-            "type": "address",
-            "internalType": "address"
-          }
-        ]
+            name: 'operator',
+            type: 'address',
+            internalType: 'address',
+          },
+        ],
       },
       {
-        "name": "extensionDuration",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'extensionDuration',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "payable"
+    outputs: [],
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "forceExit",
-    "inputs": [
+    type: 'function',
+    name: 'forceExit',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "forceRemoveOperator",
-    "inputs": [
+    type: 'function',
+    name: 'forceRemoveOperator',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "fundService",
-    "inputs": [
+    type: 'function',
+    name: 'fundService',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "payable"
+    outputs: [],
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "getBillableServices",
-    "inputs": [
+    type: 'function',
+    name: 'getBillableServices',
+    inputs: [
       {
-        "name": "serviceIds",
-        "type": "uint64[]",
-        "internalType": "uint64[]"
-      }
+        name: 'serviceIds',
+        type: 'uint64[]',
+        internalType: 'uint64[]',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "billable",
-        "type": "uint64[]",
-        "internalType": "uint64[]"
-      }
+        name: 'billable',
+        type: 'uint64[]',
+        internalType: 'uint64[]',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getBlueprint",
-    "inputs": [
+    type: 'function',
+    name: 'getBlueprint',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Types.Blueprint",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct Types.Blueprint',
+        components: [
           {
-            "name": "owner",
-            "type": "address",
-            "internalType": "address"
+            name: 'owner',
+            type: 'address',
+            internalType: 'address',
           },
           {
-            "name": "manager",
-            "type": "address",
-            "internalType": "address"
+            name: 'manager',
+            type: 'address',
+            internalType: 'address',
           },
           {
-            "name": "createdAt",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'createdAt',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "operatorCount",
-            "type": "uint32",
-            "internalType": "uint32"
+            name: 'operatorCount',
+            type: 'uint32',
+            internalType: 'uint32',
           },
           {
-            "name": "membership",
-            "type": "uint8",
-            "internalType": "enum Types.MembershipModel"
+            name: 'membership',
+            type: 'uint8',
+            internalType: 'enum Types.MembershipModel',
           },
           {
-            "name": "pricing",
-            "type": "uint8",
-            "internalType": "enum Types.PricingModel"
+            name: 'pricing',
+            type: 'uint8',
+            internalType: 'enum Types.PricingModel',
           },
           {
-            "name": "active",
-            "type": "bool",
-            "internalType": "bool"
-          }
-        ]
-      }
+            name: 'active',
+            type: 'bool',
+            internalType: 'bool',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getBlueprintConfig",
-    "inputs": [
+    type: 'function',
+    name: 'getBlueprintConfig',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Types.BlueprintConfig",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct Types.BlueprintConfig',
+        components: [
           {
-            "name": "membership",
-            "type": "uint8",
-            "internalType": "enum Types.MembershipModel"
+            name: 'membership',
+            type: 'uint8',
+            internalType: 'enum Types.MembershipModel',
           },
           {
-            "name": "pricing",
-            "type": "uint8",
-            "internalType": "enum Types.PricingModel"
+            name: 'pricing',
+            type: 'uint8',
+            internalType: 'enum Types.PricingModel',
           },
           {
-            "name": "minOperators",
-            "type": "uint32",
-            "internalType": "uint32"
+            name: 'minOperators',
+            type: 'uint32',
+            internalType: 'uint32',
           },
           {
-            "name": "maxOperators",
-            "type": "uint32",
-            "internalType": "uint32"
+            name: 'maxOperators',
+            type: 'uint32',
+            internalType: 'uint32',
           },
           {
-            "name": "subscriptionRate",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'subscriptionRate',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "subscriptionInterval",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'subscriptionInterval',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "eventRate",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
+            name: 'eventRate',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getBlueprintDefinition",
-    "inputs": [
+    type: 'function',
+    name: 'getBlueprintDefinition',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "definition",
-        "type": "tuple",
-        "internalType": "struct Types.BlueprintDefinition",
-        "components": [
+        name: 'definition',
+        type: 'tuple',
+        internalType: 'struct Types.BlueprintDefinition',
+        components: [
           {
-            "name": "metadataUri",
-            "type": "string",
-            "internalType": "string"
+            name: 'metadataUri',
+            type: 'string',
+            internalType: 'string',
           },
           {
-            "name": "metadataHash",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: 'metadataHash',
+            type: 'bytes32',
+            internalType: 'bytes32',
           },
           {
-            "name": "manager",
-            "type": "address",
-            "internalType": "address"
+            name: 'manager',
+            type: 'address',
+            internalType: 'address',
           },
           {
-            "name": "masterManagerRevision",
-            "type": "uint32",
-            "internalType": "uint32"
+            name: 'masterManagerRevision',
+            type: 'uint32',
+            internalType: 'uint32',
           },
           {
-            "name": "hasConfig",
-            "type": "bool",
-            "internalType": "bool"
+            name: 'hasConfig',
+            type: 'bool',
+            internalType: 'bool',
           },
           {
-            "name": "config",
-            "type": "tuple",
-            "internalType": "struct Types.BlueprintConfig",
-            "components": [
+            name: 'config',
+            type: 'tuple',
+            internalType: 'struct Types.BlueprintConfig',
+            components: [
               {
-                "name": "membership",
-                "type": "uint8",
-                "internalType": "enum Types.MembershipModel"
+                name: 'membership',
+                type: 'uint8',
+                internalType: 'enum Types.MembershipModel',
               },
               {
-                "name": "pricing",
-                "type": "uint8",
-                "internalType": "enum Types.PricingModel"
+                name: 'pricing',
+                type: 'uint8',
+                internalType: 'enum Types.PricingModel',
               },
               {
-                "name": "minOperators",
-                "type": "uint32",
-                "internalType": "uint32"
+                name: 'minOperators',
+                type: 'uint32',
+                internalType: 'uint32',
               },
               {
-                "name": "maxOperators",
-                "type": "uint32",
-                "internalType": "uint32"
+                name: 'maxOperators',
+                type: 'uint32',
+                internalType: 'uint32',
               },
               {
-                "name": "subscriptionRate",
-                "type": "uint256",
-                "internalType": "uint256"
+                name: 'subscriptionRate',
+                type: 'uint256',
+                internalType: 'uint256',
               },
               {
-                "name": "subscriptionInterval",
-                "type": "uint64",
-                "internalType": "uint64"
+                name: 'subscriptionInterval',
+                type: 'uint64',
+                internalType: 'uint64',
               },
               {
-                "name": "eventRate",
-                "type": "uint256",
-                "internalType": "uint256"
-              }
-            ]
+                name: 'eventRate',
+                type: 'uint256',
+                internalType: 'uint256',
+              },
+            ],
           },
           {
-            "name": "metadata",
-            "type": "tuple",
-            "internalType": "struct Types.BlueprintMetadata",
-            "components": [
+            name: 'metadata',
+            type: 'tuple',
+            internalType: 'struct Types.BlueprintMetadata',
+            components: [
               {
-                "name": "name",
-                "type": "string",
-                "internalType": "string"
+                name: 'name',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "description",
-                "type": "string",
-                "internalType": "string"
+                name: 'description',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "author",
-                "type": "string",
-                "internalType": "string"
+                name: 'author',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "category",
-                "type": "string",
-                "internalType": "string"
+                name: 'category',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "codeRepository",
-                "type": "string",
-                "internalType": "string"
+                name: 'codeRepository',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "logo",
-                "type": "string",
-                "internalType": "string"
+                name: 'logo',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "website",
-                "type": "string",
-                "internalType": "string"
+                name: 'website',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "license",
-                "type": "string",
-                "internalType": "string"
+                name: 'license',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "profilingData",
-                "type": "string",
-                "internalType": "string"
-              }
-            ]
+                name: 'profilingData',
+                type: 'string',
+                internalType: 'string',
+              },
+            ],
           },
           {
-            "name": "jobs",
-            "type": "tuple[]",
-            "internalType": "struct Types.JobDefinition[]",
-            "components": [
+            name: 'jobs',
+            type: 'tuple[]',
+            internalType: 'struct Types.JobDefinition[]',
+            components: [
               {
-                "name": "name",
-                "type": "string",
-                "internalType": "string"
+                name: 'name',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "description",
-                "type": "string",
-                "internalType": "string"
+                name: 'description',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "metadataUri",
-                "type": "string",
-                "internalType": "string"
+                name: 'metadataUri',
+                type: 'string',
+                internalType: 'string',
               },
               {
-                "name": "paramsSchema",
-                "type": "bytes",
-                "internalType": "bytes"
+                name: 'paramsSchema',
+                type: 'bytes',
+                internalType: 'bytes',
               },
               {
-                "name": "resultSchema",
-                "type": "bytes",
-                "internalType": "bytes"
-              }
-            ]
+                name: 'resultSchema',
+                type: 'bytes',
+                internalType: 'bytes',
+              },
+            ],
           },
           {
-            "name": "registrationSchema",
-            "type": "bytes",
-            "internalType": "bytes"
+            name: 'registrationSchema',
+            type: 'bytes',
+            internalType: 'bytes',
           },
           {
-            "name": "requestSchema",
-            "type": "bytes",
-            "internalType": "bytes"
+            name: 'requestSchema',
+            type: 'bytes',
+            internalType: 'bytes',
           },
           {
-            "name": "sources",
-            "type": "tuple[]",
-            "internalType": "struct Types.BlueprintSource[]",
-            "components": [
+            name: 'sources',
+            type: 'tuple[]',
+            internalType: 'struct Types.BlueprintSource[]',
+            components: [
               {
-                "name": "kind",
-                "type": "uint8",
-                "internalType": "enum Types.BlueprintSourceKind"
+                name: 'kind',
+                type: 'uint8',
+                internalType: 'enum Types.BlueprintSourceKind',
               },
               {
-                "name": "container",
-                "type": "tuple",
-                "internalType": "struct Types.ImageRegistrySource",
-                "components": [
+                name: 'container',
+                type: 'tuple',
+                internalType: 'struct Types.ImageRegistrySource',
+                components: [
                   {
-                    "name": "registry",
-                    "type": "string",
-                    "internalType": "string"
+                    name: 'registry',
+                    type: 'string',
+                    internalType: 'string',
                   },
                   {
-                    "name": "image",
-                    "type": "string",
-                    "internalType": "string"
+                    name: 'image',
+                    type: 'string',
+                    internalType: 'string',
                   },
                   {
-                    "name": "tag",
-                    "type": "string",
-                    "internalType": "string"
-                  }
-                ]
+                    name: 'tag',
+                    type: 'string',
+                    internalType: 'string',
+                  },
+                ],
               },
               {
-                "name": "wasm",
-                "type": "tuple",
-                "internalType": "struct Types.WasmSource",
-                "components": [
+                name: 'wasm',
+                type: 'tuple',
+                internalType: 'struct Types.WasmSource',
+                components: [
                   {
-                    "name": "runtime",
-                    "type": "uint8",
-                    "internalType": "enum Types.WasmRuntime"
+                    name: 'runtime',
+                    type: 'uint8',
+                    internalType: 'enum Types.WasmRuntime',
                   },
                   {
-                    "name": "fetcher",
-                    "type": "uint8",
-                    "internalType": "enum Types.BlueprintFetcherKind"
+                    name: 'fetcher',
+                    type: 'uint8',
+                    internalType: 'enum Types.BlueprintFetcherKind',
                   },
                   {
-                    "name": "artifactUri",
-                    "type": "string",
-                    "internalType": "string"
+                    name: 'artifactUri',
+                    type: 'string',
+                    internalType: 'string',
                   },
                   {
-                    "name": "entrypoint",
-                    "type": "string",
-                    "internalType": "string"
-                  }
-                ]
+                    name: 'entrypoint',
+                    type: 'string',
+                    internalType: 'string',
+                  },
+                ],
               },
               {
-                "name": "native",
-                "type": "tuple",
-                "internalType": "struct Types.NativeSource",
-                "components": [
+                name: 'native',
+                type: 'tuple',
+                internalType: 'struct Types.NativeSource',
+                components: [
                   {
-                    "name": "fetcher",
-                    "type": "uint8",
-                    "internalType": "enum Types.BlueprintFetcherKind"
+                    name: 'fetcher',
+                    type: 'uint8',
+                    internalType: 'enum Types.BlueprintFetcherKind',
                   },
                   {
-                    "name": "artifactUri",
-                    "type": "string",
-                    "internalType": "string"
+                    name: 'artifactUri',
+                    type: 'string',
+                    internalType: 'string',
                   },
                   {
-                    "name": "entrypoint",
-                    "type": "string",
-                    "internalType": "string"
-                  }
-                ]
+                    name: 'entrypoint',
+                    type: 'string',
+                    internalType: 'string',
+                  },
+                ],
               },
               {
-                "name": "testing",
-                "type": "tuple",
-                "internalType": "struct Types.TestingSource",
-                "components": [
+                name: 'testing',
+                type: 'tuple',
+                internalType: 'struct Types.TestingSource',
+                components: [
                   {
-                    "name": "cargoPackage",
-                    "type": "string",
-                    "internalType": "string"
+                    name: 'cargoPackage',
+                    type: 'string',
+                    internalType: 'string',
                   },
                   {
-                    "name": "cargoBin",
-                    "type": "string",
-                    "internalType": "string"
+                    name: 'cargoBin',
+                    type: 'string',
+                    internalType: 'string',
                   },
                   {
-                    "name": "basePath",
-                    "type": "string",
-                    "internalType": "string"
-                  }
-                ]
+                    name: 'basePath',
+                    type: 'string',
+                    internalType: 'string',
+                  },
+                ],
               },
               {
-                "name": "binaries",
-                "type": "tuple[]",
-                "internalType": "struct Types.BlueprintBinary[]",
-                "components": [
+                name: 'binaries',
+                type: 'tuple[]',
+                internalType: 'struct Types.BlueprintBinary[]',
+                components: [
                   {
-                    "name": "arch",
-                    "type": "uint8",
-                    "internalType": "enum Types.BlueprintArchitecture"
+                    name: 'arch',
+                    type: 'uint8',
+                    internalType: 'enum Types.BlueprintArchitecture',
                   },
                   {
-                    "name": "os",
-                    "type": "uint8",
-                    "internalType": "enum Types.BlueprintOperatingSystem"
+                    name: 'os',
+                    type: 'uint8',
+                    internalType: 'enum Types.BlueprintOperatingSystem',
                   },
                   {
-                    "name": "name",
-                    "type": "string",
-                    "internalType": "string"
+                    name: 'name',
+                    type: 'string',
+                    internalType: 'string',
                   },
                   {
-                    "name": "sha256",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  }
-                ]
-              }
-            ]
+                    name: 'sha256',
+                    type: 'bytes32',
+                    internalType: 'bytes32',
+                  },
+                ],
+              },
+            ],
           },
           {
-            "name": "supportedMemberships",
-            "type": "uint8[]",
-            "internalType": "enum Types.MembershipModel[]"
-          }
-        ]
-      }
+            name: 'supportedMemberships',
+            type: 'uint8[]',
+            internalType: 'enum Types.MembershipModel[]',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getBlueprintResourceRequirements",
-    "inputs": [
+    type: 'function',
+    name: 'getBlueprintResourceRequirements',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple[]",
-        "internalType": "struct Types.ResourceCommitment[]",
-        "components": [
+        name: '',
+        type: 'tuple[]',
+        internalType: 'struct Types.ResourceCommitment[]',
+        components: [
           {
-            "name": "kind",
-            "type": "uint8",
-            "internalType": "uint8"
+            name: 'kind',
+            type: 'uint8',
+            internalType: 'uint8',
           },
           {
-            "name": "count",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
-        ]
-      }
+            name: 'count',
+            type: 'uint64',
+            internalType: 'uint64',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getExecutableSlashes",
-    "inputs": [
+    type: 'function',
+    name: 'getExecutableSlashes',
+    inputs: [
       {
-        "name": "fromId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'fromId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "toId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'toId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "ids",
-        "type": "uint64[]",
-        "internalType": "uint64[]"
-      }
+        name: 'ids',
+        type: 'uint64[]',
+        internalType: 'uint64[]',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getExitConfig",
-    "inputs": [
+    type: 'function',
+    name: 'getExitConfig',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Types.ExitConfig",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct Types.ExitConfig',
+        components: [
           {
-            "name": "minCommitmentDuration",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'minCommitmentDuration',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "exitQueueDuration",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'exitQueueDuration',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "forceExitAllowed",
-            "type": "bool",
-            "internalType": "bool"
-          }
-        ]
-      }
+            name: 'forceExitAllowed',
+            type: 'bool',
+            internalType: 'bool',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getExitRequest",
-    "inputs": [
+    type: 'function',
+    name: 'getExitRequest',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Types.ExitRequest",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct Types.ExitRequest',
+        components: [
           {
-            "name": "serviceId",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'serviceId',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "scheduledAt",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'scheduledAt',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "executeAfter",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'executeAfter',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "pending",
-            "type": "bool",
-            "internalType": "bool"
-          }
-        ]
-      }
+            name: 'pending',
+            type: 'bool',
+            internalType: 'bool',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getExitStatus",
-    "inputs": [
+    type: 'function',
+    name: 'getExitStatus',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint8",
-        "internalType": "enum Types.ExitStatus"
-      }
+        name: '',
+        type: 'uint8',
+        internalType: 'enum Types.ExitStatus',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getJobCall",
-    "inputs": [
+    type: 'function',
+    name: 'getJobCall',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "callId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'callId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Types.JobCall",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct Types.JobCall',
+        components: [
           {
-            "name": "jobIndex",
-            "type": "uint8",
-            "internalType": "uint8"
+            name: 'jobIndex',
+            type: 'uint8',
+            internalType: 'uint8',
           },
           {
-            "name": "caller",
-            "type": "address",
-            "internalType": "address"
+            name: 'caller',
+            type: 'address',
+            internalType: 'address',
           },
           {
-            "name": "createdAt",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'createdAt',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "resultCount",
-            "type": "uint32",
-            "internalType": "uint32"
+            name: 'resultCount',
+            type: 'uint32',
+            internalType: 'uint32',
           },
           {
-            "name": "payment",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'payment',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "completed",
-            "type": "bool",
-            "internalType": "bool"
+            name: 'completed',
+            type: 'bool',
+            internalType: 'bool',
           },
           {
-            "name": "isRFQ",
-            "type": "bool",
-            "internalType": "bool"
-          }
-        ]
-      }
+            name: 'isRFQ',
+            type: 'bool',
+            internalType: 'bool',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getJobEventRate",
-    "inputs": [
+    type: 'function',
+    name: 'getJobEventRate',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "jobIndex",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
+        name: 'jobIndex',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "rate",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'rate',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getJobQuotedOperators",
-    "inputs": [
+    type: 'function',
+    name: 'getJobQuotedOperators',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "callId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'callId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "address[]",
-        "internalType": "address[]"
-      }
+        name: '',
+        type: 'address[]',
+        internalType: 'address[]',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getJobQuotedPrice",
-    "inputs": [
+    type: 'function',
+    name: 'getJobQuotedPrice',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "callId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'callId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorBlsPubkey",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorBlsPubkey',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "blsPubkey",
-        "type": "uint256[4]",
-        "internalType": "uint256[4]"
-      }
+        name: 'blsPubkey',
+        type: 'uint256[4]',
+        internalType: 'uint256[4]',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorPreferences",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorPreferences',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Types.OperatorPreferences",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct Types.OperatorPreferences',
+        components: [
           {
-            "name": "ecdsaPublicKey",
-            "type": "bytes",
-            "internalType": "bytes"
+            name: 'ecdsaPublicKey',
+            type: 'bytes',
+            internalType: 'bytes',
           },
           {
-            "name": "rpcAddress",
-            "type": "string",
-            "internalType": "string"
-          }
-        ]
-      }
+            name: 'rpcAddress',
+            type: 'string',
+            internalType: 'string',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorPublicKey",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorPublicKey',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
+        name: '',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorRegistration",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorRegistration',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Types.OperatorRegistration",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct Types.OperatorRegistration',
+        components: [
           {
-            "name": "registeredAt",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'registeredAt',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "updatedAt",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'updatedAt',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "active",
-            "type": "bool",
-            "internalType": "bool"
+            name: 'active',
+            type: 'bool',
+            internalType: 'bool',
           },
           {
-            "name": "online",
-            "type": "bool",
-            "internalType": "bool"
-          }
-        ]
-      }
+            name: 'online',
+            type: 'bool',
+            internalType: 'bool',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getOperatorTotalActiveServices",
-    "inputs": [
+    type: 'function',
+    name: 'getOperatorTotalActiveServices',
+    inputs: [
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "count",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: 'count',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getService",
-    "inputs": [
+    type: 'function',
+    name: 'getService',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Types.Service",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct Types.Service',
+        components: [
           {
-            "name": "blueprintId",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'blueprintId',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "owner",
-            "type": "address",
-            "internalType": "address"
+            name: 'owner',
+            type: 'address',
+            internalType: 'address',
           },
           {
-            "name": "createdAt",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'createdAt',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "ttl",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'ttl',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "terminatedAt",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'terminatedAt',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "lastPaymentAt",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'lastPaymentAt',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "operatorCount",
-            "type": "uint32",
-            "internalType": "uint32"
+            name: 'operatorCount',
+            type: 'uint32',
+            internalType: 'uint32',
           },
           {
-            "name": "minOperators",
-            "type": "uint32",
-            "internalType": "uint32"
+            name: 'minOperators',
+            type: 'uint32',
+            internalType: 'uint32',
           },
           {
-            "name": "maxOperators",
-            "type": "uint32",
-            "internalType": "uint32"
+            name: 'maxOperators',
+            type: 'uint32',
+            internalType: 'uint32',
           },
           {
-            "name": "membership",
-            "type": "uint8",
-            "internalType": "enum Types.MembershipModel"
+            name: 'membership',
+            type: 'uint8',
+            internalType: 'enum Types.MembershipModel',
           },
           {
-            "name": "pricing",
-            "type": "uint8",
-            "internalType": "enum Types.PricingModel"
+            name: 'pricing',
+            type: 'uint8',
+            internalType: 'enum Types.PricingModel',
           },
           {
-            "name": "status",
-            "type": "uint8",
-            "internalType": "enum Types.ServiceStatus"
+            name: 'status',
+            type: 'uint8',
+            internalType: 'enum Types.ServiceStatus',
           },
           {
-            "name": "confidentiality",
-            "type": "uint8",
-            "internalType": "enum Types.ConfidentialityPolicy"
-          }
-        ]
-      }
+            name: 'confidentiality',
+            type: 'uint8',
+            internalType: 'enum Types.ConfidentialityPolicy',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getServiceEscrow",
-    "inputs": [
+    type: 'function',
+    name: 'getServiceEscrow',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct PaymentLib.ServiceEscrow",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct PaymentLib.ServiceEscrow',
+        components: [
           {
-            "name": "token",
-            "type": "address",
-            "internalType": "address"
+            name: 'token',
+            type: 'address',
+            internalType: 'address',
           },
           {
-            "name": "balance",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'balance',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "totalDeposited",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'totalDeposited',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "totalReleased",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
+            name: 'totalReleased',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getServiceOperator",
-    "inputs": [
+    type: 'function',
+    name: 'getServiceOperator',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Types.ServiceOperator",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct Types.ServiceOperator',
+        components: [
           {
-            "name": "exposureBps",
-            "type": "uint16",
-            "internalType": "uint16"
+            name: 'exposureBps',
+            type: 'uint16',
+            internalType: 'uint16',
           },
           {
-            "name": "joinedAt",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'joinedAt',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "leftAt",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'leftAt',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "active",
-            "type": "bool",
-            "internalType": "bool"
-          }
-        ]
-      }
+            name: 'active',
+            type: 'bool',
+            internalType: 'bool',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getServiceOperators",
-    "inputs": [
+    type: 'function',
+    name: 'getServiceOperators',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "address[]",
-        "internalType": "address[]"
-      }
+        name: '',
+        type: 'address[]',
+        internalType: 'address[]',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getServiceRequest",
-    "inputs": [
+    type: 'function',
+    name: 'getServiceRequest',
+    inputs: [
       {
-        "name": "requestId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'requestId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Types.ServiceRequest",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct Types.ServiceRequest',
+        components: [
           {
-            "name": "blueprintId",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'blueprintId',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "requester",
-            "type": "address",
-            "internalType": "address"
+            name: 'requester',
+            type: 'address',
+            internalType: 'address',
           },
           {
-            "name": "createdAt",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'createdAt',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "ttl",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'ttl',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "operatorCount",
-            "type": "uint32",
-            "internalType": "uint32"
+            name: 'operatorCount',
+            type: 'uint32',
+            internalType: 'uint32',
           },
           {
-            "name": "approvalCount",
-            "type": "uint32",
-            "internalType": "uint32"
+            name: 'approvalCount',
+            type: 'uint32',
+            internalType: 'uint32',
           },
           {
-            "name": "paymentToken",
-            "type": "address",
-            "internalType": "address"
+            name: 'paymentToken',
+            type: 'address',
+            internalType: 'address',
           },
           {
-            "name": "paymentAmount",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'paymentAmount',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "membership",
-            "type": "uint8",
-            "internalType": "enum Types.MembershipModel"
+            name: 'membership',
+            type: 'uint8',
+            internalType: 'enum Types.MembershipModel',
           },
           {
-            "name": "minOperators",
-            "type": "uint32",
-            "internalType": "uint32"
+            name: 'minOperators',
+            type: 'uint32',
+            internalType: 'uint32',
           },
           {
-            "name": "maxOperators",
-            "type": "uint32",
-            "internalType": "uint32"
+            name: 'maxOperators',
+            type: 'uint32',
+            internalType: 'uint32',
           },
           {
-            "name": "rejected",
-            "type": "bool",
-            "internalType": "bool"
+            name: 'rejected',
+            type: 'bool',
+            internalType: 'bool',
           },
           {
-            "name": "confidentiality",
-            "type": "uint8",
-            "internalType": "enum Types.ConfidentialityPolicy"
+            name: 'confidentiality',
+            type: 'uint8',
+            internalType: 'enum Types.ConfidentialityPolicy',
           },
           {
-            "name": "activated",
-            "type": "bool",
-            "internalType": "bool"
-          }
-        ]
-      }
+            name: 'activated',
+            type: 'bool',
+            internalType: 'bool',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getServiceRequestResourceRequirements",
-    "inputs": [
+    type: 'function',
+    name: 'getServiceRequestResourceRequirements',
+    inputs: [
       {
-        "name": "requestId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'requestId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple[]",
-        "internalType": "struct Types.ResourceCommitment[]",
-        "components": [
+        name: '',
+        type: 'tuple[]',
+        internalType: 'struct Types.ResourceCommitment[]',
+        components: [
           {
-            "name": "kind",
-            "type": "uint8",
-            "internalType": "uint8"
+            name: 'kind',
+            type: 'uint8',
+            internalType: 'uint8',
           },
           {
-            "name": "count",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
-        ]
-      }
+            name: 'count',
+            type: 'uint64',
+            internalType: 'uint64',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getServiceRequestSecurityCommitments",
-    "inputs": [
+    type: 'function',
+    name: 'getServiceRequestSecurityCommitments',
+    inputs: [
       {
-        "name": "requestId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'requestId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple[]",
-        "internalType": "struct Types.AssetSecurityCommitment[]",
-        "components": [
+        name: '',
+        type: 'tuple[]',
+        internalType: 'struct Types.AssetSecurityCommitment[]',
+        components: [
           {
-            "name": "asset",
-            "type": "tuple",
-            "internalType": "struct Types.Asset",
-            "components": [
+            name: 'asset',
+            type: 'tuple',
+            internalType: 'struct Types.Asset',
+            components: [
               {
-                "name": "kind",
-                "type": "uint8",
-                "internalType": "enum Types.AssetKind"
+                name: 'kind',
+                type: 'uint8',
+                internalType: 'enum Types.AssetKind',
               },
               {
-                "name": "token",
-                "type": "address",
-                "internalType": "address"
-              }
-            ]
+                name: 'token',
+                type: 'address',
+                internalType: 'address',
+              },
+            ],
           },
           {
-            "name": "exposureBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          }
-        ]
-      }
+            name: 'exposureBps',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getServiceRequestSecurityRequirements",
-    "inputs": [
+    type: 'function',
+    name: 'getServiceRequestSecurityRequirements',
+    inputs: [
       {
-        "name": "requestId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'requestId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple[]",
-        "internalType": "struct Types.AssetSecurityRequirement[]",
-        "components": [
+        name: '',
+        type: 'tuple[]',
+        internalType: 'struct Types.AssetSecurityRequirement[]',
+        components: [
           {
-            "name": "asset",
-            "type": "tuple",
-            "internalType": "struct Types.Asset",
-            "components": [
+            name: 'asset',
+            type: 'tuple',
+            internalType: 'struct Types.Asset',
+            components: [
               {
-                "name": "kind",
-                "type": "uint8",
-                "internalType": "enum Types.AssetKind"
+                name: 'kind',
+                type: 'uint8',
+                internalType: 'enum Types.AssetKind',
               },
               {
-                "name": "token",
-                "type": "address",
-                "internalType": "address"
-              }
-            ]
+                name: 'token',
+                type: 'address',
+                internalType: 'address',
+              },
+            ],
           },
           {
-            "name": "minExposureBps",
-            "type": "uint16",
-            "internalType": "uint16"
+            name: 'minExposureBps',
+            type: 'uint16',
+            internalType: 'uint16',
           },
           {
-            "name": "maxExposureBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          }
-        ]
-      }
+            name: 'maxExposureBps',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getServiceResourceCommitmentHash",
-    "inputs": [
+    type: 'function',
+    name: 'getServiceResourceCommitmentHash',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getServiceSecurityCommitments",
-    "inputs": [
+    type: 'function',
+    name: 'getServiceSecurityCommitments',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple[]",
-        "internalType": "struct Types.AssetSecurityCommitment[]",
-        "components": [
+        name: '',
+        type: 'tuple[]',
+        internalType: 'struct Types.AssetSecurityCommitment[]',
+        components: [
           {
-            "name": "asset",
-            "type": "tuple",
-            "internalType": "struct Types.Asset",
-            "components": [
+            name: 'asset',
+            type: 'tuple',
+            internalType: 'struct Types.Asset',
+            components: [
               {
-                "name": "kind",
-                "type": "uint8",
-                "internalType": "enum Types.AssetKind"
+                name: 'kind',
+                type: 'uint8',
+                internalType: 'enum Types.AssetKind',
               },
               {
-                "name": "token",
-                "type": "address",
-                "internalType": "address"
-              }
-            ]
+                name: 'token',
+                type: 'address',
+                internalType: 'address',
+              },
+            ],
           },
           {
-            "name": "exposureBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          }
-        ]
-      }
+            name: 'exposureBps',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getServiceSecurityRequirements",
-    "inputs": [
+    type: 'function',
+    name: 'getServiceSecurityRequirements',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple[]",
-        "internalType": "struct Types.AssetSecurityRequirement[]",
-        "components": [
+        name: '',
+        type: 'tuple[]',
+        internalType: 'struct Types.AssetSecurityRequirement[]',
+        components: [
           {
-            "name": "asset",
-            "type": "tuple",
-            "internalType": "struct Types.Asset",
-            "components": [
+            name: 'asset',
+            type: 'tuple',
+            internalType: 'struct Types.Asset',
+            components: [
               {
-                "name": "kind",
-                "type": "uint8",
-                "internalType": "enum Types.AssetKind"
+                name: 'kind',
+                type: 'uint8',
+                internalType: 'enum Types.AssetKind',
               },
               {
-                "name": "token",
-                "type": "address",
-                "internalType": "address"
-              }
-            ]
+                name: 'token',
+                type: 'address',
+                internalType: 'address',
+              },
+            ],
           },
           {
-            "name": "minExposureBps",
-            "type": "uint16",
-            "internalType": "uint16"
+            name: 'minExposureBps',
+            type: 'uint16',
+            internalType: 'uint16',
           },
           {
-            "name": "maxExposureBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          }
-        ]
-      }
+            name: 'maxExposureBps',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getSlashConfig",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'getSlashConfig',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct SlashingLib.SlashConfig",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct SlashingLib.SlashConfig',
+        components: [
           {
-            "name": "disputeWindow",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'disputeWindow',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "instantSlashEnabled",
-            "type": "bool",
-            "internalType": "bool"
+            name: 'instantSlashEnabled',
+            type: 'bool',
+            internalType: 'bool',
           },
           {
-            "name": "maxSlashBps",
-            "type": "uint16",
-            "internalType": "uint16"
+            name: 'maxSlashBps',
+            type: 'uint16',
+            internalType: 'uint16',
           },
           {
-            "name": "disputeResolutionDeadline",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'disputeResolutionDeadline',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "disputeBond",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'disputeBond',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "maxPendingSlashesPerOperator",
-            "type": "uint16",
-            "internalType": "uint16"
-          }
-        ]
-      }
+            name: 'maxPendingSlashesPerOperator',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getSlashProposal",
-    "inputs": [
+    type: 'function',
+    name: 'getSlashProposal',
+    inputs: [
       {
-        "name": "slashId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'slashId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct SlashingLib.SlashProposal",
-        "components": [
+        name: '',
+        type: 'tuple',
+        internalType: 'struct SlashingLib.SlashProposal',
+        components: [
           {
-            "name": "serviceId",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'serviceId',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "operator",
-            "type": "address",
-            "internalType": "address"
+            name: 'operator',
+            type: 'address',
+            internalType: 'address',
           },
           {
-            "name": "proposer",
-            "type": "address",
-            "internalType": "address"
+            name: 'proposer',
+            type: 'address',
+            internalType: 'address',
           },
           {
-            "name": "slashBps",
-            "type": "uint16",
-            "internalType": "uint16"
+            name: 'slashBps',
+            type: 'uint16',
+            internalType: 'uint16',
           },
           {
-            "name": "effectiveSlashBps",
-            "type": "uint16",
-            "internalType": "uint16"
+            name: 'effectiveSlashBps',
+            type: 'uint16',
+            internalType: 'uint16',
           },
           {
-            "name": "evidence",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            name: 'evidence',
+            type: 'bytes32',
+            internalType: 'bytes32',
           },
           {
-            "name": "proposedAt",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'proposedAt',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "executeAfter",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'executeAfter',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "status",
-            "type": "uint8",
-            "internalType": "enum SlashingLib.SlashStatus"
+            name: 'status',
+            type: 'uint8',
+            internalType: 'enum SlashingLib.SlashStatus',
           },
           {
-            "name": "disputeReason",
-            "type": "string",
-            "internalType": "string"
+            name: 'disputeReason',
+            type: 'string',
+            internalType: 'string',
           },
           {
-            "name": "disputer",
-            "type": "address",
-            "internalType": "address"
+            name: 'disputer',
+            type: 'address',
+            internalType: 'address',
           },
           {
-            "name": "disputeBond",
-            "type": "uint256",
-            "internalType": "uint256"
+            name: 'disputeBond',
+            type: 'uint256',
+            internalType: 'uint256',
           },
           {
-            "name": "disputedAt",
-            "type": "uint64",
-            "internalType": "uint64"
+            name: 'disputedAt',
+            type: 'uint64',
+            internalType: 'uint64',
           },
           {
-            "name": "disputeDeadline",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
-        ]
-      }
+            name: 'disputeDeadline',
+            type: 'uint64',
+            internalType: 'uint64',
+          },
+        ],
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "getTeeCommitmentRoot",
-    "inputs": [
+    type: 'function',
+    name: 'getTeeCommitmentRoot',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "isOperatorRegistered",
-    "inputs": [
+    type: 'function',
+    name: 'isOperatorRegistered',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "isPermittedCaller",
-    "inputs": [
+    type: 'function',
+    name: 'isPermittedCaller',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "caller",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'caller',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "isServiceActive",
-    "inputs": [
+    type: 'function',
+    name: 'isServiceActive',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "isServiceOperator",
-    "inputs": [
+    type: 'function',
+    name: 'isServiceOperator',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "joinService",
-    "inputs": [
+    type: 'function',
+    name: 'joinService',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "exposureBps",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: 'exposureBps',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "joinServiceWithCommitments",
-    "inputs": [
+    type: 'function',
+    name: 'joinServiceWithCommitments',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "exposureBps",
-        "type": "uint16",
-        "internalType": "uint16"
+        name: 'exposureBps',
+        type: 'uint16',
+        internalType: 'uint16',
       },
       {
-        "name": "commitments",
-        "type": "tuple[]",
-        "internalType": "struct Types.AssetSecurityCommitment[]",
-        "components": [
+        name: 'commitments',
+        type: 'tuple[]',
+        internalType: 'struct Types.AssetSecurityCommitment[]',
+        components: [
           {
-            "name": "asset",
-            "type": "tuple",
-            "internalType": "struct Types.Asset",
-            "components": [
+            name: 'asset',
+            type: 'tuple',
+            internalType: 'struct Types.Asset',
+            components: [
               {
-                "name": "kind",
-                "type": "uint8",
-                "internalType": "enum Types.AssetKind"
+                name: 'kind',
+                type: 'uint8',
+                internalType: 'enum Types.AssetKind',
               },
               {
-                "name": "token",
-                "type": "address",
-                "internalType": "address"
-              }
-            ]
+                name: 'token',
+                type: 'address',
+                internalType: 'address',
+              },
+            ],
           },
           {
-            "name": "exposureBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          }
-        ]
-      }
+            name: 'exposureBps',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+        ],
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "leaveService",
-    "inputs": [
+    type: 'function',
+    name: 'leaveService',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "maxBlueprintsPerOperator",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'maxBlueprintsPerOperator',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
+        name: '',
+        type: 'uint32',
+        internalType: 'uint32',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "mbsmRegistry",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'mbsmRegistry',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "metricsRecorder",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'metricsRecorder',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "operatorStatusRegistry",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'operatorStatusRegistry',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "pause",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: 'function',
+    name: 'pause',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "paymentSplit",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'paymentSplit',
+    inputs: [],
+    outputs: [
       {
-        "name": "developerBps",
-        "type": "uint16",
-        "internalType": "uint16"
+        name: 'developerBps',
+        type: 'uint16',
+        internalType: 'uint16',
       },
       {
-        "name": "protocolBps",
-        "type": "uint16",
-        "internalType": "uint16"
+        name: 'protocolBps',
+        type: 'uint16',
+        internalType: 'uint16',
       },
       {
-        "name": "operatorBps",
-        "type": "uint16",
-        "internalType": "uint16"
+        name: 'operatorBps',
+        type: 'uint16',
+        internalType: 'uint16',
       },
       {
-        "name": "stakerBps",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: 'stakerBps',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "pendingRewards",
-    "inputs": [
+    type: 'function',
+    name: 'pendingRewards',
+    inputs: [
       {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "pendingRewards",
-    "inputs": [
+    type: 'function',
+    name: 'pendingRewards',
+    inputs: [
       {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "preRegister",
-    "inputs": [
+    type: 'function',
+    name: 'preRegister',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "priceOracle",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'priceOracle',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "proposeSlash",
-    "inputs": [
+    type: 'function',
+    name: 'proposeSlash',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "slashBps",
-        "type": "uint16",
-        "internalType": "uint16"
+        name: 'slashBps',
+        type: 'uint16',
+        internalType: 'uint16',
       },
       {
-        "name": "evidence",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: 'evidence',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "slashId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'slashId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "nonpayable"
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "registerOperator",
-    "inputs": [
+    type: 'function',
+    name: 'registerOperator',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "ecdsaPublicKey",
-        "type": "bytes",
-        "internalType": "bytes"
+        name: 'ecdsaPublicKey',
+        type: 'bytes',
+        internalType: 'bytes',
       },
       {
-        "name": "rpcAddress",
-        "type": "string",
-        "internalType": "string"
+        name: 'rpcAddress',
+        type: 'string',
+        internalType: 'string',
       },
       {
-        "name": "registrationInputs",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
+        name: 'registrationInputs',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "registerOperator",
-    "inputs": [
+    type: 'function',
+    name: 'registerOperator',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "ecdsaPublicKey",
-        "type": "bytes",
-        "internalType": "bytes"
+        name: 'ecdsaPublicKey',
+        type: 'bytes',
+        internalType: 'bytes',
       },
       {
-        "name": "rpcAddress",
-        "type": "string",
-        "internalType": "string"
-      }
+        name: 'rpcAddress',
+        type: 'string',
+        internalType: 'string',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "rejectService",
-    "inputs": [
+    type: 'function',
+    name: 'rejectService',
+    inputs: [
       {
-        "name": "requestId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'requestId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "removePermittedCaller",
-    "inputs": [
+    type: 'function',
+    name: 'removePermittedCaller',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "caller",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'caller',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "requestService",
-    "inputs": [
+    type: 'function',
+    name: 'requestService',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operators",
-        "type": "address[]",
-        "internalType": "address[]"
+        name: 'operators',
+        type: 'address[]',
+        internalType: 'address[]',
       },
       {
-        "name": "config",
-        "type": "bytes",
-        "internalType": "bytes"
+        name: 'config',
+        type: 'bytes',
+        internalType: 'bytes',
       },
       {
-        "name": "permittedCallers",
-        "type": "address[]",
-        "internalType": "address[]"
+        name: 'permittedCallers',
+        type: 'address[]',
+        internalType: 'address[]',
       },
       {
-        "name": "ttl",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'ttl',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "paymentToken",
-        "type": "address",
-        "internalType": "address"
+        name: 'paymentToken',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "paymentAmount",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'paymentAmount',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "confidentiality",
-        "type": "uint8",
-        "internalType": "enum Types.ConfidentialityPolicy"
-      }
+        name: 'confidentiality',
+        type: 'uint8',
+        internalType: 'enum Types.ConfidentialityPolicy',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "requestId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'requestId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "payable"
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "requestServiceWithExposure",
-    "inputs": [
+    type: 'function',
+    name: 'requestServiceWithExposure',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operators",
-        "type": "address[]",
-        "internalType": "address[]"
+        name: 'operators',
+        type: 'address[]',
+        internalType: 'address[]',
       },
       {
-        "name": "exposureBps",
-        "type": "uint16[]",
-        "internalType": "uint16[]"
+        name: 'exposureBps',
+        type: 'uint16[]',
+        internalType: 'uint16[]',
       },
       {
-        "name": "config",
-        "type": "bytes",
-        "internalType": "bytes"
+        name: 'config',
+        type: 'bytes',
+        internalType: 'bytes',
       },
       {
-        "name": "permittedCallers",
-        "type": "address[]",
-        "internalType": "address[]"
+        name: 'permittedCallers',
+        type: 'address[]',
+        internalType: 'address[]',
       },
       {
-        "name": "ttl",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'ttl',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "paymentToken",
-        "type": "address",
-        "internalType": "address"
+        name: 'paymentToken',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "paymentAmount",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'paymentAmount',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "confidentiality",
-        "type": "uint8",
-        "internalType": "enum Types.ConfidentialityPolicy"
-      }
+        name: 'confidentiality',
+        type: 'uint8',
+        internalType: 'enum Types.ConfidentialityPolicy',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "requestId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'requestId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "payable"
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "requestServiceWithSecurity",
-    "inputs": [
+    type: 'function',
+    name: 'requestServiceWithSecurity',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "operators",
-        "type": "address[]",
-        "internalType": "address[]"
+        name: 'operators',
+        type: 'address[]',
+        internalType: 'address[]',
       },
       {
-        "name": "securityRequirements",
-        "type": "tuple[]",
-        "internalType": "struct Types.AssetSecurityRequirement[]",
-        "components": [
+        name: 'securityRequirements',
+        type: 'tuple[]',
+        internalType: 'struct Types.AssetSecurityRequirement[]',
+        components: [
           {
-            "name": "asset",
-            "type": "tuple",
-            "internalType": "struct Types.Asset",
-            "components": [
+            name: 'asset',
+            type: 'tuple',
+            internalType: 'struct Types.Asset',
+            components: [
               {
-                "name": "kind",
-                "type": "uint8",
-                "internalType": "enum Types.AssetKind"
+                name: 'kind',
+                type: 'uint8',
+                internalType: 'enum Types.AssetKind',
               },
               {
-                "name": "token",
-                "type": "address",
-                "internalType": "address"
-              }
-            ]
+                name: 'token',
+                type: 'address',
+                internalType: 'address',
+              },
+            ],
           },
           {
-            "name": "minExposureBps",
-            "type": "uint16",
-            "internalType": "uint16"
+            name: 'minExposureBps',
+            type: 'uint16',
+            internalType: 'uint16',
           },
           {
-            "name": "maxExposureBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          }
-        ]
+            name: 'maxExposureBps',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+        ],
       },
       {
-        "name": "config",
-        "type": "bytes",
-        "internalType": "bytes"
+        name: 'config',
+        type: 'bytes',
+        internalType: 'bytes',
       },
       {
-        "name": "permittedCallers",
-        "type": "address[]",
-        "internalType": "address[]"
+        name: 'permittedCallers',
+        type: 'address[]',
+        internalType: 'address[]',
       },
       {
-        "name": "ttl",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'ttl',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "paymentToken",
-        "type": "address",
-        "internalType": "address"
+        name: 'paymentToken',
+        type: 'address',
+        internalType: 'address',
       },
       {
-        "name": "paymentAmount",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'paymentAmount',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "confidentiality",
-        "type": "uint8",
-        "internalType": "enum Types.ConfidentialityPolicy"
-      }
+        name: 'confidentiality',
+        type: 'uint8',
+        internalType: 'enum Types.ConfidentialityPolicy',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "requestId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'requestId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "payable"
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "rewardTokens",
-    "inputs": [
+    type: 'function',
+    name: 'rewardTokens',
+    inputs: [
       {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'account',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "address[]",
-        "internalType": "address[]"
-      }
+        name: '',
+        type: 'address[]',
+        internalType: 'address[]',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "rewardVaults",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'rewardVaults',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "scheduleExit",
-    "inputs": [
+    type: 'function',
+    name: 'scheduleExit',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "serviceCount",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'serviceCount',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "serviceFeeDistributor",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'serviceFeeDistributor',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "setBlueprintResourceRequirements",
-    "inputs": [
+    type: 'function',
+    name: 'setBlueprintResourceRequirements',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "requirements",
-        "type": "tuple[]",
-        "internalType": "struct Types.ResourceCommitment[]",
-        "components": [
+        name: 'requirements',
+        type: 'tuple[]',
+        internalType: 'struct Types.ResourceCommitment[]',
+        components: [
           {
-            "name": "kind",
-            "type": "uint8",
-            "internalType": "uint8"
+            name: 'kind',
+            type: 'uint8',
+            internalType: 'uint8',
           },
           {
-            "name": "count",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
-        ]
-      }
+            name: 'count',
+            type: 'uint64',
+            internalType: 'uint64',
+          },
+        ],
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setDefaultTntMinExposureBps",
-    "inputs": [
+    type: 'function',
+    name: 'setDefaultTntMinExposureBps',
+    inputs: [
       {
-        "name": "minExposureBps",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: 'minExposureBps',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setJobEventRates",
-    "inputs": [
+    type: 'function',
+    name: 'setJobEventRates',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "jobIndexes",
-        "type": "uint8[]",
-        "internalType": "uint8[]"
+        name: 'jobIndexes',
+        type: 'uint8[]',
+        internalType: 'uint8[]',
       },
       {
-        "name": "rates",
-        "type": "uint256[]",
-        "internalType": "uint256[]"
-      }
+        name: 'rates',
+        type: 'uint256[]',
+        internalType: 'uint256[]',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setMBSMRegistry",
-    "inputs": [
+    type: 'function',
+    name: 'setMBSMRegistry',
+    inputs: [
       {
-        "name": "registry",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'registry',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setMaxBlueprintsPerOperator",
-    "inputs": [
+    type: 'function',
+    name: 'setMaxBlueprintsPerOperator',
+    inputs: [
       {
-        "name": "newMax",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
+        name: 'newMax',
+        type: 'uint32',
+        internalType: 'uint32',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setMetricsRecorder",
-    "inputs": [
+    type: 'function',
+    name: 'setMetricsRecorder',
+    inputs: [
       {
-        "name": "recorder",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'recorder',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setOperatorStatusRegistry",
-    "inputs": [
+    type: 'function',
+    name: 'setOperatorStatusRegistry',
+    inputs: [
       {
-        "name": "registry",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'registry',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setPaymentSplit",
-    "inputs": [
+    type: 'function',
+    name: 'setPaymentSplit',
+    inputs: [
       {
-        "name": "split",
-        "type": "tuple",
-        "internalType": "struct Types.PaymentSplit",
-        "components": [
+        name: 'split',
+        type: 'tuple',
+        internalType: 'struct Types.PaymentSplit',
+        components: [
           {
-            "name": "developerBps",
-            "type": "uint16",
-            "internalType": "uint16"
+            name: 'developerBps',
+            type: 'uint16',
+            internalType: 'uint16',
           },
           {
-            "name": "protocolBps",
-            "type": "uint16",
-            "internalType": "uint16"
+            name: 'protocolBps',
+            type: 'uint16',
+            internalType: 'uint16',
           },
           {
-            "name": "operatorBps",
-            "type": "uint16",
-            "internalType": "uint16"
+            name: 'operatorBps',
+            type: 'uint16',
+            internalType: 'uint16',
           },
           {
-            "name": "stakerBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          }
-        ]
-      }
+            name: 'stakerBps',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+        ],
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setPriceOracle",
-    "inputs": [
+    type: 'function',
+    name: 'setPriceOracle',
+    inputs: [
       {
-        "name": "oracle",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'oracle',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setRewardVaults",
-    "inputs": [
+    type: 'function',
+    name: 'setRewardVaults',
+    inputs: [
       {
-        "name": "vaults",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'vaults',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setServiceFeeDistributor",
-    "inputs": [
+    type: 'function',
+    name: 'setServiceFeeDistributor',
+    inputs: [
       {
-        "name": "distributor",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'distributor',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setSlashConfig",
-    "inputs": [
+    type: 'function',
+    name: 'setSlashConfig',
+    inputs: [
       {
-        "name": "disputeWindow",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'disputeWindow',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "instantSlashEnabled",
-        "type": "bool",
-        "internalType": "bool"
+        name: 'instantSlashEnabled',
+        type: 'bool',
+        internalType: 'bool',
       },
       {
-        "name": "maxSlashBps",
-        "type": "uint16",
-        "internalType": "uint16"
+        name: 'maxSlashBps',
+        type: 'uint16',
+        internalType: 'uint16',
       },
       {
-        "name": "disputeResolutionDeadline",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'disputeResolutionDeadline',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "disputeBond",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'disputeBond',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "maxPendingSlashesPerOperator",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: 'maxPendingSlashesPerOperator',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setStaking",
-    "inputs": [
+    type: 'function',
+    name: 'setStaking',
+    inputs: [
       {
-        "name": "staking",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'staking',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setTntPaymentDiscountBps",
-    "inputs": [
+    type: 'function',
+    name: 'setTntPaymentDiscountBps',
+    inputs: [
       {
-        "name": "discountBps",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: 'discountBps',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setTntToken",
-    "inputs": [
+    type: 'function',
+    name: 'setTntToken',
+    inputs: [
       {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "setTreasury",
-    "inputs": [
+    type: 'function',
+    name: 'setTreasury',
+    inputs: [
       {
-        "name": "treasury",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'treasury',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "submitAggregatedResult",
-    "inputs": [
+    type: 'function',
+    name: 'submitAggregatedResult',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "callId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'callId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "output",
-        "type": "bytes",
-        "internalType": "bytes"
+        name: 'output',
+        type: 'bytes',
+        internalType: 'bytes',
       },
       {
-        "name": "signerBitmap",
-        "type": "uint256",
-        "internalType": "uint256"
+        name: 'signerBitmap',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
-        "name": "aggregatedSignature",
-        "type": "uint256[2]",
-        "internalType": "uint256[2]"
+        name: 'aggregatedSignature',
+        type: 'uint256[2]',
+        internalType: 'uint256[2]',
       },
       {
-        "name": "aggregatedPubkey",
-        "type": "uint256[4]",
-        "internalType": "uint256[4]"
-      }
+        name: 'aggregatedPubkey',
+        type: 'uint256[4]',
+        internalType: 'uint256[4]',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "submitJob",
-    "inputs": [
+    type: 'function',
+    name: 'submitJob',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "jobIndex",
-        "type": "uint8",
-        "internalType": "uint8"
+        name: 'jobIndex',
+        type: 'uint8',
+        internalType: 'uint8',
       },
       {
-        "name": "inputs",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
+        name: 'inputs',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "callId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'callId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "payable"
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "submitJobFromQuote",
-    "inputs": [
+    type: 'function',
+    name: 'submitJobFromQuote',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "jobIndex",
-        "type": "uint8",
-        "internalType": "uint8"
+        name: 'jobIndex',
+        type: 'uint8',
+        internalType: 'uint8',
       },
       {
-        "name": "inputs",
-        "type": "bytes",
-        "internalType": "bytes"
+        name: 'inputs',
+        type: 'bytes',
+        internalType: 'bytes',
       },
       {
-        "name": "quotes",
-        "type": "tuple[]",
-        "internalType": "struct Types.SignedJobQuote[]",
-        "components": [
+        name: 'quotes',
+        type: 'tuple[]',
+        internalType: 'struct Types.SignedJobQuote[]',
+        components: [
           {
-            "name": "details",
-            "type": "tuple",
-            "internalType": "struct Types.JobQuoteDetails",
-            "components": [
+            name: 'details',
+            type: 'tuple',
+            internalType: 'struct Types.JobQuoteDetails',
+            components: [
               {
-                "name": "requester",
-                "type": "address",
-                "internalType": "address"
+                name: 'requester',
+                type: 'address',
+                internalType: 'address',
               },
               {
-                "name": "serviceId",
-                "type": "uint64",
-                "internalType": "uint64"
+                name: 'serviceId',
+                type: 'uint64',
+                internalType: 'uint64',
               },
               {
-                "name": "jobIndex",
-                "type": "uint8",
-                "internalType": "uint8"
+                name: 'jobIndex',
+                type: 'uint8',
+                internalType: 'uint8',
               },
               {
-                "name": "price",
-                "type": "uint256",
-                "internalType": "uint256"
+                name: 'price',
+                type: 'uint256',
+                internalType: 'uint256',
               },
               {
-                "name": "timestamp",
-                "type": "uint64",
-                "internalType": "uint64"
+                name: 'timestamp',
+                type: 'uint64',
+                internalType: 'uint64',
               },
               {
-                "name": "expiry",
-                "type": "uint64",
-                "internalType": "uint64"
+                name: 'expiry',
+                type: 'uint64',
+                internalType: 'uint64',
               },
               {
-                "name": "confidentiality",
-                "type": "uint8",
-                "internalType": "uint8"
-              }
-            ]
+                name: 'confidentiality',
+                type: 'uint8',
+                internalType: 'uint8',
+              },
+            ],
           },
           {
-            "name": "signature",
-            "type": "bytes",
-            "internalType": "bytes"
+            name: 'signature',
+            type: 'bytes',
+            internalType: 'bytes',
           },
           {
-            "name": "operator",
-            "type": "address",
-            "internalType": "address"
-          }
-        ]
-      }
+            name: 'operator',
+            type: 'address',
+            internalType: 'address',
+          },
+        ],
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "callId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'callId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "stateMutability": "payable"
+    stateMutability: 'payable',
   },
   {
-    "type": "function",
-    "name": "submitResult",
-    "inputs": [
+    type: 'function',
+    name: 'submitResult',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "callId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'callId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "result",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
+        name: 'result',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "submitResults",
-    "inputs": [
+    type: 'function',
+    name: 'submitResults',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "callIds",
-        "type": "uint64[]",
-        "internalType": "uint64[]"
+        name: 'callIds',
+        type: 'uint64[]',
+        internalType: 'uint64[]',
       },
       {
-        "name": "results",
-        "type": "bytes[]",
-        "internalType": "bytes[]"
-      }
+        name: 'results',
+        type: 'bytes[]',
+        internalType: 'bytes[]',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "teeNonceFor",
-    "inputs": [
+    type: 'function',
+    name: 'teeNonceFor',
+    inputs: [
       {
-        "name": "requestId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'requestId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [
+    outputs: [
       {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "terminateService",
-    "inputs": [
+    type: 'function',
+    name: 'terminateService',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "terminateServiceForNonPayment",
-    "inputs": [
+    type: 'function',
+    name: 'terminateServiceForNonPayment',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "tntPaymentDiscountBps",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'tntPaymentDiscountBps',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
+        name: '',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "tntToken",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'tntToken',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "transferBlueprint",
-    "inputs": [
+    type: 'function',
+    name: 'transferBlueprint',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "newOwner",
-        "type": "address",
-        "internalType": "address"
-      }
+        name: 'newOwner',
+        type: 'address',
+        internalType: 'address',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "treasury",
-    "inputs": [],
-    "outputs": [
+    type: 'function',
+    name: 'treasury',
+    inputs: [],
+    outputs: [
       {
-        "name": "",
-        "type": "address",
-        "internalType": "address payable"
-      }
+        name: '',
+        type: 'address',
+        internalType: 'address payable',
+      },
     ],
-    "stateMutability": "view"
+    stateMutability: 'view',
   },
   {
-    "type": "function",
-    "name": "unpause",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    type: 'function',
+    name: 'unpause',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "unregisterOperator",
-    "inputs": [
+    type: 'function',
+    name: 'unregisterOperator',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "updateBlueprint",
-    "inputs": [
+    type: 'function',
+    name: 'updateBlueprint',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "metadataUri",
-        "type": "string",
-        "internalType": "string"
+        name: 'metadataUri',
+        type: 'string',
+        internalType: 'string',
       },
       {
-        "name": "metadataHash",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+        name: 'metadataHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "updateOperatorPreferences",
-    "inputs": [
+    type: 'function',
+    name: 'updateOperatorPreferences',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        internalType: 'uint64',
       },
       {
-        "name": "ecdsaPublicKey",
-        "type": "bytes",
-        "internalType": "bytes"
+        name: 'ecdsaPublicKey',
+        type: 'bytes',
+        internalType: 'bytes',
       },
       {
-        "name": "rpcAddress",
-        "type": "string",
-        "internalType": "string"
-      }
+        name: 'rpcAddress',
+        type: 'string',
+        internalType: 'string',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "function",
-    "name": "withdrawRemainingEscrow",
-    "inputs": [
+    type: 'function',
+    name: 'withdrawRemainingEscrow',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
-    "type": "event",
-    "name": "BlueprintCreated",
-    "inputs": [
+    type: 'event',
+    name: 'BlueprintCreated',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "owner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'owner',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "manager",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
+        name: 'manager',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
       },
       {
-        "name": "metadataUri",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
+        name: 'metadataUri',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
       },
       {
-        "name": "metadataHash",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
-      }
+        name: 'metadataHash',
+        type: 'bytes32',
+        indexed: false,
+        internalType: 'bytes32',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "BlueprintDeactivated",
-    "inputs": [
+    type: 'event',
+    name: 'BlueprintDeactivated',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
-      }
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "BlueprintResourceRequirementsSet",
-    "inputs": [
+    type: 'event',
+    name: 'BlueprintResourceRequirementsSet',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "count",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'count',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "BlueprintTransferred",
-    "inputs": [
+    type: 'event',
+    name: 'BlueprintTransferred',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "from",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'from',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "to",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
+        name: 'to',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "BlueprintUpdated",
-    "inputs": [
+    type: 'event',
+    name: 'BlueprintUpdated',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "metadataUri",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
+        name: 'metadataUri',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
       },
       {
-        "name": "metadataHash",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
-      }
+        name: 'metadataHash',
+        type: 'bytes32',
+        indexed: false,
+        internalType: 'bytes32',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "JobCompleted",
-    "inputs": [
+    type: 'event',
+    name: 'JobCompleted',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "callId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
-      }
+        name: 'callId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "JobResultSubmitted",
-    "inputs": [
+    type: 'event',
+    name: 'JobResultSubmitted',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "callId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'callId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "result",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
+        name: 'result',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "JobSubmitted",
-    "inputs": [
+    type: 'event',
+    name: 'JobSubmitted',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "callId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'callId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "jobIndex",
-        "type": "uint8",
-        "indexed": true,
-        "internalType": "uint8"
+        name: 'jobIndex',
+        type: 'uint8',
+        indexed: true,
+        internalType: 'uint8',
       },
       {
-        "name": "caller",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
+        name: 'caller',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
       },
       {
-        "name": "inputs",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
+        name: 'inputs',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "JobSubmittedFromQuote",
-    "inputs": [
+    type: 'event',
+    name: 'JobSubmittedFromQuote',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "callId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'callId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "jobIndex",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
+        name: 'jobIndex',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'uint8',
       },
       {
-        "name": "caller",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
+        name: 'caller',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
       },
       {
-        "name": "quotedOperators",
-        "type": "address[]",
-        "indexed": false,
-        "internalType": "address[]"
+        name: 'quotedOperators',
+        type: 'address[]',
+        indexed: false,
+        internalType: 'address[]',
       },
       {
-        "name": "totalPrice",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'totalPrice',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "inputs",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
+        name: 'inputs',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorJoinedService",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorJoinedService',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "exposureBps",
-        "type": "uint16",
-        "indexed": false,
-        "internalType": "uint16"
-      }
+        name: 'exposureBps',
+        type: 'uint16',
+        indexed: false,
+        internalType: 'uint16',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorLeftService",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorLeftService',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorPreferencesUpdated",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorPreferencesUpdated',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "ecdsaPublicKey",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
+        name: 'ecdsaPublicKey',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
       },
       {
-        "name": "rpcAddress",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
-      }
+        name: 'rpcAddress',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorRegistered",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorRegistered',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "ecdsaPublicKey",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
+        name: 'ecdsaPublicKey',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
       },
       {
-        "name": "rpcAddress",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
-      }
+        name: 'rpcAddress',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorRewardAccrued",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorRewardAccrued',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "OperatorUnregistered",
-    "inputs": [
+    type: 'event',
+    name: 'OperatorUnregistered',
+    inputs: [
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "PaymentDistributed",
-    "inputs": [
+    type: 'event',
+    name: 'PaymentDistributed',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "token",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "grossAmount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'grossAmount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "developerRecipient",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
+        name: 'developerRecipient',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
       },
       {
-        "name": "developerAmount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'developerAmount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "protocolAmount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'protocolAmount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "operatorPoolAmount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'operatorPoolAmount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "stakerPoolAmount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'stakerPoolAmount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "RewardsClaimed",
-    "inputs": [
+    type: 'event',
+    name: 'RewardsClaimed',
+    inputs: [
       {
-        "name": "account",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'account',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "token",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "ServiceActivated",
-    "inputs": [
+    type: 'event',
+    name: 'ServiceActivated',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "requestId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'requestId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "confidentiality",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "enum Types.ConfidentialityPolicy"
-      }
+        name: 'confidentiality',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'enum Types.ConfidentialityPolicy',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "ServiceApproved",
-    "inputs": [
+    type: 'event',
+    name: 'ServiceApproved',
+    inputs: [
       {
-        "name": "requestId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'requestId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "ServiceRejected",
-    "inputs": [
+    type: 'event',
+    name: 'ServiceRejected',
+    inputs: [
       {
-        "name": "requestId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'requestId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "ServiceRequested",
-    "inputs": [
+    type: 'event',
+    name: 'ServiceRequested',
+    inputs: [
       {
-        "name": "requestId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'requestId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "requester",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'requester',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "confidentiality",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "enum Types.ConfidentialityPolicy"
-      }
+        name: 'confidentiality',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'enum Types.ConfidentialityPolicy',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "ServiceRequestedWithSecurity",
-    "inputs": [
+    type: 'event',
+    name: 'ServiceRequestedWithSecurity',
+    inputs: [
       {
-        "name": "requestId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'requestId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "blueprintId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'blueprintId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "requester",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'requester',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "confidentiality",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "enum Types.ConfidentialityPolicy"
-      }
+        name: 'confidentiality',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'enum Types.ConfidentialityPolicy',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "ServiceTerminated",
-    "inputs": [
+    type: 'event',
+    name: 'ServiceTerminated',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
-      }
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "ServiceTerminatedForNonPayment",
-    "inputs": [
+    type: 'event',
+    name: 'ServiceTerminatedForNonPayment',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "triggeredBy",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'triggeredBy',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "dueAt",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
+        name: 'dueAt',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
       },
       {
-        "name": "graceEndsAt",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
+        name: 'graceEndsAt',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
       },
       {
-        "name": "requiredAmount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'requiredAmount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "escrowBalance",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'escrowBalance',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "SlashCancelled",
-    "inputs": [
+    type: 'event',
+    name: 'SlashCancelled',
+    inputs: [
       {
-        "name": "slashId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'slashId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "canceller",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'canceller',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "reason",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
-      }
+        name: 'reason',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "SlashConfigUpdated",
-    "inputs": [
+    type: 'event',
+    name: 'SlashConfigUpdated',
+    inputs: [
       {
-        "name": "disputeWindow",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
+        name: 'disputeWindow',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
       },
       {
-        "name": "instantSlashEnabled",
-        "type": "bool",
-        "indexed": false,
-        "internalType": "bool"
+        name: 'instantSlashEnabled',
+        type: 'bool',
+        indexed: false,
+        internalType: 'bool',
       },
       {
-        "name": "maxSlashBps",
-        "type": "uint16",
-        "indexed": false,
-        "internalType": "uint16"
+        name: 'maxSlashBps',
+        type: 'uint16',
+        indexed: false,
+        internalType: 'uint16',
       },
       {
-        "name": "disputeResolutionDeadline",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
+        name: 'disputeResolutionDeadline',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
       },
       {
-        "name": "disputeBond",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'disputeBond',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "maxPendingSlashesPerOperator",
-        "type": "uint16",
-        "indexed": false,
-        "internalType": "uint16"
-      }
+        name: 'maxPendingSlashesPerOperator',
+        type: 'uint16',
+        indexed: false,
+        internalType: 'uint16',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "SlashDisputed",
-    "inputs": [
+    type: 'event',
+    name: 'SlashDisputed',
+    inputs: [
       {
-        "name": "slashId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'slashId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "disputer",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'disputer',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "reason",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
-      }
+        name: 'reason',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "SlashExecuted",
-    "inputs": [
+    type: 'event',
+    name: 'SlashExecuted',
+    inputs: [
       {
-        "name": "slashId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'slashId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "actualSlashed",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
+        name: 'actualSlashed',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "SlashProposed",
-    "inputs": [
+    type: 'event',
+    name: 'SlashProposed',
+    inputs: [
       {
-        "name": "slashId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'slashId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "operator",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'operator',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "proposer",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
+        name: 'proposer',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
       },
       {
-        "name": "slashBps",
-        "type": "uint16",
-        "indexed": false,
-        "internalType": "uint16"
+        name: 'slashBps',
+        type: 'uint16',
+        indexed: false,
+        internalType: 'uint16',
       },
       {
-        "name": "effectiveSlashBps",
-        "type": "uint16",
-        "indexed": false,
-        "internalType": "uint16"
+        name: 'effectiveSlashBps',
+        type: 'uint16',
+        indexed: false,
+        internalType: 'uint16',
       },
       {
-        "name": "evidence",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
+        name: 'evidence',
+        type: 'bytes32',
+        indexed: false,
+        internalType: 'bytes32',
       },
       {
-        "name": "executeAfter",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
+        name: 'executeAfter',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
+      },
     ],
-    "anonymous": false
+    anonymous: false,
   },
   {
-    "type": "event",
-    "name": "SubscriptionBilled",
-    "inputs": [
+    type: 'event',
+    name: 'SubscriptionBilled',
+    inputs: [
       {
-        "name": "serviceId",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
+        name: 'serviceId',
+        type: 'uint64',
+        indexed: true,
+        internalType: 'uint64',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "period",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
+        name: 'period',
+        type: 'uint64',
+        indexed: false,
+        internalType: 'uint64',
+      },
     ],
-    "anonymous": false
-  }
+    anonymous: false,
+  },
 ] as const;
 
 export default ABI;

--- a/libs/tangle-shared-ui/src/abi/tangle.ts
+++ b/libs/tangle-shared-ui/src/abi/tangle.ts
@@ -1,5041 +1,5169 @@
 // AUTO-GENERATED FROM tnt-core. DO NOT EDIT MANUALLY.
 const ABI = [
   {
-    type: 'function',
-    name: 'addPermittedCaller',
-    inputs: [
+    "type": "function",
+    "name": "addPermittedCaller",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'caller',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "caller",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'approveService',
-    inputs: [
+    "type": "function",
+    "name": "approveService",
+    "inputs": [
       {
-        name: 'params',
-        type: 'tuple',
-        internalType: 'struct Types.ApprovalParams',
-        components: [
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct Types.ApprovalParams",
+        "components": [
           {
-            name: 'requestId',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "requestId",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'securityCommitments',
-            type: 'tuple[]',
-            internalType: 'struct Types.AssetSecurityCommitment[]',
-            components: [
+            "name": "securityCommitments",
+            "type": "tuple[]",
+            "internalType": "struct Types.AssetSecurityCommitment[]",
+            "components": [
               {
-                name: 'asset',
-                type: 'tuple',
-                internalType: 'struct Types.Asset',
-                components: [
+                "name": "asset",
+                "type": "tuple",
+                "internalType": "struct Types.Asset",
+                "components": [
                   {
-                    name: 'kind',
-                    type: 'uint8',
-                    internalType: 'enum Types.AssetKind',
+                    "name": "kind",
+                    "type": "uint8",
+                    "internalType": "enum Types.AssetKind"
                   },
                   {
-                    name: 'token',
-                    type: 'address',
-                    internalType: 'address',
-                  },
-                ],
+                    "name": "token",
+                    "type": "address",
+                    "internalType": "address"
+                  }
+                ]
               },
               {
-                name: 'exposureBps',
-                type: 'uint16',
-                internalType: 'uint16',
-              },
-            ],
+                "name": "exposureBps",
+                "type": "uint16",
+                "internalType": "uint16"
+              }
+            ]
           },
           {
-            name: 'blsPubkey',
-            type: 'uint256[4]',
-            internalType: 'uint256[4]',
+            "name": "blsPubkey",
+            "type": "uint256[4]",
+            "internalType": "uint256[4]"
           },
           {
-            name: 'blsPopSignature',
-            type: 'uint256[2]',
-            internalType: 'uint256[2]',
+            "name": "blsPopSignature",
+            "type": "uint256[2]",
+            "internalType": "uint256[2]"
           },
           {
-            name: 'teeCommitments',
-            type: 'tuple[]',
-            internalType: 'struct Types.TeeAttestationCommitment[]',
-            components: [
+            "name": "teeCommitments",
+            "type": "tuple[]",
+            "internalType": "struct Types.TeeAttestationCommitment[]",
+            "components": [
               {
-                name: 'backend',
-                type: 'uint8',
-                internalType: 'enum Types.TeeBackend',
+                "name": "backend",
+                "type": "uint8",
+                "internalType": "enum Types.TeeBackend"
               },
               {
-                name: 'expectedMeasurement',
-                type: 'bytes32',
-                internalType: 'bytes32',
+                "name": "expectedMeasurement",
+                "type": "bytes32",
+                "internalType": "bytes32"
               },
               {
-                name: 'nonceBinding',
-                type: 'bytes32',
-                internalType: 'bytes32',
+                "name": "nonceBinding",
+                "type": "bytes32",
+                "internalType": "bytes32"
               },
               {
-                name: 'expiresAt',
-                type: 'uint64',
-                internalType: 'uint64',
-              },
-            ],
-          },
-        ],
-      },
+                "name": "expiresAt",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          }
+        ]
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'billSubscription',
-    inputs: [
+    "type": "function",
+    "name": "billSubscription",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'billSubscriptionBatch',
-    inputs: [
+    "type": "function",
+    "name": "billSubscriptionBatch",
+    "inputs": [
       {
-        name: 'serviceIds',
-        type: 'uint64[]',
-        internalType: 'uint64[]',
-      },
+        "name": "serviceIds",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'totalBilled',
-        type: 'uint256',
-        internalType: 'uint256',
+        "name": "totalBilled",
+        "type": "uint256",
+        "internalType": "uint256"
       },
       {
-        name: 'billedCount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "billedCount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    stateMutability: 'nonpayable',
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'blsPopMessage',
-    inputs: [
+    "type": "function",
+    "name": "blsPopMessage",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
       },
       {
-        name: 'blsPubkey',
-        type: 'uint256[4]',
-        internalType: 'uint256[4]',
-      },
+        "name": "blsPubkey",
+        "type": "uint256[4]",
+        "internalType": "uint256[4]"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'blueprintCount',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "blueprintCount",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'blueprintMasterRevision',
-    inputs: [
+    "type": "function",
+    "name": "blueprintMasterRevision",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'uint32',
-        internalType: 'uint32',
-      },
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'blueprintMetadata',
-    inputs: [
+    "type": "function",
+    "name": "blueprintMetadata",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'metadata',
-        type: 'tuple',
-        internalType: 'struct Types.BlueprintMetadata',
-        components: [
+        "name": "metadata",
+        "type": "tuple",
+        "internalType": "struct Types.BlueprintMetadata",
+        "components": [
           {
-            name: 'name',
-            type: 'string',
-            internalType: 'string',
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
           },
           {
-            name: 'description',
-            type: 'string',
-            internalType: 'string',
+            "name": "description",
+            "type": "string",
+            "internalType": "string"
           },
           {
-            name: 'author',
-            type: 'string',
-            internalType: 'string',
+            "name": "author",
+            "type": "string",
+            "internalType": "string"
           },
           {
-            name: 'category',
-            type: 'string',
-            internalType: 'string',
+            "name": "category",
+            "type": "string",
+            "internalType": "string"
           },
           {
-            name: 'codeRepository',
-            type: 'string',
-            internalType: 'string',
+            "name": "codeRepository",
+            "type": "string",
+            "internalType": "string"
           },
           {
-            name: 'logo',
-            type: 'string',
-            internalType: 'string',
+            "name": "logo",
+            "type": "string",
+            "internalType": "string"
           },
           {
-            name: 'website',
-            type: 'string',
-            internalType: 'string',
+            "name": "website",
+            "type": "string",
+            "internalType": "string"
           },
           {
-            name: 'license',
-            type: 'string',
-            internalType: 'string',
+            "name": "license",
+            "type": "string",
+            "internalType": "string"
           },
           {
-            name: 'profilingData',
-            type: 'string',
-            internalType: 'string',
-          },
-        ],
+            "name": "profilingData",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
       },
       {
-        name: 'metadataUri',
-        type: 'string',
-        internalType: 'string',
+        "name": "metadataUri",
+        "type": "string",
+        "internalType": "string"
       },
       {
-        name: 'metadataHash',
-        type: 'bytes32',
-        internalType: 'bytes32',
-      },
+        "name": "metadataHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'blueprintOperatorCount',
-    inputs: [
+    "type": "function",
+    "name": "blueprintOperatorCount",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'blueprintSources',
-    inputs: [
+    "type": "function",
+    "name": "blueprintSources",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'sources',
-        type: 'tuple[]',
-        internalType: 'struct Types.BlueprintSource[]',
-        components: [
+        "name": "sources",
+        "type": "tuple[]",
+        "internalType": "struct Types.BlueprintSource[]",
+        "components": [
           {
-            name: 'kind',
-            type: 'uint8',
-            internalType: 'enum Types.BlueprintSourceKind',
+            "name": "kind",
+            "type": "uint8",
+            "internalType": "enum Types.BlueprintSourceKind"
           },
           {
-            name: 'container',
-            type: 'tuple',
-            internalType: 'struct Types.ImageRegistrySource',
-            components: [
+            "name": "container",
+            "type": "tuple",
+            "internalType": "struct Types.ImageRegistrySource",
+            "components": [
               {
-                name: 'registry',
-                type: 'string',
-                internalType: 'string',
+                "name": "registry",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'image',
-                type: 'string',
-                internalType: 'string',
+                "name": "image",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'tag',
-                type: 'string',
-                internalType: 'string',
-              },
-            ],
+                "name": "tag",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
           },
           {
-            name: 'wasm',
-            type: 'tuple',
-            internalType: 'struct Types.WasmSource',
-            components: [
+            "name": "wasm",
+            "type": "tuple",
+            "internalType": "struct Types.WasmSource",
+            "components": [
               {
-                name: 'runtime',
-                type: 'uint8',
-                internalType: 'enum Types.WasmRuntime',
+                "name": "runtime",
+                "type": "uint8",
+                "internalType": "enum Types.WasmRuntime"
               },
               {
-                name: 'fetcher',
-                type: 'uint8',
-                internalType: 'enum Types.BlueprintFetcherKind',
+                "name": "fetcher",
+                "type": "uint8",
+                "internalType": "enum Types.BlueprintFetcherKind"
               },
               {
-                name: 'artifactUri',
-                type: 'string',
-                internalType: 'string',
+                "name": "artifactUri",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'entrypoint',
-                type: 'string',
-                internalType: 'string',
-              },
-            ],
+                "name": "entrypoint",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
           },
           {
-            name: 'native',
-            type: 'tuple',
-            internalType: 'struct Types.NativeSource',
-            components: [
+            "name": "native",
+            "type": "tuple",
+            "internalType": "struct Types.NativeSource",
+            "components": [
               {
-                name: 'fetcher',
-                type: 'uint8',
-                internalType: 'enum Types.BlueprintFetcherKind',
+                "name": "fetcher",
+                "type": "uint8",
+                "internalType": "enum Types.BlueprintFetcherKind"
               },
               {
-                name: 'artifactUri',
-                type: 'string',
-                internalType: 'string',
+                "name": "artifactUri",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'entrypoint',
-                type: 'string',
-                internalType: 'string',
-              },
-            ],
+                "name": "entrypoint",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
           },
           {
-            name: 'testing',
-            type: 'tuple',
-            internalType: 'struct Types.TestingSource',
-            components: [
+            "name": "testing",
+            "type": "tuple",
+            "internalType": "struct Types.TestingSource",
+            "components": [
               {
-                name: 'cargoPackage',
-                type: 'string',
-                internalType: 'string',
+                "name": "cargoPackage",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'cargoBin',
-                type: 'string',
-                internalType: 'string',
+                "name": "cargoBin",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'basePath',
-                type: 'string',
-                internalType: 'string',
-              },
-            ],
+                "name": "basePath",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
           },
           {
-            name: 'binaries',
-            type: 'tuple[]',
-            internalType: 'struct Types.BlueprintBinary[]',
-            components: [
+            "name": "binaries",
+            "type": "tuple[]",
+            "internalType": "struct Types.BlueprintBinary[]",
+            "components": [
               {
-                name: 'arch',
-                type: 'uint8',
-                internalType: 'enum Types.BlueprintArchitecture',
+                "name": "arch",
+                "type": "uint8",
+                "internalType": "enum Types.BlueprintArchitecture"
               },
               {
-                name: 'os',
-                type: 'uint8',
-                internalType: 'enum Types.BlueprintOperatingSystem',
+                "name": "os",
+                "type": "uint8",
+                "internalType": "enum Types.BlueprintOperatingSystem"
               },
               {
-                name: 'name',
-                type: 'string',
-                internalType: 'string',
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'sha256',
-                type: 'bytes32',
-                internalType: 'bytes32',
-              },
-            ],
-          },
-        ],
-      },
+                "name": "sha256",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              }
+            ]
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'blueprintSupportedMemberships',
-    inputs: [
+    "type": "function",
+    "name": "blueprintSupportedMemberships",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'memberships',
-        type: 'uint8[]',
-        internalType: 'enum Types.MembershipModel[]',
-      },
+        "name": "memberships",
+        "type": "uint8[]",
+        "internalType": "enum Types.MembershipModel[]"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'canScheduleExit',
-    inputs: [
+    "type": "function",
+    "name": "canScheduleExit",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'canExit',
-        type: 'bool',
-        internalType: 'bool',
+        "name": "canExit",
+        "type": "bool",
+        "internalType": "bool"
       },
       {
-        name: 'reason',
-        type: 'string',
-        internalType: 'string',
-      },
+        "name": "reason",
+        "type": "string",
+        "internalType": "string"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'cancelExit',
-    inputs: [
+    "type": "function",
+    "name": "cancelExit",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'cancelSlash',
-    inputs: [
+    "type": "function",
+    "name": "cancelSlash",
+    "inputs": [
       {
-        name: 'slashId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "slashId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'reason',
-        type: 'string',
-        internalType: 'string',
-      },
+        "name": "reason",
+        "type": "string",
+        "internalType": "string"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'claimRewards',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "type": "function",
+    "name": "claimRewards",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'claimRewards',
-    inputs: [
+    "type": "function",
+    "name": "claimRewards",
+    "inputs": [
       {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'claimRewardsAll',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "type": "function",
+    "name": "claimRewardsAll",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'claimRewardsBatch',
-    inputs: [
+    "type": "function",
+    "name": "claimRewardsBatch",
+    "inputs": [
       {
-        name: 'tokens',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
+        "name": "tokens",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'createBlueprint',
-    inputs: [
+    "type": "function",
+    "name": "createBlueprint",
+    "inputs": [
       {
-        name: 'definition',
-        type: 'tuple',
-        internalType: 'struct Types.BlueprintDefinition',
-        components: [
+        "name": "definition",
+        "type": "tuple",
+        "internalType": "struct Types.BlueprintDefinition",
+        "components": [
           {
-            name: 'metadataUri',
-            type: 'string',
-            internalType: 'string',
+            "name": "metadataUri",
+            "type": "string",
+            "internalType": "string"
           },
           {
-            name: 'metadataHash',
-            type: 'bytes32',
-            internalType: 'bytes32',
+            "name": "metadataHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
           },
           {
-            name: 'manager',
-            type: 'address',
-            internalType: 'address',
+            "name": "manager",
+            "type": "address",
+            "internalType": "address"
           },
           {
-            name: 'masterManagerRevision',
-            type: 'uint32',
-            internalType: 'uint32',
+            "name": "masterManagerRevision",
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            name: 'hasConfig',
-            type: 'bool',
-            internalType: 'bool',
+            "name": "hasConfig",
+            "type": "bool",
+            "internalType": "bool"
           },
           {
-            name: 'config',
-            type: 'tuple',
-            internalType: 'struct Types.BlueprintConfig',
-            components: [
+            "name": "config",
+            "type": "tuple",
+            "internalType": "struct Types.BlueprintConfig",
+            "components": [
               {
-                name: 'membership',
-                type: 'uint8',
-                internalType: 'enum Types.MembershipModel',
+                "name": "membership",
+                "type": "uint8",
+                "internalType": "enum Types.MembershipModel"
               },
               {
-                name: 'pricing',
-                type: 'uint8',
-                internalType: 'enum Types.PricingModel',
+                "name": "pricing",
+                "type": "uint8",
+                "internalType": "enum Types.PricingModel"
               },
               {
-                name: 'minOperators',
-                type: 'uint32',
-                internalType: 'uint32',
+                "name": "minOperators",
+                "type": "uint32",
+                "internalType": "uint32"
               },
               {
-                name: 'maxOperators',
-                type: 'uint32',
-                internalType: 'uint32',
+                "name": "maxOperators",
+                "type": "uint32",
+                "internalType": "uint32"
               },
               {
-                name: 'subscriptionRate',
-                type: 'uint256',
-                internalType: 'uint256',
+                "name": "subscriptionRate",
+                "type": "uint256",
+                "internalType": "uint256"
               },
               {
-                name: 'subscriptionInterval',
-                type: 'uint64',
-                internalType: 'uint64',
+                "name": "subscriptionInterval",
+                "type": "uint64",
+                "internalType": "uint64"
               },
               {
-                name: 'eventRate',
-                type: 'uint256',
-                internalType: 'uint256',
-              },
-            ],
+                "name": "eventRate",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
           },
           {
-            name: 'metadata',
-            type: 'tuple',
-            internalType: 'struct Types.BlueprintMetadata',
-            components: [
+            "name": "metadata",
+            "type": "tuple",
+            "internalType": "struct Types.BlueprintMetadata",
+            "components": [
               {
-                name: 'name',
-                type: 'string',
-                internalType: 'string',
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'description',
-                type: 'string',
-                internalType: 'string',
+                "name": "description",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'author',
-                type: 'string',
-                internalType: 'string',
+                "name": "author",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'category',
-                type: 'string',
-                internalType: 'string',
+                "name": "category",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'codeRepository',
-                type: 'string',
-                internalType: 'string',
+                "name": "codeRepository",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'logo',
-                type: 'string',
-                internalType: 'string',
+                "name": "logo",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'website',
-                type: 'string',
-                internalType: 'string',
+                "name": "website",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'license',
-                type: 'string',
-                internalType: 'string',
+                "name": "license",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'profilingData',
-                type: 'string',
-                internalType: 'string',
-              },
-            ],
+                "name": "profilingData",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
           },
           {
-            name: 'jobs',
-            type: 'tuple[]',
-            internalType: 'struct Types.JobDefinition[]',
-            components: [
+            "name": "jobs",
+            "type": "tuple[]",
+            "internalType": "struct Types.JobDefinition[]",
+            "components": [
               {
-                name: 'name',
-                type: 'string',
-                internalType: 'string',
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'description',
-                type: 'string',
-                internalType: 'string',
+                "name": "description",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'metadataUri',
-                type: 'string',
-                internalType: 'string',
+                "name": "metadataUri",
+                "type": "string",
+                "internalType": "string"
               },
               {
-                name: 'paramsSchema',
-                type: 'bytes',
-                internalType: 'bytes',
+                "name": "paramsSchema",
+                "type": "bytes",
+                "internalType": "bytes"
               },
               {
-                name: 'resultSchema',
-                type: 'bytes',
-                internalType: 'bytes',
-              },
-            ],
+                "name": "resultSchema",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
           },
           {
-            name: 'registrationSchema',
-            type: 'bytes',
-            internalType: 'bytes',
+            "name": "registrationSchema",
+            "type": "bytes",
+            "internalType": "bytes"
           },
           {
-            name: 'requestSchema',
-            type: 'bytes',
-            internalType: 'bytes',
+            "name": "requestSchema",
+            "type": "bytes",
+            "internalType": "bytes"
           },
           {
-            name: 'sources',
-            type: 'tuple[]',
-            internalType: 'struct Types.BlueprintSource[]',
-            components: [
+            "name": "sources",
+            "type": "tuple[]",
+            "internalType": "struct Types.BlueprintSource[]",
+            "components": [
               {
-                name: 'kind',
-                type: 'uint8',
-                internalType: 'enum Types.BlueprintSourceKind',
+                "name": "kind",
+                "type": "uint8",
+                "internalType": "enum Types.BlueprintSourceKind"
               },
               {
-                name: 'container',
-                type: 'tuple',
-                internalType: 'struct Types.ImageRegistrySource',
-                components: [
+                "name": "container",
+                "type": "tuple",
+                "internalType": "struct Types.ImageRegistrySource",
+                "components": [
                   {
-                    name: 'registry',
-                    type: 'string',
-                    internalType: 'string',
+                    "name": "registry",
+                    "type": "string",
+                    "internalType": "string"
                   },
                   {
-                    name: 'image',
-                    type: 'string',
-                    internalType: 'string',
+                    "name": "image",
+                    "type": "string",
+                    "internalType": "string"
                   },
                   {
-                    name: 'tag',
-                    type: 'string',
-                    internalType: 'string',
-                  },
-                ],
+                    "name": "tag",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
               },
               {
-                name: 'wasm',
-                type: 'tuple',
-                internalType: 'struct Types.WasmSource',
-                components: [
+                "name": "wasm",
+                "type": "tuple",
+                "internalType": "struct Types.WasmSource",
+                "components": [
                   {
-                    name: 'runtime',
-                    type: 'uint8',
-                    internalType: 'enum Types.WasmRuntime',
+                    "name": "runtime",
+                    "type": "uint8",
+                    "internalType": "enum Types.WasmRuntime"
                   },
                   {
-                    name: 'fetcher',
-                    type: 'uint8',
-                    internalType: 'enum Types.BlueprintFetcherKind',
+                    "name": "fetcher",
+                    "type": "uint8",
+                    "internalType": "enum Types.BlueprintFetcherKind"
                   },
                   {
-                    name: 'artifactUri',
-                    type: 'string',
-                    internalType: 'string',
+                    "name": "artifactUri",
+                    "type": "string",
+                    "internalType": "string"
                   },
                   {
-                    name: 'entrypoint',
-                    type: 'string',
-                    internalType: 'string',
-                  },
-                ],
+                    "name": "entrypoint",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
               },
               {
-                name: 'native',
-                type: 'tuple',
-                internalType: 'struct Types.NativeSource',
-                components: [
+                "name": "native",
+                "type": "tuple",
+                "internalType": "struct Types.NativeSource",
+                "components": [
                   {
-                    name: 'fetcher',
-                    type: 'uint8',
-                    internalType: 'enum Types.BlueprintFetcherKind',
+                    "name": "fetcher",
+                    "type": "uint8",
+                    "internalType": "enum Types.BlueprintFetcherKind"
                   },
                   {
-                    name: 'artifactUri',
-                    type: 'string',
-                    internalType: 'string',
+                    "name": "artifactUri",
+                    "type": "string",
+                    "internalType": "string"
                   },
                   {
-                    name: 'entrypoint',
-                    type: 'string',
-                    internalType: 'string',
-                  },
-                ],
+                    "name": "entrypoint",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
               },
               {
-                name: 'testing',
-                type: 'tuple',
-                internalType: 'struct Types.TestingSource',
-                components: [
+                "name": "testing",
+                "type": "tuple",
+                "internalType": "struct Types.TestingSource",
+                "components": [
                   {
-                    name: 'cargoPackage',
-                    type: 'string',
-                    internalType: 'string',
+                    "name": "cargoPackage",
+                    "type": "string",
+                    "internalType": "string"
                   },
                   {
-                    name: 'cargoBin',
-                    type: 'string',
-                    internalType: 'string',
+                    "name": "cargoBin",
+                    "type": "string",
+                    "internalType": "string"
                   },
                   {
-                    name: 'basePath',
-                    type: 'string',
-                    internalType: 'string',
-                  },
-                ],
+                    "name": "basePath",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
               },
               {
-                name: 'binaries',
-                type: 'tuple[]',
-                internalType: 'struct Types.BlueprintBinary[]',
-                components: [
+                "name": "binaries",
+                "type": "tuple[]",
+                "internalType": "struct Types.BlueprintBinary[]",
+                "components": [
                   {
-                    name: 'arch',
-                    type: 'uint8',
-                    internalType: 'enum Types.BlueprintArchitecture',
+                    "name": "arch",
+                    "type": "uint8",
+                    "internalType": "enum Types.BlueprintArchitecture"
                   },
                   {
-                    name: 'os',
-                    type: 'uint8',
-                    internalType: 'enum Types.BlueprintOperatingSystem',
+                    "name": "os",
+                    "type": "uint8",
+                    "internalType": "enum Types.BlueprintOperatingSystem"
                   },
                   {
-                    name: 'name',
-                    type: 'string',
-                    internalType: 'string',
+                    "name": "name",
+                    "type": "string",
+                    "internalType": "string"
                   },
                   {
-                    name: 'sha256',
-                    type: 'bytes32',
-                    internalType: 'bytes32',
-                  },
-                ],
-              },
-            ],
+                    "name": "sha256",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  }
+                ]
+              }
+            ]
           },
           {
-            name: 'supportedMemberships',
-            type: 'uint8[]',
-            internalType: 'enum Types.MembershipModel[]',
-          },
-        ],
-      },
+            "name": "supportedMemberships",
+            "type": "uint8[]",
+            "internalType": "enum Types.MembershipModel[]"
+          }
+        ]
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    stateMutability: 'nonpayable',
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'createServiceFromQuotes',
-    inputs: [
+    "type": "function",
+    "name": "createServiceFromQuotes",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'quotes',
-        type: 'tuple[]',
-        internalType: 'struct Types.SignedQuote[]',
-        components: [
+        "name": "quotes",
+        "type": "tuple[]",
+        "internalType": "struct Types.SignedQuote[]",
+        "components": [
           {
-            name: 'details',
-            type: 'tuple',
-            internalType: 'struct Types.QuoteDetails',
-            components: [
+            "name": "details",
+            "type": "tuple",
+            "internalType": "struct Types.QuoteDetails",
+            "components": [
               {
-                name: 'requester',
-                type: 'address',
-                internalType: 'address',
+                "name": "requester",
+                "type": "address",
+                "internalType": "address"
               },
               {
-                name: 'blueprintId',
-                type: 'uint64',
-                internalType: 'uint64',
+                "name": "blueprintId",
+                "type": "uint64",
+                "internalType": "uint64"
               },
               {
-                name: 'ttlBlocks',
-                type: 'uint64',
-                internalType: 'uint64',
+                "name": "ttlBlocks",
+                "type": "uint64",
+                "internalType": "uint64"
               },
               {
-                name: 'totalCost',
-                type: 'uint256',
-                internalType: 'uint256',
+                "name": "totalCost",
+                "type": "uint256",
+                "internalType": "uint256"
               },
               {
-                name: 'timestamp',
-                type: 'uint64',
-                internalType: 'uint64',
+                "name": "timestamp",
+                "type": "uint64",
+                "internalType": "uint64"
               },
               {
-                name: 'expiry',
-                type: 'uint64',
-                internalType: 'uint64',
+                "name": "expiry",
+                "type": "uint64",
+                "internalType": "uint64"
               },
               {
-                name: 'confidentiality',
-                type: 'uint8',
-                internalType: 'enum Types.ConfidentialityPolicy',
+                "name": "confidentiality",
+                "type": "uint8",
+                "internalType": "enum Types.ConfidentialityPolicy"
               },
               {
-                name: 'securityCommitments',
-                type: 'tuple[]',
-                internalType: 'struct Types.AssetSecurityCommitment[]',
-                components: [
+                "name": "securityCommitments",
+                "type": "tuple[]",
+                "internalType": "struct Types.AssetSecurityCommitment[]",
+                "components": [
                   {
-                    name: 'asset',
-                    type: 'tuple',
-                    internalType: 'struct Types.Asset',
-                    components: [
+                    "name": "asset",
+                    "type": "tuple",
+                    "internalType": "struct Types.Asset",
+                    "components": [
                       {
-                        name: 'kind',
-                        type: 'uint8',
-                        internalType: 'enum Types.AssetKind',
+                        "name": "kind",
+                        "type": "uint8",
+                        "internalType": "enum Types.AssetKind"
                       },
                       {
-                        name: 'token',
-                        type: 'address',
-                        internalType: 'address',
-                      },
-                    ],
+                        "name": "token",
+                        "type": "address",
+                        "internalType": "address"
+                      }
+                    ]
                   },
                   {
-                    name: 'exposureBps',
-                    type: 'uint16',
-                    internalType: 'uint16',
-                  },
-                ],
+                    "name": "exposureBps",
+                    "type": "uint16",
+                    "internalType": "uint16"
+                  }
+                ]
               },
               {
-                name: 'resourceCommitments',
-                type: 'tuple[]',
-                internalType: 'struct Types.ResourceCommitment[]',
-                components: [
+                "name": "resourceCommitments",
+                "type": "tuple[]",
+                "internalType": "struct Types.ResourceCommitment[]",
+                "components": [
                   {
-                    name: 'kind',
-                    type: 'uint8',
-                    internalType: 'uint8',
+                    "name": "kind",
+                    "type": "uint8",
+                    "internalType": "uint8"
                   },
                   {
-                    name: 'count',
-                    type: 'uint64',
-                    internalType: 'uint64',
-                  },
-                ],
-              },
-            ],
+                    "name": "count",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  }
+                ]
+              }
+            ]
           },
           {
-            name: 'signature',
-            type: 'bytes',
-            internalType: 'bytes',
+            "name": "signature",
+            "type": "bytes",
+            "internalType": "bytes"
           },
           {
-            name: 'operator',
-            type: 'address',
-            internalType: 'address',
-          },
-        ],
+            "name": "operator",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
       },
       {
-        name: 'config',
-        type: 'bytes',
-        internalType: 'bytes',
+        "name": "config",
+        "type": "bytes",
+        "internalType": "bytes"
       },
       {
-        name: 'permittedCallers',
-        type: 'address[]',
-        internalType: 'address[]',
+        "name": "permittedCallers",
+        "type": "address[]",
+        "internalType": "address[]"
       },
       {
-        name: 'ttl',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "ttl",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    stateMutability: 'payable',
+    "stateMutability": "payable"
   },
   {
-    type: 'function',
-    name: 'deactivateBlueprint',
-    inputs: [
+    "type": "function",
+    "name": "deactivateBlueprint",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'defaultTntMinExposureBps',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "defaultTntMinExposureBps",
+    "inputs": [],
+    "outputs": [
       {
-        name: '',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'disputeSlash',
-    inputs: [
+    "type": "function",
+    "name": "disputeSlash",
+    "inputs": [
       {
-        name: 'slashId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "slashId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'reason',
-        type: 'string',
-        internalType: 'string',
-      },
+        "name": "reason",
+        "type": "string",
+        "internalType": "string"
+      }
     ],
-    outputs: [],
-    stateMutability: 'payable',
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
-    type: 'function',
-    name: 'executeExit',
-    inputs: [
+    "type": "function",
+    "name": "executeExit",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'executeSlash',
-    inputs: [
+    "type": "function",
+    "name": "executeSlash",
+    "inputs": [
       {
-        name: 'slashId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "slashId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'actualSlashed',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "actualSlashed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    stateMutability: 'nonpayable',
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'executeSlashBatch',
-    inputs: [
+    "type": "function",
+    "name": "executeSlashBatch",
+    "inputs": [
       {
-        name: 'slashIds',
-        type: 'uint64[]',
-        internalType: 'uint64[]',
-      },
+        "name": "slashIds",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'totalSlashed',
-        type: 'uint256',
-        internalType: 'uint256',
+        "name": "totalSlashed",
+        "type": "uint256",
+        "internalType": "uint256"
       },
       {
-        name: 'executedCount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "executedCount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    stateMutability: 'nonpayable',
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'expireServiceRequest',
-    inputs: [
+    "type": "function",
+    "name": "expireServiceRequest",
+    "inputs": [
       {
-        name: 'requestId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "requestId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'extendServiceFromQuotes',
-    inputs: [
+    "type": "function",
+    "name": "extendServiceFromQuotes",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'quotes',
-        type: 'tuple[]',
-        internalType: 'struct Types.SignedQuote[]',
-        components: [
+        "name": "quotes",
+        "type": "tuple[]",
+        "internalType": "struct Types.SignedQuote[]",
+        "components": [
           {
-            name: 'details',
-            type: 'tuple',
-            internalType: 'struct Types.QuoteDetails',
-            components: [
+            "name": "details",
+            "type": "tuple",
+            "internalType": "struct Types.QuoteDetails",
+            "components": [
               {
-                name: 'requester',
-                type: 'address',
-                internalType: 'address',
+                "name": "requester",
+                "type": "address",
+                "internalType": "address"
               },
               {
-                name: 'blueprintId',
-                type: 'uint64',
-                internalType: 'uint64',
+                "name": "blueprintId",
+                "type": "uint64",
+                "internalType": "uint64"
               },
               {
-                name: 'ttlBlocks',
-                type: 'uint64',
-                internalType: 'uint64',
+                "name": "ttlBlocks",
+                "type": "uint64",
+                "internalType": "uint64"
               },
               {
-                name: 'totalCost',
-                type: 'uint256',
-                internalType: 'uint256',
+                "name": "totalCost",
+                "type": "uint256",
+                "internalType": "uint256"
               },
               {
-                name: 'timestamp',
-                type: 'uint64',
-                internalType: 'uint64',
+                "name": "timestamp",
+                "type": "uint64",
+                "internalType": "uint64"
               },
               {
-                name: 'expiry',
-                type: 'uint64',
-                internalType: 'uint64',
+                "name": "expiry",
+                "type": "uint64",
+                "internalType": "uint64"
               },
               {
-                name: 'confidentiality',
-                type: 'uint8',
-                internalType: 'enum Types.ConfidentialityPolicy',
+                "name": "confidentiality",
+                "type": "uint8",
+                "internalType": "enum Types.ConfidentialityPolicy"
               },
               {
-                name: 'securityCommitments',
-                type: 'tuple[]',
-                internalType: 'struct Types.AssetSecurityCommitment[]',
-                components: [
+                "name": "securityCommitments",
+                "type": "tuple[]",
+                "internalType": "struct Types.AssetSecurityCommitment[]",
+                "components": [
                   {
-                    name: 'asset',
-                    type: 'tuple',
-                    internalType: 'struct Types.Asset',
-                    components: [
+                    "name": "asset",
+                    "type": "tuple",
+                    "internalType": "struct Types.Asset",
+                    "components": [
                       {
-                        name: 'kind',
-                        type: 'uint8',
-                        internalType: 'enum Types.AssetKind',
+                        "name": "kind",
+                        "type": "uint8",
+                        "internalType": "enum Types.AssetKind"
                       },
                       {
-                        name: 'token',
-                        type: 'address',
-                        internalType: 'address',
-                      },
-                    ],
+                        "name": "token",
+                        "type": "address",
+                        "internalType": "address"
+                      }
+                    ]
                   },
                   {
-                    name: 'exposureBps',
-                    type: 'uint16',
-                    internalType: 'uint16',
-                  },
-                ],
+                    "name": "exposureBps",
+                    "type": "uint16",
+                    "internalType": "uint16"
+                  }
+                ]
               },
               {
-                name: 'resourceCommitments',
-                type: 'tuple[]',
-                internalType: 'struct Types.ResourceCommitment[]',
-                components: [
+                "name": "resourceCommitments",
+                "type": "tuple[]",
+                "internalType": "struct Types.ResourceCommitment[]",
+                "components": [
                   {
-                    name: 'kind',
-                    type: 'uint8',
-                    internalType: 'uint8',
-                  },
-                  {
-                    name: 'count',
-                    type: 'uint64',
-                    internalType: 'uint64',
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            name: 'signature',
-            type: 'bytes',
-            internalType: 'bytes',
-          },
-          {
-            name: 'operator',
-            type: 'address',
-            internalType: 'address',
-          },
-        ],
-      },
-      {
-        name: 'extensionDuration',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'payable',
-  },
-  {
-    type: 'function',
-    name: 'forceExit',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'forceRemoveOperator',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'fundService',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'payable',
-  },
-  {
-    type: 'function',
-    name: 'getBillableServices',
-    inputs: [
-      {
-        name: 'serviceIds',
-        type: 'uint64[]',
-        internalType: 'uint64[]',
-      },
-    ],
-    outputs: [
-      {
-        name: 'billable',
-        type: 'uint64[]',
-        internalType: 'uint64[]',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getBlueprint',
-    inputs: [
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct Types.Blueprint',
-        components: [
-          {
-            name: 'owner',
-            type: 'address',
-            internalType: 'address',
-          },
-          {
-            name: 'manager',
-            type: 'address',
-            internalType: 'address',
-          },
-          {
-            name: 'createdAt',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-          {
-            name: 'operatorCount',
-            type: 'uint32',
-            internalType: 'uint32',
-          },
-          {
-            name: 'membership',
-            type: 'uint8',
-            internalType: 'enum Types.MembershipModel',
-          },
-          {
-            name: 'pricing',
-            type: 'uint8',
-            internalType: 'enum Types.PricingModel',
-          },
-          {
-            name: 'active',
-            type: 'bool',
-            internalType: 'bool',
-          },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getBlueprintConfig',
-    inputs: [
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct Types.BlueprintConfig',
-        components: [
-          {
-            name: 'membership',
-            type: 'uint8',
-            internalType: 'enum Types.MembershipModel',
-          },
-          {
-            name: 'pricing',
-            type: 'uint8',
-            internalType: 'enum Types.PricingModel',
-          },
-          {
-            name: 'minOperators',
-            type: 'uint32',
-            internalType: 'uint32',
-          },
-          {
-            name: 'maxOperators',
-            type: 'uint32',
-            internalType: 'uint32',
-          },
-          {
-            name: 'subscriptionRate',
-            type: 'uint256',
-            internalType: 'uint256',
-          },
-          {
-            name: 'subscriptionInterval',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-          {
-            name: 'eventRate',
-            type: 'uint256',
-            internalType: 'uint256',
-          },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getBlueprintDefinition',
-    inputs: [
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [
-      {
-        name: 'definition',
-        type: 'tuple',
-        internalType: 'struct Types.BlueprintDefinition',
-        components: [
-          {
-            name: 'metadataUri',
-            type: 'string',
-            internalType: 'string',
-          },
-          {
-            name: 'metadataHash',
-            type: 'bytes32',
-            internalType: 'bytes32',
-          },
-          {
-            name: 'manager',
-            type: 'address',
-            internalType: 'address',
-          },
-          {
-            name: 'masterManagerRevision',
-            type: 'uint32',
-            internalType: 'uint32',
-          },
-          {
-            name: 'hasConfig',
-            type: 'bool',
-            internalType: 'bool',
-          },
-          {
-            name: 'config',
-            type: 'tuple',
-            internalType: 'struct Types.BlueprintConfig',
-            components: [
-              {
-                name: 'membership',
-                type: 'uint8',
-                internalType: 'enum Types.MembershipModel',
-              },
-              {
-                name: 'pricing',
-                type: 'uint8',
-                internalType: 'enum Types.PricingModel',
-              },
-              {
-                name: 'minOperators',
-                type: 'uint32',
-                internalType: 'uint32',
-              },
-              {
-                name: 'maxOperators',
-                type: 'uint32',
-                internalType: 'uint32',
-              },
-              {
-                name: 'subscriptionRate',
-                type: 'uint256',
-                internalType: 'uint256',
-              },
-              {
-                name: 'subscriptionInterval',
-                type: 'uint64',
-                internalType: 'uint64',
-              },
-              {
-                name: 'eventRate',
-                type: 'uint256',
-                internalType: 'uint256',
-              },
-            ],
-          },
-          {
-            name: 'metadata',
-            type: 'tuple',
-            internalType: 'struct Types.BlueprintMetadata',
-            components: [
-              {
-                name: 'name',
-                type: 'string',
-                internalType: 'string',
-              },
-              {
-                name: 'description',
-                type: 'string',
-                internalType: 'string',
-              },
-              {
-                name: 'author',
-                type: 'string',
-                internalType: 'string',
-              },
-              {
-                name: 'category',
-                type: 'string',
-                internalType: 'string',
-              },
-              {
-                name: 'codeRepository',
-                type: 'string',
-                internalType: 'string',
-              },
-              {
-                name: 'logo',
-                type: 'string',
-                internalType: 'string',
-              },
-              {
-                name: 'website',
-                type: 'string',
-                internalType: 'string',
-              },
-              {
-                name: 'license',
-                type: 'string',
-                internalType: 'string',
-              },
-              {
-                name: 'profilingData',
-                type: 'string',
-                internalType: 'string',
-              },
-            ],
-          },
-          {
-            name: 'jobs',
-            type: 'tuple[]',
-            internalType: 'struct Types.JobDefinition[]',
-            components: [
-              {
-                name: 'name',
-                type: 'string',
-                internalType: 'string',
-              },
-              {
-                name: 'description',
-                type: 'string',
-                internalType: 'string',
-              },
-              {
-                name: 'metadataUri',
-                type: 'string',
-                internalType: 'string',
-              },
-              {
-                name: 'paramsSchema',
-                type: 'bytes',
-                internalType: 'bytes',
-              },
-              {
-                name: 'resultSchema',
-                type: 'bytes',
-                internalType: 'bytes',
-              },
-            ],
-          },
-          {
-            name: 'registrationSchema',
-            type: 'bytes',
-            internalType: 'bytes',
-          },
-          {
-            name: 'requestSchema',
-            type: 'bytes',
-            internalType: 'bytes',
-          },
-          {
-            name: 'sources',
-            type: 'tuple[]',
-            internalType: 'struct Types.BlueprintSource[]',
-            components: [
-              {
-                name: 'kind',
-                type: 'uint8',
-                internalType: 'enum Types.BlueprintSourceKind',
-              },
-              {
-                name: 'container',
-                type: 'tuple',
-                internalType: 'struct Types.ImageRegistrySource',
-                components: [
-                  {
-                    name: 'registry',
-                    type: 'string',
-                    internalType: 'string',
+                    "name": "kind",
+                    "type": "uint8",
+                    "internalType": "uint8"
                   },
                   {
-                    name: 'image',
-                    type: 'string',
-                    internalType: 'string',
+                    "name": "count",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "signature",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "operator",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      },
+      {
+        "name": "extensionDuration",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "forceExit",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "forceRemoveOperator",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "fundService",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "getBillableServices",
+    "inputs": [
+      {
+        "name": "serviceIds",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "billable",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBlueprint",
+    "inputs": [
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Types.Blueprint",
+        "components": [
+          {
+            "name": "owner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "manager",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "createdAt",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "operatorCount",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "membership",
+            "type": "uint8",
+            "internalType": "enum Types.MembershipModel"
+          },
+          {
+            "name": "pricing",
+            "type": "uint8",
+            "internalType": "enum Types.PricingModel"
+          },
+          {
+            "name": "active",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBlueprintConfig",
+    "inputs": [
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Types.BlueprintConfig",
+        "components": [
+          {
+            "name": "membership",
+            "type": "uint8",
+            "internalType": "enum Types.MembershipModel"
+          },
+          {
+            "name": "pricing",
+            "type": "uint8",
+            "internalType": "enum Types.PricingModel"
+          },
+          {
+            "name": "minOperators",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "maxOperators",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "subscriptionRate",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "subscriptionInterval",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "eventRate",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBlueprintDefinition",
+    "inputs": [
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "definition",
+        "type": "tuple",
+        "internalType": "struct Types.BlueprintDefinition",
+        "components": [
+          {
+            "name": "metadataUri",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "metadataHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "manager",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "masterManagerRevision",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "hasConfig",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "config",
+            "type": "tuple",
+            "internalType": "struct Types.BlueprintConfig",
+            "components": [
+              {
+                "name": "membership",
+                "type": "uint8",
+                "internalType": "enum Types.MembershipModel"
+              },
+              {
+                "name": "pricing",
+                "type": "uint8",
+                "internalType": "enum Types.PricingModel"
+              },
+              {
+                "name": "minOperators",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "maxOperators",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "subscriptionRate",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "subscriptionInterval",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "eventRate",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "metadata",
+            "type": "tuple",
+            "internalType": "struct Types.BlueprintMetadata",
+            "components": [
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "description",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "author",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "category",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "codeRepository",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "logo",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "website",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "license",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "profilingData",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "jobs",
+            "type": "tuple[]",
+            "internalType": "struct Types.JobDefinition[]",
+            "components": [
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "description",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "metadataUri",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "paramsSchema",
+                "type": "bytes",
+                "internalType": "bytes"
+              },
+              {
+                "name": "resultSchema",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "registrationSchema",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "requestSchema",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "sources",
+            "type": "tuple[]",
+            "internalType": "struct Types.BlueprintSource[]",
+            "components": [
+              {
+                "name": "kind",
+                "type": "uint8",
+                "internalType": "enum Types.BlueprintSourceKind"
+              },
+              {
+                "name": "container",
+                "type": "tuple",
+                "internalType": "struct Types.ImageRegistrySource",
+                "components": [
+                  {
+                    "name": "registry",
+                    "type": "string",
+                    "internalType": "string"
                   },
                   {
-                    name: 'tag',
-                    type: 'string',
-                    internalType: 'string',
-                  },
-                ],
-              },
-              {
-                name: 'wasm',
-                type: 'tuple',
-                internalType: 'struct Types.WasmSource',
-                components: [
-                  {
-                    name: 'runtime',
-                    type: 'uint8',
-                    internalType: 'enum Types.WasmRuntime',
+                    "name": "image",
+                    "type": "string",
+                    "internalType": "string"
                   },
                   {
-                    name: 'fetcher',
-                    type: 'uint8',
-                    internalType: 'enum Types.BlueprintFetcherKind',
+                    "name": "tag",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "wasm",
+                "type": "tuple",
+                "internalType": "struct Types.WasmSource",
+                "components": [
+                  {
+                    "name": "runtime",
+                    "type": "uint8",
+                    "internalType": "enum Types.WasmRuntime"
                   },
                   {
-                    name: 'artifactUri',
-                    type: 'string',
-                    internalType: 'string',
+                    "name": "fetcher",
+                    "type": "uint8",
+                    "internalType": "enum Types.BlueprintFetcherKind"
                   },
                   {
-                    name: 'entrypoint',
-                    type: 'string',
-                    internalType: 'string',
-                  },
-                ],
-              },
-              {
-                name: 'native',
-                type: 'tuple',
-                internalType: 'struct Types.NativeSource',
-                components: [
-                  {
-                    name: 'fetcher',
-                    type: 'uint8',
-                    internalType: 'enum Types.BlueprintFetcherKind',
+                    "name": "artifactUri",
+                    "type": "string",
+                    "internalType": "string"
                   },
                   {
-                    name: 'artifactUri',
-                    type: 'string',
-                    internalType: 'string',
+                    "name": "entrypoint",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "native",
+                "type": "tuple",
+                "internalType": "struct Types.NativeSource",
+                "components": [
+                  {
+                    "name": "fetcher",
+                    "type": "uint8",
+                    "internalType": "enum Types.BlueprintFetcherKind"
                   },
                   {
-                    name: 'entrypoint',
-                    type: 'string',
-                    internalType: 'string',
-                  },
-                ],
-              },
-              {
-                name: 'testing',
-                type: 'tuple',
-                internalType: 'struct Types.TestingSource',
-                components: [
-                  {
-                    name: 'cargoPackage',
-                    type: 'string',
-                    internalType: 'string',
+                    "name": "artifactUri",
+                    "type": "string",
+                    "internalType": "string"
                   },
                   {
-                    name: 'cargoBin',
-                    type: 'string',
-                    internalType: 'string',
+                    "name": "entrypoint",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "testing",
+                "type": "tuple",
+                "internalType": "struct Types.TestingSource",
+                "components": [
+                  {
+                    "name": "cargoPackage",
+                    "type": "string",
+                    "internalType": "string"
                   },
                   {
-                    name: 'basePath',
-                    type: 'string',
-                    internalType: 'string',
-                  },
-                ],
-              },
-              {
-                name: 'binaries',
-                type: 'tuple[]',
-                internalType: 'struct Types.BlueprintBinary[]',
-                components: [
-                  {
-                    name: 'arch',
-                    type: 'uint8',
-                    internalType: 'enum Types.BlueprintArchitecture',
+                    "name": "cargoBin",
+                    "type": "string",
+                    "internalType": "string"
                   },
                   {
-                    name: 'os',
-                    type: 'uint8',
-                    internalType: 'enum Types.BlueprintOperatingSystem',
+                    "name": "basePath",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "binaries",
+                "type": "tuple[]",
+                "internalType": "struct Types.BlueprintBinary[]",
+                "components": [
+                  {
+                    "name": "arch",
+                    "type": "uint8",
+                    "internalType": "enum Types.BlueprintArchitecture"
                   },
                   {
-                    name: 'name',
-                    type: 'string',
-                    internalType: 'string',
+                    "name": "os",
+                    "type": "uint8",
+                    "internalType": "enum Types.BlueprintOperatingSystem"
                   },
                   {
-                    name: 'sha256',
-                    type: 'bytes32',
-                    internalType: 'bytes32',
+                    "name": "name",
+                    "type": "string",
+                    "internalType": "string"
                   },
-                ],
-              },
-            ],
+                  {
+                    "name": "sha256",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  }
+                ]
+              }
+            ]
           },
           {
-            name: 'supportedMemberships',
-            type: 'uint8[]',
-            internalType: 'enum Types.MembershipModel[]',
-          },
-        ],
-      },
+            "name": "supportedMemberships",
+            "type": "uint8[]",
+            "internalType": "enum Types.MembershipModel[]"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getBlueprintResourceRequirements',
-    inputs: [
+    "type": "function",
+    "name": "getBlueprintResourceRequirements",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple[]',
-        internalType: 'struct Types.ResourceCommitment[]',
-        components: [
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct Types.ResourceCommitment[]",
+        "components": [
           {
-            name: 'kind',
-            type: 'uint8',
-            internalType: 'uint8',
+            "name": "kind",
+            "type": "uint8",
+            "internalType": "uint8"
           },
           {
-            name: 'count',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-        ],
-      },
+            "name": "count",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getExecutableSlashes',
-    inputs: [
+    "type": "function",
+    "name": "getExecutableSlashes",
+    "inputs": [
       {
-        name: 'fromId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "fromId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'toId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "toId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'ids',
-        type: 'uint64[]',
-        internalType: 'uint64[]',
-      },
+        "name": "ids",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getExitConfig',
-    inputs: [
+    "type": "function",
+    "name": "getExitConfig",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct Types.ExitConfig',
-        components: [
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Types.ExitConfig",
+        "components": [
           {
-            name: 'minCommitmentDuration',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "minCommitmentDuration",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'exitQueueDuration',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "exitQueueDuration",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'forceExitAllowed',
-            type: 'bool',
-            internalType: 'bool',
-          },
-        ],
-      },
+            "name": "forceExitAllowed",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getExitRequest',
-    inputs: [
+    "type": "function",
+    "name": "getExitRequest",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct Types.ExitRequest',
-        components: [
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Types.ExitRequest",
+        "components": [
           {
-            name: 'serviceId',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "serviceId",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'scheduledAt',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "scheduledAt",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'executeAfter',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "executeAfter",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'pending',
-            type: 'bool',
-            internalType: 'bool',
-          },
-        ],
-      },
+            "name": "pending",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getExitStatus',
-    inputs: [
+    "type": "function",
+    "name": "getExitStatus",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'uint8',
-        internalType: 'enum Types.ExitStatus',
-      },
+        "name": "",
+        "type": "uint8",
+        "internalType": "enum Types.ExitStatus"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getJobCall',
-    inputs: [
+    "type": "function",
+    "name": "getJobCall",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'callId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "callId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct Types.JobCall',
-        components: [
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Types.JobCall",
+        "components": [
           {
-            name: 'jobIndex',
-            type: 'uint8',
-            internalType: 'uint8',
+            "name": "jobIndex",
+            "type": "uint8",
+            "internalType": "uint8"
           },
           {
-            name: 'caller',
-            type: 'address',
-            internalType: 'address',
+            "name": "caller",
+            "type": "address",
+            "internalType": "address"
           },
           {
-            name: 'createdAt',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "createdAt",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'resultCount',
-            type: 'uint32',
-            internalType: 'uint32',
+            "name": "resultCount",
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            name: 'payment',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "payment",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'completed',
-            type: 'bool',
-            internalType: 'bool',
+            "name": "completed",
+            "type": "bool",
+            "internalType": "bool"
           },
           {
-            name: 'isRFQ',
-            type: 'bool',
-            internalType: 'bool',
-          },
-        ],
-      },
+            "name": "isRFQ",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getJobEventRate',
-    inputs: [
+    "type": "function",
+    "name": "getJobEventRate",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'jobIndex',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
+        "name": "jobIndex",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'rate',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "rate",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getJobQuotedOperators',
-    inputs: [
+    "type": "function",
+    "name": "getJobQuotedOperators",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'callId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "callId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getJobQuotedPrice',
-    inputs: [
+    "type": "function",
+    "name": "getJobQuotedPrice",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'callId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "callId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getOperatorBlsPubkey',
-    inputs: [
+    "type": "function",
+    "name": "getOperatorBlsPubkey",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'blsPubkey',
-        type: 'uint256[4]',
-        internalType: 'uint256[4]',
-      },
+        "name": "blsPubkey",
+        "type": "uint256[4]",
+        "internalType": "uint256[4]"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getOperatorPreferences',
-    inputs: [
+    "type": "function",
+    "name": "getOperatorPreferences",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct Types.OperatorPreferences',
-        components: [
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Types.OperatorPreferences",
+        "components": [
           {
-            name: 'ecdsaPublicKey',
-            type: 'bytes',
-            internalType: 'bytes',
+            "name": "ecdsaPublicKey",
+            "type": "bytes",
+            "internalType": "bytes"
           },
           {
-            name: 'rpcAddress',
-            type: 'string',
-            internalType: 'string',
-          },
-        ],
-      },
+            "name": "rpcAddress",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getOperatorPublicKey',
-    inputs: [
+    "type": "function",
+    "name": "getOperatorPublicKey",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getOperatorRegistration',
-    inputs: [
+    "type": "function",
+    "name": "getOperatorRegistration",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct Types.OperatorRegistration',
-        components: [
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Types.OperatorRegistration",
+        "components": [
           {
-            name: 'registeredAt',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "registeredAt",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'updatedAt',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "updatedAt",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'active',
-            type: 'bool',
-            internalType: 'bool',
+            "name": "active",
+            "type": "bool",
+            "internalType": "bool"
           },
           {
-            name: 'online',
-            type: 'bool',
-            internalType: 'bool',
-          },
-        ],
-      },
+            "name": "online",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getOperatorTotalActiveServices',
-    inputs: [
+    "type": "function",
+    "name": "getOperatorTotalActiveServices",
+    "inputs": [
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: 'count',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
+        "name": "count",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getService',
-    inputs: [
+    "type": "function",
+    "name": "getService",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct Types.Service',
-        components: [
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Types.Service",
+        "components": [
           {
-            name: 'blueprintId',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "blueprintId",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'owner',
-            type: 'address',
-            internalType: 'address',
+            "name": "owner",
+            "type": "address",
+            "internalType": "address"
           },
           {
-            name: 'createdAt',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "createdAt",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'ttl',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "ttl",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'terminatedAt',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "terminatedAt",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'lastPaymentAt',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "lastPaymentAt",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'operatorCount',
-            type: 'uint32',
-            internalType: 'uint32',
+            "name": "operatorCount",
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            name: 'minOperators',
-            type: 'uint32',
-            internalType: 'uint32',
+            "name": "minOperators",
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            name: 'maxOperators',
-            type: 'uint32',
-            internalType: 'uint32',
+            "name": "maxOperators",
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            name: 'membership',
-            type: 'uint8',
-            internalType: 'enum Types.MembershipModel',
+            "name": "membership",
+            "type": "uint8",
+            "internalType": "enum Types.MembershipModel"
           },
           {
-            name: 'pricing',
-            type: 'uint8',
-            internalType: 'enum Types.PricingModel',
+            "name": "pricing",
+            "type": "uint8",
+            "internalType": "enum Types.PricingModel"
           },
           {
-            name: 'status',
-            type: 'uint8',
-            internalType: 'enum Types.ServiceStatus',
+            "name": "status",
+            "type": "uint8",
+            "internalType": "enum Types.ServiceStatus"
           },
           {
-            name: 'confidentiality',
-            type: 'uint8',
-            internalType: 'enum Types.ConfidentialityPolicy',
-          },
-        ],
-      },
+            "name": "confidentiality",
+            "type": "uint8",
+            "internalType": "enum Types.ConfidentialityPolicy"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getServiceEscrow',
-    inputs: [
+    "type": "function",
+    "name": "getServiceEscrow",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct PaymentLib.ServiceEscrow',
-        components: [
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PaymentLib.ServiceEscrow",
+        "components": [
           {
-            name: 'token',
-            type: 'address',
-            internalType: 'address',
+            "name": "token",
+            "type": "address",
+            "internalType": "address"
           },
           {
-            name: 'balance',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "balance",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'totalDeposited',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "totalDeposited",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'totalReleased',
-            type: 'uint256',
-            internalType: 'uint256',
-          },
-        ],
-      },
+            "name": "totalReleased",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getServiceOperator',
-    inputs: [
+    "type": "function",
+    "name": "getServiceOperator",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct Types.ServiceOperator',
-        components: [
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Types.ServiceOperator",
+        "components": [
           {
-            name: 'exposureBps',
-            type: 'uint16',
-            internalType: 'uint16',
+            "name": "exposureBps",
+            "type": "uint16",
+            "internalType": "uint16"
           },
           {
-            name: 'joinedAt',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "joinedAt",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'leftAt',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "leftAt",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'active',
-            type: 'bool',
-            internalType: 'bool',
-          },
-        ],
-      },
+            "name": "active",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getServiceOperators',
-    inputs: [
+    "type": "function",
+    "name": "getServiceOperators",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getServiceRequest',
-    inputs: [
+    "type": "function",
+    "name": "getServiceRequest",
+    "inputs": [
       {
-        name: 'requestId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "requestId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct Types.ServiceRequest',
-        components: [
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Types.ServiceRequest",
+        "components": [
           {
-            name: 'blueprintId',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "blueprintId",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'requester',
-            type: 'address',
-            internalType: 'address',
+            "name": "requester",
+            "type": "address",
+            "internalType": "address"
           },
           {
-            name: 'createdAt',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "createdAt",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'ttl',
-            type: 'uint64',
-            internalType: 'uint64',
+            "name": "ttl",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'operatorCount',
-            type: 'uint32',
-            internalType: 'uint32',
+            "name": "operatorCount",
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            name: 'approvalCount',
-            type: 'uint32',
-            internalType: 'uint32',
+            "name": "approvalCount",
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            name: 'paymentToken',
-            type: 'address',
-            internalType: 'address',
+            "name": "paymentToken",
+            "type": "address",
+            "internalType": "address"
           },
           {
-            name: 'paymentAmount',
-            type: 'uint256',
-            internalType: 'uint256',
+            "name": "paymentAmount",
+            "type": "uint256",
+            "internalType": "uint256"
           },
           {
-            name: 'membership',
-            type: 'uint8',
-            internalType: 'enum Types.MembershipModel',
+            "name": "membership",
+            "type": "uint8",
+            "internalType": "enum Types.MembershipModel"
           },
           {
-            name: 'minOperators',
-            type: 'uint32',
-            internalType: 'uint32',
+            "name": "minOperators",
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            name: 'maxOperators',
-            type: 'uint32',
-            internalType: 'uint32',
+            "name": "maxOperators",
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            name: 'rejected',
-            type: 'bool',
-            internalType: 'bool',
+            "name": "rejected",
+            "type": "bool",
+            "internalType": "bool"
           },
           {
-            name: 'activated',
-            type: 'bool',
-            internalType: 'bool',
+            "name": "confidentiality",
+            "type": "uint8",
+            "internalType": "enum Types.ConfidentialityPolicy"
           },
           {
-            name: 'confidentiality',
-            type: 'uint8',
-            internalType: 'enum Types.ConfidentialityPolicy',
-          },
-        ],
-      },
+            "name": "activated",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getServiceRequestResourceRequirements',
-    inputs: [
+    "type": "function",
+    "name": "getServiceRequestResourceRequirements",
+    "inputs": [
       {
-        name: 'requestId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "requestId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple[]',
-        internalType: 'struct Types.ResourceCommitment[]',
-        components: [
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct Types.ResourceCommitment[]",
+        "components": [
           {
-            name: 'kind',
-            type: 'uint8',
-            internalType: 'uint8',
+            "name": "kind",
+            "type": "uint8",
+            "internalType": "uint8"
           },
           {
-            name: 'count',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-        ],
-      },
+            "name": "count",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getServiceRequestSecurityCommitments',
-    inputs: [
+    "type": "function",
+    "name": "getServiceRequestSecurityCommitments",
+    "inputs": [
       {
-        name: 'requestId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "requestId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'tuple[]',
-        internalType: 'struct Types.AssetSecurityCommitment[]',
-        components: [
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct Types.AssetSecurityCommitment[]",
+        "components": [
           {
-            name: 'asset',
-            type: 'tuple',
-            internalType: 'struct Types.Asset',
-            components: [
+            "name": "asset",
+            "type": "tuple",
+            "internalType": "struct Types.Asset",
+            "components": [
               {
-                name: 'kind',
-                type: 'uint8',
-                internalType: 'enum Types.AssetKind',
-              },
-              {
-                name: 'token',
-                type: 'address',
-                internalType: 'address',
-              },
-            ],
-          },
-          {
-            name: 'exposureBps',
-            type: 'uint16',
-            internalType: 'uint16',
-          },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getServiceRequestSecurityRequirements',
-    inputs: [
-      {
-        name: 'requestId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple[]',
-        internalType: 'struct Types.AssetSecurityRequirement[]',
-        components: [
-          {
-            name: 'asset',
-            type: 'tuple',
-            internalType: 'struct Types.Asset',
-            components: [
-              {
-                name: 'kind',
-                type: 'uint8',
-                internalType: 'enum Types.AssetKind',
+                "name": "kind",
+                "type": "uint8",
+                "internalType": "enum Types.AssetKind"
               },
               {
-                name: 'token',
-                type: 'address',
-                internalType: 'address',
-              },
-            ],
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
           },
           {
-            name: 'minExposureBps',
-            type: 'uint16',
-            internalType: 'uint16',
-          },
-          {
-            name: 'maxExposureBps',
-            type: 'uint16',
-            internalType: 'uint16',
-          },
-        ],
-      },
+            "name": "exposureBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getServiceResourceCommitmentHash',
-    inputs: [
+    "type": "function",
+    "name": "getServiceRequestSecurityRequirements",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "requestId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'bytes32',
-        internalType: 'bytes32',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getServiceSecurityCommitments',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple[]',
-        internalType: 'struct Types.AssetSecurityCommitment[]',
-        components: [
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct Types.AssetSecurityRequirement[]",
+        "components": [
           {
-            name: 'asset',
-            type: 'tuple',
-            internalType: 'struct Types.Asset',
-            components: [
+            "name": "asset",
+            "type": "tuple",
+            "internalType": "struct Types.Asset",
+            "components": [
               {
-                name: 'kind',
-                type: 'uint8',
-                internalType: 'enum Types.AssetKind',
+                "name": "kind",
+                "type": "uint8",
+                "internalType": "enum Types.AssetKind"
               },
               {
-                name: 'token',
-                type: 'address',
-                internalType: 'address',
-              },
-            ],
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
           },
           {
-            name: 'exposureBps',
-            type: 'uint16',
-            internalType: 'uint16',
+            "name": "minExposureBps",
+            "type": "uint16",
+            "internalType": "uint16"
           },
-        ],
-      },
+          {
+            "name": "maxExposureBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'getServiceSecurityRequirements',
-    inputs: [
+    "type": "function",
+    "name": "getServiceResourceCommitmentHash",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
-    ],
-    outputs: [
       {
-        name: '',
-        type: 'tuple[]',
-        internalType: 'struct Types.AssetSecurityRequirement[]',
-        components: [
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getServiceSecurityCommitments",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct Types.AssetSecurityCommitment[]",
+        "components": [
           {
-            name: 'asset',
-            type: 'tuple',
-            internalType: 'struct Types.Asset',
-            components: [
+            "name": "asset",
+            "type": "tuple",
+            "internalType": "struct Types.Asset",
+            "components": [
               {
-                name: 'kind',
-                type: 'uint8',
-                internalType: 'enum Types.AssetKind',
-              },
-              {
-                name: 'token',
-                type: 'address',
-                internalType: 'address',
-              },
-            ],
-          },
-          {
-            name: 'minExposureBps',
-            type: 'uint16',
-            internalType: 'uint16',
-          },
-          {
-            name: 'maxExposureBps',
-            type: 'uint16',
-            internalType: 'uint16',
-          },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getSlashConfig',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct SlashingLib.SlashConfig',
-        components: [
-          {
-            name: 'disputeWindow',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-          {
-            name: 'instantSlashEnabled',
-            type: 'bool',
-            internalType: 'bool',
-          },
-          {
-            name: 'maxSlashBps',
-            type: 'uint16',
-            internalType: 'uint16',
-          },
-          {
-            name: 'disputeResolutionDeadline',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-          {
-            name: 'disputeBond',
-            type: 'uint256',
-            internalType: 'uint256',
-          },
-          {
-            name: 'maxPendingSlashesPerOperator',
-            type: 'uint16',
-            internalType: 'uint16',
-          },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getSlashProposal',
-    inputs: [
-      {
-        name: 'slashId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple',
-        internalType: 'struct SlashingLib.SlashProposal',
-        components: [
-          {
-            name: 'serviceId',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-          {
-            name: 'operator',
-            type: 'address',
-            internalType: 'address',
-          },
-          {
-            name: 'proposer',
-            type: 'address',
-            internalType: 'address',
-          },
-          {
-            name: 'slashBps',
-            type: 'uint16',
-            internalType: 'uint16',
-          },
-          {
-            name: 'effectiveSlashBps',
-            type: 'uint16',
-            internalType: 'uint16',
-          },
-          {
-            name: 'evidence',
-            type: 'bytes32',
-            internalType: 'bytes32',
-          },
-          {
-            name: 'proposedAt',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-          {
-            name: 'executeAfter',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-          {
-            name: 'status',
-            type: 'uint8',
-            internalType: 'enum SlashingLib.SlashStatus',
-          },
-          {
-            name: 'disputeReason',
-            type: 'string',
-            internalType: 'string',
-          },
-          {
-            name: 'disputer',
-            type: 'address',
-            internalType: 'address',
-          },
-          {
-            name: 'disputeBond',
-            type: 'uint256',
-            internalType: 'uint256',
-          },
-          {
-            name: 'disputedAt',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-          {
-            name: 'disputeDeadline',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getTeeCommitmentRoot',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'bytes32',
-        internalType: 'bytes32',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'isOperatorRegistered',
-    inputs: [
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'bool',
-        internalType: 'bool',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'isPermittedCaller',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'caller',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'bool',
-        internalType: 'bool',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'isServiceActive',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'bool',
-        internalType: 'bool',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'isServiceOperator',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'bool',
-        internalType: 'bool',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'joinService',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'exposureBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'joinServiceWithCommitments',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'exposureBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-      {
-        name: 'commitments',
-        type: 'tuple[]',
-        internalType: 'struct Types.AssetSecurityCommitment[]',
-        components: [
-          {
-            name: 'asset',
-            type: 'tuple',
-            internalType: 'struct Types.Asset',
-            components: [
-              {
-                name: 'kind',
-                type: 'uint8',
-                internalType: 'enum Types.AssetKind',
+                "name": "kind",
+                "type": "uint8",
+                "internalType": "enum Types.AssetKind"
               },
               {
-                name: 'token',
-                type: 'address',
-                internalType: 'address',
-              },
-            ],
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
           },
           {
-            name: 'exposureBps',
-            type: 'uint16',
-            internalType: 'uint16',
-          },
-        ],
-      },
+            "name": "exposureBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          }
+        ]
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'leaveService',
-    inputs: [
+    "type": "function",
+    "name": "getServiceSecurityRequirements",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'maxBlueprintsPerOperator',
-    inputs: [],
-    outputs: [
+    "outputs": [
       {
-        name: '',
-        type: 'uint32',
-        internalType: 'uint32',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'mbsmRegistry',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'metricsRecorder',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'operatorStatusRegistry',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'pause',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'paymentSplit',
-    inputs: [],
-    outputs: [
-      {
-        name: 'developerBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-      {
-        name: 'protocolBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-      {
-        name: 'operatorBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-      {
-        name: 'stakerBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'pendingRewards',
-    inputs: [
-      {
-        name: 'account',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'pendingRewards',
-    inputs: [
-      {
-        name: 'account',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'preRegister',
-    inputs: [
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'priceOracle',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'proposeSlash',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'slashBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-      {
-        name: 'evidence',
-        type: 'bytes32',
-        internalType: 'bytes32',
-      },
-    ],
-    outputs: [
-      {
-        name: 'slashId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'registerOperator',
-    inputs: [
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'ecdsaPublicKey',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-      {
-        name: 'rpcAddress',
-        type: 'string',
-        internalType: 'string',
-      },
-      {
-        name: 'registrationInputs',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'registerOperator',
-    inputs: [
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'ecdsaPublicKey',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-      {
-        name: 'rpcAddress',
-        type: 'string',
-        internalType: 'string',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'rejectService',
-    inputs: [
-      {
-        name: 'requestId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'removePermittedCaller',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'caller',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'requestService',
-    inputs: [
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operators',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
-      {
-        name: 'config',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-      {
-        name: 'permittedCallers',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
-      {
-        name: 'ttl',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'paymentToken',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'paymentAmount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: 'confidentiality',
-        type: 'uint8',
-        internalType: 'enum Types.ConfidentialityPolicy',
-      },
-    ],
-    outputs: [
-      {
-        name: 'requestId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    stateMutability: 'payable',
-  },
-  {
-    type: 'function',
-    name: 'requestServiceWithExposure',
-    inputs: [
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operators',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
-      {
-        name: 'exposureBps',
-        type: 'uint16[]',
-        internalType: 'uint16[]',
-      },
-      {
-        name: 'config',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-      {
-        name: 'permittedCallers',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
-      {
-        name: 'ttl',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'paymentToken',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'paymentAmount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: 'confidentiality',
-        type: 'uint8',
-        internalType: 'enum Types.ConfidentialityPolicy',
-      },
-    ],
-    outputs: [
-      {
-        name: 'requestId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    stateMutability: 'payable',
-  },
-  {
-    type: 'function',
-    name: 'requestServiceWithSecurity',
-    inputs: [
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'operators',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
-      {
-        name: 'securityRequirements',
-        type: 'tuple[]',
-        internalType: 'struct Types.AssetSecurityRequirement[]',
-        components: [
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct Types.AssetSecurityRequirement[]",
+        "components": [
           {
-            name: 'asset',
-            type: 'tuple',
-            internalType: 'struct Types.Asset',
-            components: [
+            "name": "asset",
+            "type": "tuple",
+            "internalType": "struct Types.Asset",
+            "components": [
               {
-                name: 'kind',
-                type: 'uint8',
-                internalType: 'enum Types.AssetKind',
+                "name": "kind",
+                "type": "uint8",
+                "internalType": "enum Types.AssetKind"
               },
               {
-                name: 'token',
-                type: 'address',
-                internalType: 'address',
-              },
-            ],
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
           },
           {
-            name: 'minExposureBps',
-            type: 'uint16',
-            internalType: 'uint16',
+            "name": "minExposureBps",
+            "type": "uint16",
+            "internalType": "uint16"
           },
           {
-            name: 'maxExposureBps',
-            type: 'uint16',
-            internalType: 'uint16',
-          },
-        ],
-      },
-      {
-        name: 'config',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-      {
-        name: 'permittedCallers',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
-      {
-        name: 'ttl',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'paymentToken',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: 'paymentAmount',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: 'confidentiality',
-        type: 'uint8',
-        internalType: 'enum Types.ConfidentialityPolicy',
-      },
+            "name": "maxExposureBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          }
+        ]
+      }
     ],
-    outputs: [
-      {
-        name: 'requestId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    stateMutability: 'payable',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'rewardTokens',
-    inputs: [
+    "type": "function",
+    "name": "getSlashConfig",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'account',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [
-      {
-        name: '',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'rewardVaults',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'scheduleExit',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'serviceCount',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'serviceFeeDistributor',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'setBlueprintResourceRequirements',
-    inputs: [
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'requirements',
-        type: 'tuple[]',
-        internalType: 'struct Types.ResourceCommitment[]',
-        components: [
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct SlashingLib.SlashConfig",
+        "components": [
           {
-            name: 'kind',
-            type: 'uint8',
-            internalType: 'uint8',
+            "name": "disputeWindow",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'count',
-            type: 'uint64',
-            internalType: 'uint64',
-          },
-        ],
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setDefaultTntMinExposureBps',
-    inputs: [
-      {
-        name: 'minExposureBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setJobEventRates',
-    inputs: [
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'jobIndexes',
-        type: 'uint8[]',
-        internalType: 'uint8[]',
-      },
-      {
-        name: 'rates',
-        type: 'uint256[]',
-        internalType: 'uint256[]',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setMBSMRegistry',
-    inputs: [
-      {
-        name: 'registry',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setMaxBlueprintsPerOperator',
-    inputs: [
-      {
-        name: 'newMax',
-        type: 'uint32',
-        internalType: 'uint32',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setMetricsRecorder',
-    inputs: [
-      {
-        name: 'recorder',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setOperatorStatusRegistry',
-    inputs: [
-      {
-        name: 'registry',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setPaymentSplit',
-    inputs: [
-      {
-        name: 'split',
-        type: 'tuple',
-        internalType: 'struct Types.PaymentSplit',
-        components: [
-          {
-            name: 'developerBps',
-            type: 'uint16',
-            internalType: 'uint16',
+            "name": "instantSlashEnabled",
+            "type": "bool",
+            "internalType": "bool"
           },
           {
-            name: 'protocolBps',
-            type: 'uint16',
-            internalType: 'uint16',
+            "name": "maxSlashBps",
+            "type": "uint16",
+            "internalType": "uint16"
           },
           {
-            name: 'operatorBps',
-            type: 'uint16',
-            internalType: 'uint16',
+            "name": "disputeResolutionDeadline",
+            "type": "uint64",
+            "internalType": "uint64"
           },
           {
-            name: 'stakerBps',
-            type: 'uint16',
-            internalType: 'uint16',
+            "name": "disputeBond",
+            "type": "uint256",
+            "internalType": "uint256"
           },
-        ],
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setPriceOracle',
-    inputs: [
-      {
-        name: 'oracle',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setRewardVaults',
-    inputs: [
-      {
-        name: 'vaults',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setServiceFeeDistributor',
-    inputs: [
-      {
-        name: 'distributor',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setSlashConfig',
-    inputs: [
-      {
-        name: 'disputeWindow',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'instantSlashEnabled',
-        type: 'bool',
-        internalType: 'bool',
-      },
-      {
-        name: 'maxSlashBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-      {
-        name: 'disputeResolutionDeadline',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'disputeBond',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: 'maxPendingSlashesPerOperator',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setStaking',
-    inputs: [
-      {
-        name: 'staking',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setTntPaymentDiscountBps',
-    inputs: [
-      {
-        name: 'discountBps',
-        type: 'uint16',
-        internalType: 'uint16',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setTntToken',
-    inputs: [
-      {
-        name: 'token',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'setTreasury',
-    inputs: [
-      {
-        name: 'treasury',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'submitAggregatedResult',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'callId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'output',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-      {
-        name: 'signerBitmap',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: 'aggregatedSignature',
-        type: 'uint256[2]',
-        internalType: 'uint256[2]',
-      },
-      {
-        name: 'aggregatedPubkey',
-        type: 'uint256[4]',
-        internalType: 'uint256[4]',
-      },
-    ],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'submitJob',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'jobIndex',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
-      {
-        name: 'inputs',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-    ],
-    outputs: [
-      {
-        name: 'callId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-    ],
-    stateMutability: 'payable',
-  },
-  {
-    type: 'function',
-    name: 'submitJobFromQuote',
-    inputs: [
-      {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'jobIndex',
-        type: 'uint8',
-        internalType: 'uint8',
-      },
-      {
-        name: 'inputs',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-      {
-        name: 'quotes',
-        type: 'tuple[]',
-        internalType: 'struct Types.SignedJobQuote[]',
-        components: [
           {
-            name: 'details',
-            type: 'tuple',
-            internalType: 'struct Types.JobQuoteDetails',
-            components: [
+            "name": "maxPendingSlashesPerOperator",
+            "type": "uint16",
+            "internalType": "uint16"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getSlashProposal",
+    "inputs": [
+      {
+        "name": "slashId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct SlashingLib.SlashProposal",
+        "components": [
+          {
+            "name": "serviceId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "operator",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "proposer",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "slashBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "effectiveSlashBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "evidence",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "proposedAt",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "executeAfter",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "status",
+            "type": "uint8",
+            "internalType": "enum SlashingLib.SlashStatus"
+          },
+          {
+            "name": "disputeReason",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "disputer",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "disputeBond",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "disputedAt",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "disputeDeadline",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getTeeCommitmentRoot",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isOperatorRegistered",
+    "inputs": [
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isPermittedCaller",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "caller",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isServiceActive",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isServiceOperator",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "joinService",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "exposureBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "joinServiceWithCommitments",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "exposureBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "commitments",
+        "type": "tuple[]",
+        "internalType": "struct Types.AssetSecurityCommitment[]",
+        "components": [
+          {
+            "name": "asset",
+            "type": "tuple",
+            "internalType": "struct Types.Asset",
+            "components": [
               {
-                name: 'serviceId',
-                type: 'uint64',
-                internalType: 'uint64',
+                "name": "kind",
+                "type": "uint8",
+                "internalType": "enum Types.AssetKind"
               },
               {
-                name: 'jobIndex',
-                type: 'uint8',
-                internalType: 'uint8',
-              },
-              {
-                name: 'price',
-                type: 'uint256',
-                internalType: 'uint256',
-              },
-              {
-                name: 'timestamp',
-                type: 'uint64',
-                internalType: 'uint64',
-              },
-              {
-                name: 'expiry',
-                type: 'uint64',
-                internalType: 'uint64',
-              },
-              {
-                name: 'confidentiality',
-                type: 'uint8',
-                internalType: 'uint8',
-              },
-            ],
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
           },
           {
-            name: 'signature',
-            type: 'bytes',
-            internalType: 'bytes',
+            "name": "exposureBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "leaveService",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "maxBlueprintsPerOperator",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "mbsmRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "metricsRecorder",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "operatorStatusRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "paymentSplit",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "developerBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "protocolBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "operatorBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "stakerBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pendingRewards",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pendingRewards",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "preRegister",
+    "inputs": [
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "priceOracle",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proposeSlash",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "slashBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "evidence",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "slashId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "registerOperator",
+    "inputs": [
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "ecdsaPublicKey",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "rpcAddress",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "registrationInputs",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "registerOperator",
+    "inputs": [
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "ecdsaPublicKey",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "rpcAddress",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "rejectService",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "removePermittedCaller",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "caller",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "requestService",
+    "inputs": [
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "operators",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "config",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "permittedCallers",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "ttl",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "paymentToken",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "paymentAmount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "confidentiality",
+        "type": "uint8",
+        "internalType": "enum Types.ConfidentialityPolicy"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "requestId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "requestServiceWithExposure",
+    "inputs": [
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "operators",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "exposureBps",
+        "type": "uint16[]",
+        "internalType": "uint16[]"
+      },
+      {
+        "name": "config",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "permittedCallers",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "ttl",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "paymentToken",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "paymentAmount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "confidentiality",
+        "type": "uint8",
+        "internalType": "enum Types.ConfidentialityPolicy"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "requestId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "requestServiceWithSecurity",
+    "inputs": [
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "operators",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "securityRequirements",
+        "type": "tuple[]",
+        "internalType": "struct Types.AssetSecurityRequirement[]",
+        "components": [
+          {
+            "name": "asset",
+            "type": "tuple",
+            "internalType": "struct Types.Asset",
+            "components": [
+              {
+                "name": "kind",
+                "type": "uint8",
+                "internalType": "enum Types.AssetKind"
+              },
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
           },
           {
-            name: 'operator',
-            type: 'address',
-            internalType: 'address',
+            "name": "minExposureBps",
+            "type": "uint16",
+            "internalType": "uint16"
           },
-        ],
+          {
+            "name": "maxExposureBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          }
+        ]
       },
-    ],
-    outputs: [
       {
-        name: 'callId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "config",
+        "type": "bytes",
+        "internalType": "bytes"
       },
+      {
+        "name": "permittedCallers",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "ttl",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "paymentToken",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "paymentAmount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "confidentiality",
+        "type": "uint8",
+        "internalType": "enum Types.ConfidentialityPolicy"
+      }
     ],
-    stateMutability: 'payable',
+    "outputs": [
+      {
+        "name": "requestId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "payable"
   },
   {
-    type: 'function',
-    name: 'submitResult',
-    inputs: [
+    "type": "function",
+    "name": "rewardTokens",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'callId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'result',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'submitResults',
-    inputs: [
+    "type": "function",
+    "name": "rewardVaults",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'callIds',
-        type: 'uint64[]',
-        internalType: 'uint64[]',
-      },
-      {
-        name: 'results',
-        type: 'bytes[]',
-        internalType: 'bytes[]',
-      },
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'teeNonceFor',
-    inputs: [
+    "type": "function",
+    "name": "scheduleExit",
+    "inputs": [
       {
-        name: 'requestId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [
-      {
-        name: '',
-        type: 'bytes32',
-        internalType: 'bytes32',
-      },
-    ],
-    stateMutability: 'view',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'terminateService',
-    inputs: [
+    "type": "function",
+    "name": "serviceCount",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'terminateServiceForNonPayment',
-    inputs: [
+    "type": "function",
+    "name": "serviceFeeDistributor",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "stateMutability": "view"
   },
   {
-    type: 'function',
-    name: 'tntPaymentDiscountBps',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "setBlueprintResourceRequirements",
+    "inputs": [
       {
-        name: '',
-        type: 'uint16',
-        internalType: 'uint16',
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "requirements",
+        "type": "tuple[]",
+        "internalType": "struct Types.ResourceCommitment[]",
+        "components": [
+          {
+            "name": "kind",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "count",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
     ],
-    stateMutability: 'view',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'tntToken',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "setDefaultTntMinExposureBps",
+    "inputs": [
       {
-        name: '',
-        type: 'address',
-        internalType: 'address',
-      },
+        "name": "minExposureBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    stateMutability: 'view',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'transferBlueprint',
-    inputs: [
+    "type": "function",
+    "name": "setJobEventRates",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'newOwner',
-        type: 'address',
-        internalType: 'address',
+        "name": "jobIndexes",
+        "type": "uint8[]",
+        "internalType": "uint8[]"
       },
+      {
+        "name": "rates",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'treasury',
-    inputs: [],
-    outputs: [
+    "type": "function",
+    "name": "setMBSMRegistry",
+    "inputs": [
       {
-        name: '',
-        type: 'address',
-        internalType: 'address payable',
-      },
+        "name": "registry",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    stateMutability: 'view',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'unpause',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "type": "function",
+    "name": "setMaxBlueprintsPerOperator",
+    "inputs": [
+      {
+        "name": "newMax",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'unregisterOperator',
-    inputs: [
+    "type": "function",
+    "name": "setMetricsRecorder",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "recorder",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'updateBlueprint',
-    inputs: [
+    "type": "function",
+    "name": "setOperatorStatusRegistry",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'metadataUri',
-        type: 'string',
-        internalType: 'string',
-      },
-      {
-        name: 'metadataHash',
-        type: 'bytes32',
-        internalType: 'bytes32',
-      },
+        "name": "registry",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'updateOperatorPreferences',
-    inputs: [
+    "type": "function",
+    "name": "setPaymentSplit",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
-      {
-        name: 'ecdsaPublicKey',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-      {
-        name: 'rpcAddress',
-        type: 'string',
-        internalType: 'string',
-      },
+        "name": "split",
+        "type": "tuple",
+        "internalType": "struct Types.PaymentSplit",
+        "components": [
+          {
+            "name": "developerBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "protocolBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "operatorBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "stakerBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          }
+        ]
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'function',
-    name: 'withdrawRemainingEscrow',
-    inputs: [
+    "type": "function",
+    "name": "setPriceOracle",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        internalType: 'uint64',
-      },
+        "name": "oracle",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    outputs: [],
-    stateMutability: 'nonpayable',
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'BlueprintCreated',
-    inputs: [
+    "type": "function",
+    "name": "setRewardVaults",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'owner',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'manager',
-        type: 'address',
-        indexed: false,
-        internalType: 'address',
-      },
-      {
-        name: 'metadataUri',
-        type: 'string',
-        indexed: false,
-        internalType: 'string',
-      },
-      {
-        name: 'metadataHash',
-        type: 'bytes32',
-        indexed: false,
-        internalType: 'bytes32',
-      },
+        "name": "vaults",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'BlueprintDeactivated',
-    inputs: [
+    "type": "function",
+    "name": "setServiceFeeDistributor",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
+        "name": "distributor",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'BlueprintResourceRequirementsSet',
-    inputs: [
+    "type": "function",
+    "name": "setSlashConfig",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "disputeWindow",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'count',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
+        "name": "instantSlashEnabled",
+        "type": "bool",
+        "internalType": "bool"
       },
+      {
+        "name": "maxSlashBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "disputeResolutionDeadline",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "disputeBond",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxPendingSlashesPerOperator",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'BlueprintTransferred',
-    inputs: [
+    "type": "function",
+    "name": "setStaking",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'from',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'to',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
+        "name": "staking",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'BlueprintUpdated',
-    inputs: [
+    "type": "function",
+    "name": "setTntPaymentDiscountBps",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'metadataUri',
-        type: 'string',
-        indexed: false,
-        internalType: 'string',
-      },
-      {
-        name: 'metadataHash',
-        type: 'bytes32',
-        indexed: false,
-        internalType: 'bytes32',
-      },
+        "name": "discountBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'JobCompleted',
-    inputs: [
+    "type": "function",
+    "name": "setTntToken",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'callId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'JobResultSubmitted',
-    inputs: [
+    "type": "function",
+    "name": "setTreasury",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'callId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'result',
-        type: 'bytes',
-        indexed: false,
-        internalType: 'bytes',
-      },
+        "name": "treasury",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'JobSubmitted',
-    inputs: [
+    "type": "function",
+    "name": "submitAggregatedResult",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'callId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "callId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'jobIndex',
-        type: 'uint8',
-        indexed: true,
-        internalType: 'uint8',
+        "name": "output",
+        "type": "bytes",
+        "internalType": "bytes"
       },
       {
-        name: 'caller',
-        type: 'address',
-        indexed: false,
-        internalType: 'address',
+        "name": "signerBitmap",
+        "type": "uint256",
+        "internalType": "uint256"
       },
       {
-        name: 'inputs',
-        type: 'bytes',
-        indexed: false,
-        internalType: 'bytes',
+        "name": "aggregatedSignature",
+        "type": "uint256[2]",
+        "internalType": "uint256[2]"
       },
+      {
+        "name": "aggregatedPubkey",
+        "type": "uint256[4]",
+        "internalType": "uint256[4]"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'JobSubmittedFromQuote',
-    inputs: [
+    "type": "function",
+    "name": "submitJob",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'callId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "jobIndex",
+        "type": "uint8",
+        "internalType": "uint8"
       },
       {
-        name: 'jobIndex',
-        type: 'uint8',
-        indexed: false,
-        internalType: 'uint8',
-      },
-      {
-        name: 'caller',
-        type: 'address',
-        indexed: false,
-        internalType: 'address',
-      },
-      {
-        name: 'quotedOperators',
-        type: 'address[]',
-        indexed: false,
-        internalType: 'address[]',
-      },
-      {
-        name: 'totalPrice',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'inputs',
-        type: 'bytes',
-        indexed: false,
-        internalType: 'bytes',
-      },
+        "name": "inputs",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
     ],
-    anonymous: false,
+    "outputs": [
+      {
+        "name": "callId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "payable"
   },
   {
-    type: 'event',
-    name: 'OperatorJoinedService',
-    inputs: [
+    "type": "function",
+    "name": "submitJobFromQuote",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "jobIndex",
+        "type": "uint8",
+        "internalType": "uint8"
       },
       {
-        name: 'exposureBps',
-        type: 'uint16',
-        indexed: false,
-        internalType: 'uint16',
+        "name": "inputs",
+        "type": "bytes",
+        "internalType": "bytes"
       },
+      {
+        "name": "quotes",
+        "type": "tuple[]",
+        "internalType": "struct Types.SignedJobQuote[]",
+        "components": [
+          {
+            "name": "details",
+            "type": "tuple",
+            "internalType": "struct Types.JobQuoteDetails",
+            "components": [
+              {
+                "name": "requester",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "serviceId",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "jobIndex",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "price",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "timestamp",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "expiry",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "confidentiality",
+                "type": "uint8",
+                "internalType": "uint8"
+              }
+            ]
+          },
+          {
+            "name": "signature",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "operator",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      }
     ],
-    anonymous: false,
+    "outputs": [
+      {
+        "name": "callId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "payable"
   },
   {
-    type: 'event',
-    name: 'OperatorLeftService',
-    inputs: [
+    "type": "function",
+    "name": "submitResult",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "callId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "result",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'OperatorPreferencesUpdated',
-    inputs: [
+    "type": "function",
+    "name": "submitResults",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "callIds",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
       },
       {
-        name: 'ecdsaPublicKey',
-        type: 'bytes',
-        indexed: false,
-        internalType: 'bytes',
-      },
-      {
-        name: 'rpcAddress',
-        type: 'string',
-        indexed: false,
-        internalType: 'string',
-      },
+        "name": "results",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'OperatorRegistered',
-    inputs: [
+    "type": "function",
+    "name": "teeNonceFor",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'ecdsaPublicKey',
-        type: 'bytes',
-        indexed: false,
-        internalType: 'bytes',
-      },
-      {
-        name: 'rpcAddress',
-        type: 'string',
-        indexed: false,
-        internalType: 'string',
-      },
+        "name": "requestId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    anonymous: false,
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'OperatorRewardAccrued',
-    inputs: [
+    "type": "function",
+    "name": "terminateService",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'token',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: false,
-        internalType: 'uint64',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'OperatorUnregistered',
-    inputs: [
+    "type": "function",
+    "name": "terminateServiceForNonPayment",
+    "inputs": [
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'PaymentDistributed',
-    inputs: [
+    "type": "function",
+    "name": "tntPaymentDiscountBps",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'token',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'grossAmount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'developerRecipient',
-        type: 'address',
-        indexed: false,
-        internalType: 'address',
-      },
-      {
-        name: 'developerAmount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'protocolAmount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'operatorPoolAmount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'stakerPoolAmount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    anonymous: false,
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'RewardsClaimed',
-    inputs: [
+    "type": "function",
+    "name": "tntToken",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'account',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'token',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'amount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'ServiceActivated',
-    inputs: [
+    "type": "function",
+    "name": "transferBlueprint",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'requestId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'confidentiality',
-        type: 'uint8',
-        indexed: false,
-        internalType: 'enum Types.ConfidentialityPolicy',
-      },
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'ServiceApproved',
-    inputs: [
+    "type": "function",
+    "name": "treasury",
+    "inputs": [],
+    "outputs": [
       {
-        name: 'requestId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
+        "name": "",
+        "type": "address",
+        "internalType": "address payable"
+      }
     ],
-    anonymous: false,
+    "stateMutability": "view"
   },
   {
-    type: 'event',
-    name: 'ServiceRejected',
-    inputs: [
-      {
-        name: 'requestId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-    ],
-    anonymous: false,
+    "type": "function",
+    "name": "unpause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'ServiceRequested',
-    inputs: [
+    "type": "function",
+    "name": "unregisterOperator",
+    "inputs": [
       {
-        name: 'requestId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'requester',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'confidentiality',
-        type: 'uint8',
-        indexed: false,
-        internalType: 'enum Types.ConfidentialityPolicy',
-      },
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'ServiceRequestedWithSecurity',
-    inputs: [
+    "type": "function",
+    "name": "updateBlueprint",
+    "inputs": [
       {
-        name: 'requestId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
       {
-        name: 'blueprintId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "metadataUri",
+        "type": "string",
+        "internalType": "string"
       },
       {
-        name: 'requester',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'confidentiality',
-        type: 'uint8',
-        indexed: false,
-        internalType: 'enum Types.ConfidentialityPolicy',
-      },
+        "name": "metadataHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'ServiceTerminated',
-    inputs: [
+    "type": "function",
+    "name": "updateOperatorPreferences",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "blueprintId",
+        "type": "uint64",
+        "internalType": "uint64"
       },
+      {
+        "name": "ecdsaPublicKey",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "rpcAddress",
+        "type": "string",
+        "internalType": "string"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'ServiceTerminatedForNonPayment',
-    inputs: [
+    "type": "function",
+    "name": "withdrawRemainingEscrow",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'triggeredBy',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'dueAt',
-        type: 'uint64',
-        indexed: false,
-        internalType: 'uint64',
-      },
-      {
-        name: 'graceEndsAt',
-        type: 'uint64',
-        indexed: false,
-        internalType: 'uint64',
-      },
-      {
-        name: 'requiredAmount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'escrowBalance',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
+        "name": "serviceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
     ],
-    anonymous: false,
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    type: 'event',
-    name: 'SlashExecuted',
-    inputs: [
+    "type": "event",
+    "name": "BlueprintCreated",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
       },
       {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
       },
       {
-        name: 'amount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
+        "name": "manager",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
       },
+      {
+        "name": "metadataUri",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "metadataHash",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      }
     ],
-    anonymous: false,
+    "anonymous": false
   },
   {
-    type: 'event',
-    name: 'SlashProposed',
-    inputs: [
+    "type": "event",
+    "name": "BlueprintDeactivated",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
-      },
-      {
-        name: 'operator',
-        type: 'address',
-        indexed: true,
-        internalType: 'address',
-      },
-      {
-        name: 'slashBps',
-        type: 'uint16',
-        indexed: false,
-        internalType: 'uint16',
-      },
-      {
-        name: 'evidence',
-        type: 'bytes32',
-        indexed: false,
-        internalType: 'bytes32',
-      },
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      }
     ],
-    anonymous: false,
+    "anonymous": false
   },
   {
-    type: 'event',
-    name: 'SubscriptionBilled',
-    inputs: [
+    "type": "event",
+    "name": "BlueprintResourceRequirementsSet",
+    "inputs": [
       {
-        name: 'serviceId',
-        type: 'uint64',
-        indexed: true,
-        internalType: 'uint64',
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
       },
       {
-        name: 'amount',
-        type: 'uint256',
-        indexed: false,
-        internalType: 'uint256',
-      },
-      {
-        name: 'period',
-        type: 'uint64',
-        indexed: false,
-        internalType: 'uint64',
-      },
+        "name": "count",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
     ],
-    anonymous: false,
+    "anonymous": false
   },
+  {
+    "type": "event",
+    "name": "BlueprintTransferred",
+    "inputs": [
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BlueprintUpdated",
+    "inputs": [
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "metadataUri",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "metadataHash",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "JobCompleted",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "callId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "JobResultSubmitted",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "callId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "result",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "JobSubmitted",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "callId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "jobIndex",
+        "type": "uint8",
+        "indexed": true,
+        "internalType": "uint8"
+      },
+      {
+        "name": "caller",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "inputs",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "JobSubmittedFromQuote",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "callId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "jobIndex",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "caller",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "quotedOperators",
+        "type": "address[]",
+        "indexed": false,
+        "internalType": "address[]"
+      },
+      {
+        "name": "totalPrice",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "inputs",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OperatorJoinedService",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "exposureBps",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OperatorLeftService",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OperatorPreferencesUpdated",
+    "inputs": [
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "ecdsaPublicKey",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "rpcAddress",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OperatorRegistered",
+    "inputs": [
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "ecdsaPublicKey",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "rpcAddress",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OperatorRewardAccrued",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OperatorUnregistered",
+    "inputs": [
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PaymentDistributed",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "grossAmount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "developerRecipient",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "developerAmount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "protocolAmount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "operatorPoolAmount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "stakerPoolAmount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RewardsClaimed",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ServiceActivated",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "requestId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "confidentiality",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum Types.ConfidentialityPolicy"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ServiceApproved",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ServiceRejected",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ServiceRequested",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "requester",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "confidentiality",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum Types.ConfidentialityPolicy"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ServiceRequestedWithSecurity",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "blueprintId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "requester",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "confidentiality",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum Types.ConfidentialityPolicy"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ServiceTerminated",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ServiceTerminatedForNonPayment",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "triggeredBy",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "dueAt",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "graceEndsAt",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "requiredAmount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "escrowBalance",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SlashCancelled",
+    "inputs": [
+      {
+        "name": "slashId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "canceller",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "reason",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SlashConfigUpdated",
+    "inputs": [
+      {
+        "name": "disputeWindow",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "instantSlashEnabled",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      },
+      {
+        "name": "maxSlashBps",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "disputeResolutionDeadline",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "disputeBond",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxPendingSlashesPerOperator",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SlashDisputed",
+    "inputs": [
+      {
+        "name": "slashId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "disputer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "reason",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SlashExecuted",
+    "inputs": [
+      {
+        "name": "slashId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "actualSlashed",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SlashProposed",
+    "inputs": [
+      {
+        "name": "slashId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "proposer",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "slashBps",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "effectiveSlashBps",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "evidence",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "executeAfter",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SubscriptionBilled",
+    "inputs": [
+      {
+        "name": "serviceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "period",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  }
 ] as const;
 
 export default ABI;

--- a/libs/tangle-shared-ui/src/data/graphql/index.ts
+++ b/libs/tangle-shared-ui/src/data/graphql/index.ts
@@ -213,6 +213,7 @@ export {
 export {
   useSlashProposals,
   useProposableServices,
+  useSlashConfig,
   useDisputeSlashTx,
   useCancelSlashTx,
   useProposeSlashTx,

--- a/libs/tangle-shared-ui/src/data/graphql/useSlashing.ts
+++ b/libs/tangle-shared-ui/src/data/graphql/useSlashing.ts
@@ -67,6 +67,13 @@ export interface SlashProposal {
   status: SlashStatus;
   disputeReason: string | null;
   cancelReason: string | null;
+  // Dispute lifecycle (populated when status === 'Disputed' or after a dispute
+  // was filed and later resolved). Sourced from getSlashProposal on-chain or
+  // backfilled from the indexer when available.
+  disputer: Address;
+  disputeBond: bigint;
+  disputedAt: bigint;
+  disputeDeadline: bigint;
 }
 
 export interface ProposableService {
@@ -529,6 +536,11 @@ const toPrimitiveSlashProposal = (
   const slashBps = BigInt(sp.slashBps);
   const effectiveSlashBps = BigInt(sp.effectiveSlashBps);
 
+  // The Envio indexer schema may not yet expose v0.13.0 dispute-lifecycle fields.
+  // We default to zero-values; consumers that need authoritative dispute data
+  // should call useSlashProposalDetails (on-chain getSlashProposal) which is the
+  // source of truth. Once the indexer ships matching columns, surface them via
+  // sp.disputer / sp.disputeBond / sp.disputedAt / sp.disputeDeadline.
   return {
     id: BigInt(sp.slashId),
     serviceId: BigInt(sp.serviceId),
@@ -545,6 +557,10 @@ const toPrimitiveSlashProposal = (
     status: parseSlashStatus(sp.status),
     disputeReason: sp.disputeReason,
     cancelReason: sp.cancelReason,
+    disputer: zeroAddress as Address,
+    disputeBond: BigInt(0),
+    disputedAt: BigInt(0),
+    disputeDeadline: BigInt(0),
   };
 };
 
@@ -738,6 +754,10 @@ const normalizeOnChainSlashProposal = (
   slashId: bigint,
   proposal: any,
 ): SlashProposal => {
+  // Tuple layout from getSlashProposal (tnt-core v0.13.0):
+  // 0 serviceId, 1 operator, 2 proposer, 3 slashBps, 4 effectiveSlashBps,
+  // 5 evidence, 6 proposedAt, 7 executeAfter, 8 status, 9 disputeReason,
+  // 10 disputer, 11 disputeBond, 12 disputedAt, 13 disputeDeadline.
   const serviceId =
     proposal?.serviceId !== undefined
       ? BigInt(proposal.serviceId.toString())
@@ -767,6 +787,18 @@ const normalizeOnChainSlashProposal = (
   const disputeReason = (proposal?.disputeReason ?? proposal?.[9] ?? null) as
     | string
     | null;
+  const disputer = (proposal?.disputer ??
+    proposal?.[10] ??
+    zeroAddress) as Address;
+  const disputeBond = BigInt(
+    proposal?.disputeBond?.toString() ?? proposal?.[11]?.toString() ?? 0,
+  );
+  const disputedAt = BigInt(
+    proposal?.disputedAt?.toString() ?? proposal?.[12]?.toString() ?? 0,
+  );
+  const disputeDeadline = BigInt(
+    proposal?.disputeDeadline?.toString() ?? proposal?.[13]?.toString() ?? 0,
+  );
 
   return {
     id: slashId,
@@ -784,6 +816,10 @@ const normalizeOnChainSlashProposal = (
     status: parseSlashStatus(statusValue),
     disputeReason,
     cancelReason: null,
+    disputer,
+    disputeBond,
+    disputedAt,
+    disputeDeadline,
   };
 };
 

--- a/libs/tangle-shared-ui/src/data/services/index.ts
+++ b/libs/tangle-shared-ui/src/data/services/index.ts
@@ -56,6 +56,15 @@ export {
 } from './useFundServiceTx';
 
 export {
+  useExpireServiceRequestTx,
+  isServiceRequestExpired,
+  getServiceRequestExpiryEligibleAt,
+  REQUEST_EXPIRY_GRACE_PERIOD_SECONDS,
+  type ExpireServiceRequestParams,
+  type UseExpireServiceRequestTxOptions,
+} from './useExpireServiceRequest';
+
+export {
   useBillSubscriptionTx,
   type BillSubscriptionParams,
   type UseBillSubscriptionTxOptions,

--- a/libs/tangle-shared-ui/src/data/services/useExpireServiceRequest.ts
+++ b/libs/tangle-shared-ui/src/data/services/useExpireServiceRequest.ts
@@ -1,0 +1,113 @@
+/**
+ * Hook for permissionlessly expiring a stale service request.
+ *
+ * `expireServiceRequest` is callable by anyone once `block.timestamp >
+ * req.createdAt + REQUEST_EXPIRY_GRACE_PERIOD`. Calling it refunds the
+ * requester and unlocks the operator candidates, so it is safe — and
+ * incentive-aligned — to expose as a "Clean up expired request" action.
+ *
+ * This hook only handles the on-chain write. Callers are responsible for
+ * gating the button on the grace period using
+ * REQUEST_EXPIRY_GRACE_PERIOD_SECONDS, and for invalidating any request /
+ * service queries on success.
+ */
+
+import { useChainId } from 'wagmi';
+import { useQueryClient } from '@tanstack/react-query';
+import { getContractsByChainId } from '@tangle-network/dapp-config/contracts';
+import useContractWrite, { TxStatus } from '../../hooks/useContractWrite';
+import TangleABI from '../../abi/tangle';
+
+export { TxStatus };
+
+/**
+ * Mirrors `ProtocolConfig.REQUEST_EXPIRY_GRACE_PERIOD` (1 hour) from tnt-core.
+ * The contract allows admins to override `_requestExpiryGracePeriod`, but no
+ * getter is currently exposed for it; this constant reflects the protocol
+ * default and is the conservative gate to use in the UI.
+ */
+export const REQUEST_EXPIRY_GRACE_PERIOD_SECONDS = BigInt(60 * 60);
+
+export interface ExpireServiceRequestParams {
+  requestId: bigint;
+}
+
+export interface UseExpireServiceRequestTxOptions {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+}
+
+/**
+ * Returns true iff `now > createdAt + grace`. `now` defaults to the system
+ * clock; pass an externally-clocked value when you want the gate to advance
+ * at the same cadence as the rest of the page (e.g. a `useChainClock` tick).
+ */
+export const isServiceRequestExpired = (
+  createdAt: bigint,
+  nowUnixSeconds: bigint = BigInt(Math.floor(Date.now() / 1000)),
+  graceSeconds: bigint = REQUEST_EXPIRY_GRACE_PERIOD_SECONDS,
+): boolean => nowUnixSeconds > createdAt + graceSeconds;
+
+/**
+ * Returns the seconds remaining until the request can be expired. Negative
+ * (or zero) when the request is already eligible for expiry.
+ */
+export const getServiceRequestExpiryEligibleAt = (
+  createdAt: bigint,
+  graceSeconds: bigint = REQUEST_EXPIRY_GRACE_PERIOD_SECONDS,
+): bigint => createdAt + graceSeconds;
+
+export const useExpireServiceRequestTx = (
+  options?: UseExpireServiceRequestTxOptions,
+) => {
+  const chainId = useChainId();
+  const queryClient = useQueryClient();
+
+  const hook = useContractWrite(
+    TangleABI,
+    (params: ExpireServiceRequestParams) => {
+      let contracts: ReturnType<typeof getContractsByChainId>;
+      try {
+        contracts = getContractsByChainId(chainId);
+      } catch {
+        throw new Error('Tangle contract not available on this network');
+      }
+
+      return {
+        address: contracts.tangle,
+        abi: TangleABI,
+        functionName: 'expireServiceRequest' as const,
+        args: [params.requestId] as const,
+      };
+    },
+    {
+      txName: 'expire service request',
+      txDetails: (params) =>
+        new Map([['Request ID', params.requestId.toString()]]),
+      getSuccessMessage: (params) =>
+        `Service request #${params.requestId} expired and refunded.`,
+      onSuccess: () => {
+        // The expire path flips `req.rejected = true` and refunds escrow, so
+        // anything that reads the request, the surrounding service, or the
+        // requester's balance must refetch.
+        queryClient.invalidateQueries({ queryKey: ['serviceRequestDetails'] });
+        queryClient.invalidateQueries({ queryKey: ['serviceRequests'] });
+        queryClient.invalidateQueries({ queryKey: ['services'] });
+        options?.onSuccess?.();
+      },
+      onError: options?.onError,
+    },
+  );
+
+  return {
+    execute: hook.execute,
+    status: hook.status,
+    error: hook.error,
+    reset: hook.reset,
+    txHash: hook.txHash,
+    isSuccess: hook.isSuccess,
+    isPending: hook.isLoading,
+  };
+};
+
+export default useExpireServiceRequestTx;

--- a/libs/tangle-shared-ui/src/data/services/useExpireServiceRequest.ts
+++ b/libs/tangle-shared-ui/src/data/services/useExpireServiceRequest.ts
@@ -44,8 +44,8 @@ export interface UseExpireServiceRequestTxOptions {
  */
 export const isServiceRequestExpired = (
   createdAt: bigint,
-  nowUnixSeconds: bigint = BigInt(Math.floor(Date.now() / 1000)),
-  graceSeconds: bigint = REQUEST_EXPIRY_GRACE_PERIOD_SECONDS,
+  nowUnixSeconds = BigInt(Math.floor(Date.now() / 1000)),
+  graceSeconds = REQUEST_EXPIRY_GRACE_PERIOD_SECONDS,
 ): boolean => nowUnixSeconds > createdAt + graceSeconds;
 
 /**
@@ -54,7 +54,7 @@ export const isServiceRequestExpired = (
  */
 export const getServiceRequestExpiryEligibleAt = (
   createdAt: bigint,
-  graceSeconds: bigint = REQUEST_EXPIRY_GRACE_PERIOD_SECONDS,
+  graceSeconds = REQUEST_EXPIRY_GRACE_PERIOD_SECONDS,
 ): bigint => createdAt + graceSeconds;
 
 export const useExpireServiceRequestTx = (

--- a/scripts/sync-tnt-core-assets.mjs
+++ b/scripts/sync-tnt-core-assets.mjs
@@ -1,6 +1,7 @@
 import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, '..');
@@ -77,10 +78,31 @@ const syncFixtures = (tntCoreDir) => {
   }
 };
 
+const formatGeneratedAbis = () => {
+  // Run prettier so the generated `as const` ABIs match the repo style
+  // (single quotes, trailing commas) instead of raw JSON.stringify output.
+  const targets = [
+    'libs/tangle-shared-ui/src/abi/tangle.ts',
+    'libs/tangle-shared-ui/src/abi/multiAssetDelegation.ts',
+    'libs/tangle-shared-ui/src/abi/operatorStatusRegistry.ts',
+    'libs/tangle-shared-ui/src/abi/blueprintServiceManager.ts',
+  ].map((relative) => resolve(repoRoot, relative));
+
+  const result = spawnSync('npx', ['prettier', '--write', '--log-level=warn', ...targets], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+  });
+
+  if (result.status !== 0) {
+    console.warn('[sync] prettier formatting exited with a non-zero status; please run `yarn format` manually.');
+  }
+};
+
 const main = () => {
   const tntCoreDir = resolveTntCoreDir();
   syncAbis(tntCoreDir);
   syncFixtures(tntCoreDir);
+  formatGeneratedAbis();
 };
 
 main();

--- a/scripts/sync-tnt-core-assets.mjs
+++ b/scripts/sync-tnt-core-assets.mjs
@@ -41,7 +41,9 @@ const syncAbis = (tntCoreDir) => {
   const mappings = [
     { source: 'ITangleFull.json', target: 'libs/tangle-shared-ui/src/abi/tangle.ts' },
     { source: 'IMultiAssetDelegation.json', target: 'libs/tangle-shared-ui/src/abi/multiAssetDelegation.ts' },
-    { source: 'IOperatorStatusRegistry.json', target: 'libs/tangle-shared-ui/src/abi/operatorStatusRegistry.ts' },
+    // tnt-core v0.13.0 ships the implementation ABI (no `I` prefix) — it carries
+    // the same external surface the dapp needs and the interface JSON is no longer emitted.
+    { source: 'OperatorStatusRegistry.json', target: 'libs/tangle-shared-ui/src/abi/operatorStatusRegistry.ts' },
     { source: 'IBlueprintServiceManager.json', target: 'libs/tangle-shared-ui/src/abi/blueprintServiceManager.ts' },
   ];
 

--- a/storybook-migration-summary.md
+++ b/storybook-migration-summary.md
@@ -59,4 +59,6 @@ Please read the [Storybook 7.0.0 release article](https://storybook.js.org/blog/
 official [Storybook 7.0.0 migration guide](https://storybook.js.org/docs/react/migration-guide)
 for more information.
 
-You can also read the docs for the [@nx/storybook:migrate-7 generator](https://nx.dev/packages/storybook/generators/migrate-7) and our [Storybook 7 setup guide](https://nx.dev/packages/storybook/documents/storybook-7-setup).
+For Nx-specific Storybook setup, see the current Nx documentation at https://nx.dev (the
+historical `@nx/storybook:migrate-7` generator and `storybook-7-setup` document URLs have
+been retired upstream).


### PR DESCRIPTION
Picks up the v0.13.0 surface changes from tnt-core (audit follow-ups landed
in [PR #124](https://github.com/tangle-network/tnt-core/pull/124) and
[PR #125](https://github.com/tangle-network/tnt-core/pull/125)) and uses
the resync as a chance to close the loop on a handful of UX gaps that the
new contract fields make actionable.

## REQUIRED — ABI sync

- **`chore(abi): regenerate from tnt-core v0.13.0`** — runs `yarn sync:tnt-core-assets` against tnt-core@v0.13.0. Generated ABIs now contain `SlashCancelled`, `SlashConfigUpdated`, `SlashDisputed` events; the 6-field `SlashConfig`; the 14-field `SlashProposal`; `forceRemoveAllowsBelowMin` on `IBlueprintServiceManager`; the `requester`-first `JobQuoteDetails`; and the now-routable `expireServiceRequest` selector. Sync script swapped to `OperatorStatusRegistry.json` (impl ABI) since tnt-core v0.13.0 stopped emitting the interface JSON.
- **`chore(abi-sync): run prettier on generated ABIs`** — drops the JSON-style output the sync script was producing in favour of the codebase's prettier style so `yarn format:check` stays clean across regenerations.

## RECOMMENDED — UX polish (each in its own commit)

### a. DisputeSlashModal surfaces the required `disputeBond`

`feat(slashing-ui): surface dispute bond + resolution deadline on DisputeSlashModal`

The modal now reads the active `SlashConfig` and renders the required bond inline as `X ETH (refunded if dispute upheld)`, matching the message the `useDisputeSlashTx` hook already attaches as `msg.value`. When the slash is already in `Disputed` state, also surface the on-chain `disputer` address and a live countdown to `disputeDeadline` (the field added by tnt-core v0.13.0). User-facing: the "Submit Dispute" CTA is no longer a black box — operators see what bond they're posting before signing.

### b. ProposeSlashModal enforces `SlashConfig.maxSlashBps`

`feat(slashing-ui): enforce SlashConfig.maxSlashBps cap on ProposeSlashModal`

Pulls `maxSlashBps` from `useSlashConfig`, surfaces it in both the BPS input placeholder and a helper line under the field, and short-circuits validation client-side. User-facing: proposers stop wasting simulation gas on out-of-range values.

### c. `SlashProposal` extended with dispute lifecycle fields

`feat(slashing): extend SlashProposal with dispute lifecycle fields`

`SlashProposal` now exposes `disputer`, `disputeBond`, `disputedAt`, and `disputeDeadline`. `normalizeOnChainSlashProposal` reads positions 10–13 of the new `getSlashProposal` tuple; the GraphQL fallback path defaults the new columns to zero-values with a comment so callers needing authoritative dispute data can hit `useSlashProposalDetails` (on-chain). `useSlashConfig` is now exported from `data/graphql` so feature code consumes it via the public surface.

### d. New "Expire request" action

`feat(services): permissionless expire-service-request action`

New `useExpireServiceRequestTx` hook + `REQUEST_EXPIRY_GRACE_PERIOD_SECONDS` / `isServiceRequestExpired` helpers in `libs/tangle-shared-ui/src/data/services/useExpireServiceRequest.ts`. Wired into the request-detail modal as an "Expire request" button gated on `now > createdAt + grace` and `!rejected`, with full loading / error / success handling and `serviceRequestDetails` cache invalidation. Available in both default and `viewOnly` footers because the call is permissionless. User-facing: anyone can clean up a stale request, refunding the requester and freeing the operator candidates without a manual contract call.

### e. SlashConfig parameters card

`feat(slashing-ui): surface SlashConfig parameters at top of operator management`

New read-only `SlashingParametersCard` rendered above the slashing summary on `apps/tangle-cloud/src/pages/operators/manage`. Surfaces `maxSlashBps`, `disputeWindow`, `disputeResolutionDeadline`, `disputeBond`, `maxPendingSlashesPerOperator`, and `instantSlashEnabled`. User-facing: proposers and operators see the active policy levers up front instead of discovering them via failed simulations.

## Verification

- `TNT_CORE_DIR=/home/drew/code/tnt-core yarn sync:tnt-core-assets` — green; regenerated ABIs contain the expected new entries.
- `yarn nx run tangle-cloud:typecheck` — green
- `yarn nx run tangle-cloud:build` — green
- `yarn nx run tangle-cloud:lint` — green
- `yarn nx run tangle-dapp:typecheck` / `:build` / `:lint` — green (no behavioural changes there; the regenerated ABIs are the only shared touchpoint)
- `yarn nx run tangle-shared-ui:test` — 32 passed, 0 failed
- `yarn nx run tangle-shared-ui:lint` — green
- `yarn format:check` — green

## Test plan

- [ ] Open the operator-management page on a network with `SlashConfig.disputeBond > 0` and confirm the new SlashingParametersCard renders the bond, deadlines, and caps.
- [ ] Trigger ProposeSlashModal with a BPS above the active cap; expect the validation error to fire client-side without a simulation roundtrip.
- [ ] Trigger DisputeSlashModal on a Pending slash; expect the "Required Dispute Bond" row to render the bond. Submit; expect `msg.value` to match.
- [ ] Trigger DisputeSlashModal on a Disputed slash; expect the disputer address + countdown rows to render.
- [ ] Open the request-detail modal on a request whose `createdAt + 1h < now` and is not yet rejected; click "Expire request"; expect a successful tx, modal close, and the request to disappear from the parent list.