### PR TITLE
chore(abi): sync tnt-core v0.15.0 (Round 4 audit consolidation)

### DIFF
--- a/apps/tangle-cloud/src/pages/operators/manage/components/modals/DisputeSlashModal.tsx
+++ b/apps/tangle-cloud/src/pages/operators/manage/components/modals/DisputeSlashModal.tsx
@@ -162,7 +162,7 @@ const DisputeSlashModal = ({
               </Text>
               <Text variant="body3">
                 {disputeBond > BigInt(0)
-                  ? `${formatEthAmount(disputeBond)} ETH (refunded if dispute upheld)`
+                  ? `${formatEthAmount(disputeBond)} ETH (claimable via claimDisputeBond if dispute upheld)`
                   : 'No bond required'}
               </Text>
               {isAlreadyDisputed && hasKnownDisputer ? (

--- a/apps/tangle-dapp/src/abi/validatorPodManager.ts
+++ b/apps/tangle-dapp/src/abi/validatorPodManager.ts
@@ -29,6 +29,9 @@ export const VALIDATOR_POD_MANAGER_ABI = [
     type: 'function',
   },
   // Shares
+  // NOTE: tnt-core v0.15.0 refactored VPM to a share-pool model. The legacy
+  // `podOwnerShares` view is removed — readers must use `getShares` (int256,
+  // can be negative pre-rebase) or `getSharesUint` (uint256, clamped to 0).
   {
     inputs: [{ internalType: 'address', name: 'owner', type: 'address' }],
     name: 'getShares',
@@ -38,16 +41,39 @@ export const VALIDATOR_POD_MANAGER_ABI = [
   },
   {
     inputs: [{ internalType: 'address', name: 'owner', type: 'address' }],
-    name: 'podOwnerShares',
-    outputs: [{ internalType: 'int256', name: '', type: 'int256' }],
+    name: 'getSharesUint',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
     stateMutability: 'view',
     type: 'function',
   },
   {
     inputs: [],
     name: 'totalShares',
-    outputs: [{ internalType: 'int256', name: '', type: 'int256' }],
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
     stateMutability: 'view',
+    type: 'function',
+  },
+  // Beacon-chain accounting (replaces removed recordBeaconChainEthBalanceUpdate).
+  {
+    inputs: [
+      { internalType: 'address', name: 'podOwner', type: 'address' },
+      { internalType: 'uint256', name: 'assets', type: 'uint256' },
+    ],
+    name: 'recordBeaconChainDeposit',
+    outputs: [
+      { internalType: 'uint256', name: 'mintedShares', type: 'uint256' },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'podOwner', type: 'address' },
+      { internalType: 'int256', name: 'assetsDelta', type: 'int256' },
+    ],
+    name: 'recordBeaconChainRebase',
+    outputs: [],
+    stateMutability: 'nonpayable',
     type: 'function',
   },
   // Operator Management
@@ -306,12 +332,55 @@ export const VALIDATOR_POD_MANAGER_ABI = [
       },
       {
         indexed: false,
-        internalType: 'int256',
+        internalType: 'uint256',
         name: 'newShares',
-        type: 'int256',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'totalAssets',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'totalSharesPool',
+        type: 'uint256',
       },
     ],
     name: 'SharesUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'int256',
+        name: 'assetsDelta',
+        type: 'int256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'newTotalAssets',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'totalSharesPool',
+        type: 'uint256',
+      },
+    ],
+    name: 'BeaconRebase',
     type: 'event',
   },
   {
@@ -411,6 +480,12 @@ export const VALIDATOR_POD_MANAGER_ABI = [
         name: 'shares',
         type: 'uint256',
       },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'assets',
+        type: 'uint256',
+      },
     ],
     name: 'WithdrawalQueued',
     type: 'event',
@@ -434,6 +509,12 @@ export const VALIDATOR_POD_MANAGER_ABI = [
         indexed: false,
         internalType: 'uint256',
         name: 'shares',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'assets',
         type: 'uint256',
       },
     ],

--- a/apps/tangle-dapp/src/features/native-staking/hooks/useValidatorPodManager.ts
+++ b/apps/tangle-dapp/src/features/native-staking/hooks/useValidatorPodManager.ts
@@ -87,7 +87,11 @@ export const useGetPod = (ownerAddress: Address | undefined) => {
   };
 };
 
-// Hook to get owner's shares
+// Hook to get owner's shares.
+// tnt-core v0.15.0: legacy `podOwnerShares` was removed during the share-pool
+// refactor. `getShares` returns int256 (can be negative if a beacon rebase
+// pushed the owner under their previous share count); UI keeps the bigint
+// shape and downstream renderers already clamp at zero where needed.
 export const usePodOwnerShares = (ownerAddress: Address | undefined) => {
   const chainId = useChainId();
   const contractAddress = getValidatorPodManagerAddress(chainId);
@@ -95,7 +99,7 @@ export const usePodOwnerShares = (ownerAddress: Address | undefined) => {
   const { data, isLoading, error, refetch } = useReadContract({
     address: contractAddress ?? undefined,
     abi: VALIDATOR_POD_MANAGER_ABI,
-    functionName: 'podOwnerShares',
+    functionName: 'getShares',
     args: ownerAddress ? [ownerAddress] : undefined,
     query: {
       enabled: !!ownerAddress && !!contractAddress,

--- a/libs/tangle-shared-ui/src/abi/multiAssetDelegation.ts
+++ b/libs/tangle-shared-ui/src/abi/multiAssetDelegation.ts
@@ -599,6 +599,52 @@ const ABI = [
   },
   {
     type: 'function',
+    name: 'getCumStakeSeconds',
+    inputs: [
+      {
+        name: 'operator',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'asset',
+        type: 'tuple',
+        internalType: 'struct Types.Asset',
+        components: [
+          {
+            name: 'kind',
+            type: 'uint8',
+            internalType: 'enum Types.AssetKind',
+          },
+          {
+            name: 'token',
+            type: 'address',
+            internalType: 'address',
+          },
+        ],
+      },
+    ],
+    outputs: [
+      {
+        name: 'cum',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'lastUpdate',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      {
+        name: 'currentStake',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
     name: 'getDelegation',
     inputs: [
       {
@@ -2848,6 +2894,22 @@ const ABI = [
       },
     ],
     anonymous: false,
+  },
+  {
+    type: 'error',
+    name: 'AdapterChangeWhileDepositsExist',
+    inputs: [
+      {
+        name: 'token',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'currentDeposits',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
   },
 ] as const;
 

--- a/libs/tangle-shared-ui/src/abi/tangle.ts
+++ b/libs/tangle-shared-ui/src/abi/tangle.ts
@@ -519,6 +519,13 @@ const ABI = [
   },
   {
     type: 'function',
+    name: 'claimDisputeBond',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
     name: 'claimRewards',
     inputs: [],
     outputs: [],
@@ -2325,6 +2332,16 @@ const ABI = [
             type: 'uint256',
             internalType: 'uint256',
           },
+          {
+            name: '__reservedAggregateCursor',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'subscriptionBaselineStake',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
         ],
       },
     ],
@@ -3145,6 +3162,25 @@ const ABI = [
         name: 'stakerBps',
         type: 'uint16',
         internalType: 'uint16',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'pendingDisputeBondRefund',
+    inputs: [
+      {
+        name: 'disputer',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
       },
     ],
     stateMutability: 'view',

--- a/libs/tangle-shared-ui/src/data/graphql/useSlashing.ts
+++ b/libs/tangle-shared-ui/src/data/graphql/useSlashing.ts
@@ -1338,6 +1338,12 @@ export const useExecuteSlashBatchTx = () => {
 
 /**
  * Hook to cancel a slash proposal.
+ *
+ * NOTE (tnt-core v0.14.0): `cancelSlash` no longer auto-refunds the disputer's
+ * bond. After cancellation, the disputer must call `claimDisputeBond()` and
+ * may inspect their pending balance with `pendingDisputeBondRefund(address)`.
+ * TODO(v0.15.0): wire up a `useClaimDisputeBondTx` + dedicated UI affordance
+ * on the disputer-facing slash detail view (and surface the pending balance).
  */
 export const useCancelSlashTx = () => {
   const chainId = useChainId();


### PR DESCRIPTION
## Summary

Sync ABIs from tnt-core@v0.15.0 (PRs [#126](https://github.com/tangle-network/tnt-core/pull/126), [#127](https://github.com/tangle-network/tnt-core/pull/127), [#129](https://github.com/tangle-network/tnt-core/pull/129)) covering the v0.14.0 + v0.15.0 audit-hardening cycle. Two consumer-side fixes accompany the regen for the only breaking changes whose callsites live in this dapp.

Previous sync was v0.13.0 in #3198.

## ABI changes (auto-generated via `yarn sync:tnt-core-assets`)

- `ITangleFull` (`libs/tangle-shared-ui/src/abi/tangle.ts`)
  - **+** `claimDisputeBond()` (v0.14.0 pull-pattern dispute refunds)
  - **+** `pendingDisputeBondRefund(address) -> uint256` view
  - `PaymentLib.ServiceEscrow` struct: trailing `__reservedAggregateCursor` + `subscriptionBaselineStake` appended. Named decoders (e.g. `useServiceEscrow`) ignore the new fields; positional reads at the old offsets are preserved.
- `IMultiAssetDelegation` (`libs/tangle-shared-ui/src/abi/multiAssetDelegation.ts`)
  - **+** `getCumStakeSeconds(operator, asset)` view (live TWAP stake-seconds)
  - **+** `AdapterChangeWhileDepositsExist(token, currentDeposits)` error
- `ValidatorPodManager` (hand-maintained ABI under `apps/tangle-dapp/src/abi/validatorPodManager.ts`)
  - **\−** `podOwnerShares` (removed in the v0.15.0 share-pool refactor)
  - `totalShares` retyped `int256 -> uint256`
  - **+** `getSharesUint(address) -> uint256` companion to `getShares`
  - **+** `recordBeaconChainDeposit(address, uint256)` (replaces removed `recordBeaconChainEthBalanceUpdate`)
  - **+** `recordBeaconChainRebase(address, int256)`
  - **+** `BeaconRebase(owner, assetsDelta, newTotalAssets, totalSharesPool)` event
  - `SharesUpdated` signature expanded to `(owner, sharesDelta, newShares uint256, totalAssets, totalSharesPool)` (was 3 args, `newShares` was int256)
  - `WithdrawalQueued` / `WithdrawalCompleted` gained trailing `uint256 assets`

## Consumer fixes (the only breaking changes whose callsites exist in this dapp)

- `apps/tangle-dapp/src/features/native-staking/hooks/useValidatorPodManager.ts`
  - `usePodOwnerShares` now reads `getShares` (legacy `podOwnerShares` was removed in v0.15.0). `getShares` returns `int256` so values can transiently be negative after a beacon rebase; downstream renderers (`DelegationCard`, `WithdrawalCard`, `PodOverviewCard`) already clamp at zero for display.
- `apps/tangle-cloud/src/pages/operators/manage/components/modals/DisputeSlashModal.tsx`
  - Bond hint reworded from `"refunded if dispute upheld"` to `"claimable via claimDisputeBond if dispute upheld"` — v0.14.0 switched dispute refunds to pull-pattern so the previous text overpromised.
- `libs/tangle-shared-ui/src/data/graphql/useSlashing.ts`
  - Inline NOTE on `useCancelSlashTx` documenting the pull-pattern change, plus a `TODO(v0.15.0)` for the follow-up `useClaimDisputeBondTx` hook + disputer-side claim affordance (see deferred items below).

## Breaking changes intentionally NOT actioned in this PR

These are real v0.14/v0.15 contract-side breaks but have **zero consumer code in the dapp**, so the regen alone is enough:

- `TangleToken.burn` / `burnFrom` revert with `BurnDisabled()` — no dapp surface exposes a TNT burn action.
- `TangleGovernor.MAX_PROPOSAL_ACTIONS` 50 -> 10, `MAX_ACTION_VALUE` 100k -> 10k ETH — the dapp doesn't construct governor proposals from user UI.
- Quote payment + ERC20 deposits reject fee-on-transfer tokens — no FoT token whitelisting in the dapp.
- L2SlashingReceiver + 4 bridges are now UUPS-upgradeable; deploys live in tnt-core scripts, not the dapp.
- `ArbitrumCrossChainMessenger.setL2RefundAddress` — not invoked from dapp UI.
- `Tangle.billSubscription(uint64)` TWAP-fair semantics — signature unchanged, dapp does not call.

## Deferred follow-up (TODOs in code)

- `claimDisputeBond()` + `pendingDisputeBondRefund(address)` UI affordance for disputers after their bond becomes claimable. Tracked as `TODO(v0.15.0)` inside `libs/tangle-shared-ui/src/data/graphql/useSlashing.ts` on `useCancelSlashTx`. Recommend a follow-up `useClaimDisputeBondTx` hook + a "Claim refund" button on the disputer-side slash detail view, gated on a non-zero `pendingDisputeBondRefund` read.

## Verification

- `yarn nx typecheck tangle-dapp` — clean
- `yarn nx typecheck tangle-cloud` — clean
- `yarn nx lint tangle-dapp` — clean
- `yarn nx lint tangle-cloud` — clean
- `yarn nx lint tangle-shared-ui` — clean
- `prettier --check` on every touched file — clean

## Test plan

- [ ] CI green (typecheck, lint, build for tangle-dapp + tangle-cloud)
- [ ] Manual smoke: native-staking pod overview/delegate/withdraw cards still render owner shares (`getShares` path)
- [ ] Manual smoke: tangle-cloud slash dispute modal renders the new bond-claim copy