### PR TITLE
fix(vite): merge @radix-ui into react chunk to break load-order cycle (prod hotfix)

### DIFF
--- a/apps/tangle-cloud/vite.config.ts
+++ b/apps/tangle-cloud/vite.config.ts
@@ -72,13 +72,23 @@ export default defineConfig({
           if (id.includes('viem')) return 'viem';
           if (id.includes('@tanstack')) return 'tanstack';
           if (id.includes('react-router')) return 'router';
+          // Co-locate react/react-dom with @radix-ui. Splitting them lets
+          // Rollup hoist the CJS-interop helper (`_getDefaultExportFromCjs`)
+          // into whichever chunk evaluates first; on some content-hash
+          // layouts the helper landed in the radix chunk and the react
+          // chunk imported it back, forming a load-order cycle that
+          // crashed the app at module init with
+          // `Cannot read properties of undefined (reading 'forwardRef')`
+          // when radix's top-level `Qu.reduce(...)` ran before react's
+          // bindings had initialised. Co-resident avoids the cycle since
+          // radix depends on react and must evaluate after it anyway.
           if (
             id.includes('node_modules/react/') ||
-            id.includes('node_modules/react-dom/')
+            id.includes('node_modules/react-dom/') ||
+            id.includes('@radix-ui')
           ) {
             return 'react';
           }
-          if (id.includes('@radix-ui')) return 'radix';
           return undefined;
         },
       },

--- a/apps/tangle-dapp/vite.config.ts
+++ b/apps/tangle-dapp/vite.config.ts
@@ -166,13 +166,20 @@ export default defineConfig({
           if (id.includes('node_modules/globalthis/')) return 'utils';
           if (id.includes('@tanstack')) return 'tanstack';
           if (id.includes('react-router')) return 'router';
+          // Co-locate react/react-dom with @radix-ui. See tangle-cloud's
+          // vite.config.ts for the full incident write-up — splitting
+          // react from radix lets Rollup hoist the CJS-interop helper
+          // into the radix chunk, forming a load-order cycle that crashes
+          // the app with `Cannot read properties of undefined (reading
+          // 'forwardRef')` when radix's top-level `Qu.reduce(...)` runs
+          // before react's bindings have initialised.
           if (
             id.includes('node_modules/react/') ||
-            id.includes('node_modules/react-dom/')
+            id.includes('node_modules/react-dom/') ||
+            id.includes('@radix-ui')
           ) {
             return 'react';
           }
-          if (id.includes('@radix-ui')) return 'radix';
           return undefined;
         },
       },


### PR DESCRIPTION
## Production incident

\`cloud.tangle.tools\` is hard-broken right now:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'forwardRef')
    at Yu (radix-TkqFv_GX.js:1:7237)
    at Gu (radix-TkqFv_GX.js:1:6817)
    at Array.reduce (<anonymous>)
\`\`\`

Only the purple background shell mounts; \`#root\` stays empty.

## Root cause

The post-#3199/#3203 rebuild produced a circular chunk graph:

\`\`\`
react-*.js  ──imports _getDefaultExportFromCjs from──▶  radix-*.js
radix-*.js  ──top-level Qu.reduce → Yu → i.forwardRef──▶  react-*.js
\`\`\`

Rollup hoists the CJS-interop helper into whichever chunk happens to own the right modules under the current content-hash layout. On this build it landed in radix, so react imported it back. radix's top-level \`Primitive.*\` reduce (which calls \`forwardRef\` for every primitive tag) ran before react's named exports were initialised → crash at module init.

This bug has been **latent since #3185** (vendor chunk split). Content-hash-driven Rollup chunk shuffling exposed it on the ABI-sync rebuild. \`tangle-dapp\` has the same config and was one lucky chunk layout away from the same outage.

## Fix

Co-locate \`react\` / \`react-dom\` with \`@radix-ui\` in a single chunk. \`@radix-ui\` already depends on react, so they must evaluate in this order anyway — putting them together makes the chunk graph acyclic.

Applied to both \`apps/tangle-cloud/vite.config.ts\` and \`apps/tangle-dapp/vite.config.ts\`.

## Verification

- \`yarn build:tangle-cloud\` → react chunk has zero cross-chunk imports (leaf), no other chunk forms a cycle with it
- \`yarn build:tangle-dapp\` → react chunk imports only from \`noble\` (also a leaf), acyclic
- Both built dists mount cleanly under \`python3 -m http.server\` with zero \`pageerror\` events in Playwright

## Rollout

This needs the standard develop → staging → master cascade ASAP since prod is down.