### PR TITLE
chore: retire `staging` branch, document develop → master flow

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -2,9 +2,9 @@ name: 'Build 🏗️'
 
 on:
   pull_request:
-    branches: [develop, staging, master, feature/**]
+    branches: [develop, master, feature/**]
   push:
-    branches: [develop, staging, master, feature/**]
+    branches: [develop, master, feature/**]
 
   workflow_dispatch:
 

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -2,7 +2,7 @@ name: 'Clean 🧹'
 
 on:
   pull_request:
-    branches: [develop, staging, master, feature/**]
+    branches: [develop, master, feature/**]
 
   workflow_dispatch:
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,7 @@ name: 'Scan 🔎'
 
 on:
   pull_request:
-    branches: [develop, staging, master, feature/**]
+    branches: [develop, master, feature/**]
 
   schedule:
     #        ┌───────────── minute (0 - 59)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
 
   pull_request:
-    branches: [develop, staging, master, feature/**]
+    branches: [develop, master, feature/**]
 
   push:
-    branches: [develop, staging, master, feature/**]
+    branches: [develop, master, feature/**]
 
 jobs:
   build_code:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,9 +135,12 @@ yarn generate:release        # Review version bumps and changelog
 
 ### Branch Strategy
 
-- Main development branch: `develop`
-- Main branch for releases: `master`
-- Release PRs should start with `[RELEASE]` in title
+Two-branch model (the previous `staging` branch was retired May 2026):
+
+- **`develop`** — main development branch. All feature, fix, and chore PRs target it. Every push to `develop` deploys to the staging Netlify environment (`develop--tangle-{cloud,dapp,leaderboard}.netlify.app`, aliased at `staging.{cloud,app,leaderboard}.tangle.tools` when configured).
+- **`master`** — production. Promotions happen automatically via the `auto-sync-master-with-develop.yml` workflow: a push to `develop` whose head commit message starts with `[RELEASE]` fast-forwards `master` to that commit and fires the production Netlify deploy. No manual cherry-pick, no separate release branch.
+- **Release PR titles must start with `[RELEASE]`** so the auto-sync workflow promotes the merge commit to master.
+- Hotfixes follow the same flow: PR into `develop` with a `[RELEASE]`-tagged final commit (e.g. via `gh pr merge --squash --subject "[RELEASE] fix: …"`).
 
 ### Prerequisites
 

--- a/apps/leaderboard/netlify.toml
+++ b/apps/leaderboard/netlify.toml
@@ -10,5 +10,10 @@
   # covered (it's inside apps/leaderboard/), and any source/config/
   # lockfile change also re-triggers.
   #
-  # Non-master branches always build (gives PR-preview deploys).
+  # Non-master branches always build (gives PR-preview + develop-branch
+  # deploys). The `develop` branch deploy is our staging environment —
+  # surfaced at develop--tangle-leaderboard.netlify.app and, when DNS
+  # aliases are configured, at staging.leaderboard.tangle.tools. The
+  # legacy `staging` git branch has been retired (May 2026); promotions
+  # go develop → master via the `[RELEASE]`-tagged auto-sync workflow.
   ignore = "[ \"$BRANCH\" != \"master\" ] && exit 1 || git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/leaderboard/ libs/ package.json yarn.lock tsconfig.base.json nx.json && exit 0 || exit 1"

--- a/apps/tangle-cloud/netlify.toml
+++ b/apps/tangle-cloud/netlify.toml
@@ -10,7 +10,12 @@
   # implicitly covered (it's inside apps/tangle-cloud/), and any source/
   # config/lockfile change also re-triggers.
   #
-  # Non-master branches always build (gives PR-preview deploys).
+  # Non-master branches always build (gives PR-preview + develop-branch
+  # deploys). The `develop` branch deploy is our staging environment —
+  # surfaced at develop--tangle-cloud.netlify.app and, when DNS aliases
+  # are configured, at staging.cloud.tangle.tools. The legacy `staging`
+  # git branch has been retired (May 2026); promotions go develop → master
+  # via the `[RELEASE]`-tagged auto-sync workflow.
   ignore = "[ \"$BRANCH\" != \"master\" ] && exit 1 || git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/tangle-cloud/ libs/ package.json yarn.lock tsconfig.base.json nx.json && exit 0 || exit 1"
 
 # ─── Per-context environment ───────────────────────────────────────────
@@ -36,7 +41,8 @@
   VITE_BLUEPRINT_IFRAME_ENABLED = "true"
 
 [context.branch-deploy.environment]
-  # Same default for any non-master branch deploy (e.g. staging).
+  # Same default for any non-master branch deploy. The primary branch
+  # deploy is `develop`, which serves as our staging environment.
   VITE_BLUEPRINT_IFRAME_ENABLED = "true"
 
 # ─── Security headers ───────────────────────────────────────────────────

--- a/apps/tangle-dapp/netlify.toml
+++ b/apps/tangle-dapp/netlify.toml
@@ -10,7 +10,12 @@
   # implicitly covered (it's inside apps/tangle-dapp/), and any source/
   # config/lockfile change also re-triggers.
   #
-  # Non-master branches always build (gives PR-preview deploys).
+  # Non-master branches always build (gives PR-preview + develop-branch
+  # deploys). The `develop` branch deploy is our staging environment —
+  # surfaced at develop--tangle-dapp.netlify.app and, when DNS aliases
+  # are configured, at staging.app.tangle.tools. The legacy `staging` git
+  # branch has been retired (May 2026); promotions go develop → master
+  # via the `[RELEASE]`-tagged auto-sync workflow.
   ignore = "[ \"$BRANCH\" != \"master\" ] && exit 1 || git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/tangle-dapp/ libs/ package.json yarn.lock tsconfig.base.json nx.json && exit 0 || exit 1"
 
 # ─── Cache headers ──────────────────────────────────────────────────────


### PR DESCRIPTION
The \`staging\` branch has been vestigial for some time: \`auto-sync-master-with-develop.yml\` already promotes develop to master on every \`[RELEASE]\`-tagged commit, so the develop → staging → master hop only added merge artifacts. Recent history is full of post-merge cleanups attributable to staging drift:

- \`a725b00ad fix: remove staging-only web3-api-provider files not present in develop\`
- \`cff4de8c5 fix: restore api-config.ts to develop version (staging merge artifact)\`
- \`81bac419c fix: restore ChainListCard to develop version (duplicate sortedChains from merge)\`
- \`c46c77a55 style: prettier fix staging merge conflicts\`

The latest production incident (\`cloud.tangle.tools\` forwardRef crash, #3204) was triggered by exactly this kind of staging-merge rebuild surfacing a latent chunk-cycle bug — the ABI sync rebuild on master shuffled Rollup chunks differently than the staging rebuild had, exposing the cycle for the first time.

## Changes

- \`.github/workflows/{check-lint,test,check-build,codeql-analysis}.yml\`: drop \`staging\` from the branch trigger lists.
- \`apps/{tangle-cloud,tangle-dapp,leaderboard}/netlify.toml\`: update comments to reflect the new flow and the develop-as-staging deploy environment. The build ignore rule is unchanged — non-master branches already build, so develop branch deploys have always worked (verified at \`https://develop--tangle-cloud.netlify.app\` / \`-dapp\` / \`-leaderboard\` returning 200).
- \`CLAUDE.md\`: rewrite the Branch Strategy section to document the two-branch model, the \`[RELEASE]\` auto-sync convention, and the staging-deploy URL pattern.

## Out-of-band follow-up (separate ops PRs / API calls)

- Delete the \`staging\` branch on origin once this lands.
- Drop \`staging\` from GitHub branch protection rules.
- (Optional) Add Netlify domain aliases for \`staging.{cloud,app,leaderboard}.tangle.tools\` so the staging URLs are stable across deploys.