### PR TITLE
chore: sync tnt-core ABIs to v0.17.0

### DIFF
--- a/libs/tangle-shared-ui/src/abi/blueprintServiceManager.ts
+++ b/libs/tangle-shared-ui/src/abi/blueprintServiceManager.ts
@@ -50,6 +50,35 @@ const ABI = [
   },
   {
     type: 'function',
+    name: 'computeBillAdjustmentBps',
+    inputs: [
+      {
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      {
+        name: 'periodStart',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      {
+        name: 'periodEnd',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+    outputs: [
+      {
+        name: 'adjustmentBps',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
     name: 'forceRemoveAllowsBelowMin',
     inputs: [
       {

--- a/libs/tangle-shared-ui/src/abi/tangle.ts
+++ b/libs/tangle-shared-ui/src/abi/tangle.ts
@@ -2333,7 +2333,7 @@ const ABI = [
             internalType: 'uint256',
           },
           {
-            name: '__reservedAggregateCursor',
+            name: '__reserved0',
             type: 'uint256',
             internalType: 'uint256',
           },
@@ -3163,6 +3163,11 @@ const ABI = [
         type: 'uint16',
         internalType: 'uint16',
       },
+      {
+        name: 'keeperBps',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
     stateMutability: 'view',
   },
@@ -3786,6 +3791,11 @@ const ABI = [
           },
           {
             name: 'stakerBps',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+          {
+            name: 'keeperBps',
             type: 'uint16',
             internalType: 'uint16',
           },


### PR DESCRIPTION
## Summary

Regenerates the locally checked-in tnt-core ABIs in `libs/tangle-shared-ui/src/abi/` from the v0.17.0 bindings on `chore/bindings-v0.17.0` via `yarn sync:tnt-core-assets`.

### ABI delta

`tangle.ts` (+11/-1):
- Adds `keeperBps` (uint16) output to keeper-rebate view accessors.
- Renames a reserved storage slot (`__reservedAggregateCursor` -> `__reserved0`); no UI references.

`blueprintServiceManager.ts` (+29):
- Adds `computeBillAdjustmentBps(serviceId, periodStart, periodEnd) view returns (uint16)`.

`multiAssetDelegation.ts` and `operatorStatusRegistry.ts` were unchanged by the sync (no diff produced).

### Event surface

The dApp does not subscribe to Tangle facet events directly (all event consumption goes through envio). Grepped for the new event names (`OperatorPoolSlashed`, `RewardsClaimSkipped`, `KeeperRebateAccrued`, `TntPaymentDiscountApplied`, `StakerShareRefundedToEscrow`, `SubscriptionBaselineInitialized`, `SubscriptionBillSkippedNoOperators`, `SubscriptionBillAdjustedByManager`) and renamed fields (`stakingPoolAmount` -> `stakerPoolAmount`) across `libs/` and `apps/` and confirmed no UI-side code references them. No per-facet ABI exports needed.

### Verification

- `yarn sync:tnt-core-assets` ran cleanly, no `Missing ABI` warnings.
- `yarn typecheck` green across 5 projects.
- `yarn lint` green across 13 projects.

Depends on tnt-core PR #137 merging.

## Test plan

- [x] `yarn sync:tnt-core-assets`
- [x] `yarn typecheck`
- [x] `yarn lint`