### PR TITLE
chore(abi): sync tnt-core v0.17.1 ABIs

### DIFF
--- a/libs/tangle-shared-ui/src/abi/blueprintServiceManager.ts
+++ b/libs/tangle-shared-ui/src/abi/blueprintServiceManager.ts
@@ -50,6 +50,35 @@ const ABI = [
   },
   {
     type: 'function',
+    name: 'computeBillAdjustmentBps',
+    inputs: [
+      {
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      {
+        name: 'periodStart',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      {
+        name: 'periodEnd',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+    outputs: [
+      {
+        name: 'adjustmentBps',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
     name: 'forceRemoveAllowsBelowMin',
     inputs: [
       {

--- a/libs/tangle-shared-ui/src/abi/tangle.ts
+++ b/libs/tangle-shared-ui/src/abi/tangle.ts
@@ -2333,7 +2333,7 @@ const ABI = [
             internalType: 'uint256',
           },
           {
-            name: '__reservedAggregateCursor',
+            name: '__reserved0',
             type: 'uint256',
             internalType: 'uint256',
           },
@@ -3163,6 +3163,11 @@ const ABI = [
         type: 'uint16',
         internalType: 'uint16',
       },
+      {
+        name: 'keeperBps',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
     ],
     stateMutability: 'view',
   },
@@ -3786,6 +3791,11 @@ const ABI = [
           },
           {
             name: 'stakerBps',
+            type: 'uint16',
+            internalType: 'uint16',
+          },
+          {
+            name: 'keeperBps',
             type: 'uint16',
             internalType: 'uint16',
           },

--- a/libs/tangle-shared-ui/src/abi/tangle.ts
+++ b/libs/tangle-shared-ui/src/abi/tangle.ts
@@ -4317,6 +4317,24 @@ const ABI = [
     stateMutability: 'nonpayable',
   },
   {
+    type: 'function',
+    name: 'withdrawRemainingEscrowTo',
+    inputs: [
+      {
+        name: 'serviceId',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      {
+        name: 'to',
+        type: 'address',
+        internalType: 'address payable',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
     type: 'event',
     name: 'BlueprintCreated',
     inputs: [


### PR DESCRIPTION
Adds `withdrawRemainingEscrowTo` to the Tangle ABI (M-2 audit remediation: owner-chosen escrow refund recipient).

Source: tnt-core-bindings v0.17.1 on crates.io / commit 855a473 on tnt-core main.