### PR TITLE
Support AI Trading blueprint app surface

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/iframe/manifest.spec.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/manifest.spec.ts
@@ -41,6 +41,34 @@ describe('iframe manifest parser', () => {
     expect(result?.allowReadAccount).toBe(true);
   });
 
+  it('parses the AI Trading Arena iframe policy shape', () => {
+    const result = parseIframePolicy({
+      url: 'https://trading-arena.blueprint.tangle.tools/',
+      iframe: {
+        appId: 'trading-arena',
+        allowedChainIds: [31337, 84532],
+        contracts: [
+          {
+            chainId: 31337,
+            address: ADDR,
+          },
+        ],
+        messages: [],
+        allowReadAccount: true,
+        allowChainSwitch: true,
+        allowPopups: false,
+      },
+    });
+
+    expect(result?.origin).toBe('https://trading-arena.blueprint.tangle.tools');
+    expect(result?.appId).toBe('trading-arena');
+    expect(result?.allowedChainIds).toEqual([31337, 84532]);
+    expect(result?.contracts).toHaveLength(1);
+    expect(result?.allowReadAccount).toBe(true);
+    expect(result?.allowChainSwitch).toBe(true);
+    expect(result?.allowPopups).toBe(false);
+  });
+
   it('drops malformed contract grants', () => {
     const result = parseIframePolicy({
       url: 'https://x.blueprint.tangle.tools/',

--- a/apps/tangle-cloud/src/blueprintApps/manifest.spec.ts
+++ b/apps/tangle-cloud/src/blueprintApps/manifest.spec.ts
@@ -213,4 +213,62 @@ describe('blueprint app manifest parsing', () => {
     ]);
     expect(entry.manifest.description).toContain('signature mismatch');
   });
+
+  it('parses AI Trading iframe metadata into the product app surface', () => {
+    const { entry, source } = buildBlueprintManifestFromMetadata({
+      id: '78',
+      blueprintId: 78n,
+      owner: '0x0000000000000000000000000000000000000001',
+      manager: null,
+      metadataUri: 'ipfs://ai-trading',
+      active: true,
+      createdAt: 1n,
+      updatedAt: 1n,
+      operatorCount: 1n,
+      name: 'AI Trading Blueprint',
+      description: 'Autonomous trading agents',
+      author: 'Tangle Network',
+      category: 'Trading',
+      imageUrl: null,
+      codeUrl: null,
+      website: null,
+      metadataVerification: verifiedMetadata,
+      rawMetadata: {
+        blueprintUi: {
+          displayName: 'AI Trading Desk',
+          requestedSlug: 'ai-trading',
+          publisher: {
+            name: 'Tangle Network',
+            namespace: 'tangle',
+            verification: 'verified',
+          },
+          resources: {
+            serviceLabel: 'Trading fleet',
+            itemLabel: 'Bot',
+            itemRoute: 'bots',
+          },
+          surfaces: ['generic-overview', 'chat', 'metrics', 'resources'],
+          externalApp: {
+            url: 'https://trading-arena.blueprint.tangle.tools/',
+            mode: 'iframe',
+            label: 'Open Trading Arena',
+            iframe: {
+              appId: 'trading-arena',
+              allowedChainIds: [31337, 84532],
+              allowReadAccount: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(source).toBe('metadata');
+    expect(entry.slug).toBe('ai-trading');
+    expect(entry.publisher.verification).toBe('verified');
+    expect(entry.manifest.displayName).toBe('AI Trading Desk');
+    expect(entry.manifest.resources.serviceNoun).toBe('Trading fleet');
+    expect(entry.manifest.resources.resourceNoun).toBe('Bot');
+    expect(entry.manifest.resources.resourceRoute).toBe('bots');
+    expect(entry.manifest.surfaces).toContain('chat');
+  });
 });

--- a/apps/tangle-cloud/src/blueprintApps/manifest.ts
+++ b/apps/tangle-cloud/src/blueprintApps/manifest.ts
@@ -115,9 +115,16 @@ function parseResourceModel(
     return fallback;
   }
 
-  const serviceNoun = readString(record.serviceNoun) ?? fallback.serviceNoun;
-  const resourceNoun = readString(record.resourceNoun) ?? fallback.resourceNoun;
-  const resourceRoute = readString(record.resourceRoute);
+  const serviceNoun =
+    readString(record.serviceNoun) ??
+    readString(record.serviceLabel) ??
+    fallback.serviceNoun;
+  const resourceNoun =
+    readString(record.resourceNoun) ??
+    readString(record.itemLabel) ??
+    fallback.resourceNoun;
+  const resourceRoute =
+    readString(record.resourceRoute) ?? readString(record.itemRoute);
 
   return {
     serviceNoun,
@@ -327,6 +334,7 @@ export function buildBlueprintManifestFromMetadata(
     'verified';
   const requestedSlug =
     readString(manifestRoot?.slug) ??
+    readString(manifestRoot?.requestedSlug) ??
     deriveBlueprintRequestedSlug({
       id: blueprint.blueprintId,
       name: blueprint.name,

--- a/apps/tangle-dapp/src/pages/claim/migration/hooks/useSubmitClaim.spec.tsx
+++ b/apps/tangle-dapp/src/pages/claim/migration/hooks/useSubmitClaim.spec.tsx
@@ -157,6 +157,11 @@ describe('useSubmitClaim', () => {
   });
 
   it('throws when migration contract is not configured', async () => {
+    vi.stubEnv(
+      'VITE_TANGLE_MIGRATION_ADDRESS',
+      '0x0000000000000000000000000000000000000000',
+    );
+    vi.stubEnv('VITE_CLAIM_RELAYER_URL', '');
     mockGetMigrationContractsByChainId.mockReturnValue(null);
 
     const useSubmitClaim = await loadHook();

--- a/libs/tangle-shared-ui/src/utils/setupTest.ts
+++ b/libs/tangle-shared-ui/src/utils/setupTest.ts
@@ -1,5 +1,28 @@
 import { vi } from 'vitest';
 
+const storage = new Map<string, string>();
+const localStorageMock = {
+  getItem: vi.fn((key: string) => storage.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    storage.set(key, value);
+  }),
+  removeItem: vi.fn((key: string) => {
+    storage.delete(key);
+  }),
+  clear: vi.fn(() => {
+    storage.clear();
+  }),
+  key: vi.fn((index: number) => Array.from(storage.keys())[index] ?? null),
+  get length() {
+    return storage.size;
+  },
+};
+
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: localStorageMock,
+});
+
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: vi.fn().mockImplementation((query) => ({

--- a/scripts/local-env/blueprint-ui-catalog.mjs
+++ b/scripts/local-env/blueprint-ui-catalog.mjs
@@ -58,13 +58,27 @@ const OPERATOR_GOSSIP_KEYS = [
 // Where blueprint repos live on disk, relative to BLUEPRINT_ROOT
 // (defaults to ~/code so the script works for any operator).
 const BLUEPRINT_ROOT = process.env.BLUEPRINT_ROOT ?? `${process.env.HOME}/code`;
+const WEBB_ROOT = resolve(DAPP_ROOT, '..');
+const firstExistingPath = (...paths) =>
+  paths.find((path) => existsSync(path)) ?? paths[0];
 const BLUEPRINTS = [
   ['ai-agent-sandbox', `${BLUEPRINT_ROOT}/ai-agent-sandbox-blueprint`],
-  ['ai-trading', `${BLUEPRINT_ROOT}/ai-trading-blueprints`],
+  [
+    'ai-trading',
+    process.env.AI_TRADING_BLUEPRINT_PATH ??
+      firstExistingPath(
+        `${WEBB_ROOT}/ai-trading-blueprint`,
+        `${BLUEPRINT_ROOT}/ai-trading-blueprint`,
+        `${BLUEPRINT_ROOT}/ai-trading-blueprints`,
+      ),
+  ],
   ['llm-inference', `${BLUEPRINT_ROOT}/llm-inference-blueprint`],
   ['voice-inference', `${BLUEPRINT_ROOT}/voice-inference-blueprint`],
   ['embedding-inference', `${BLUEPRINT_ROOT}/embedding-inference-blueprint`],
-  ['distributed-inference', `${BLUEPRINT_ROOT}/distributed-inference-blueprint`],
+  [
+    'distributed-inference',
+    `${BLUEPRINT_ROOT}/distributed-inference-blueprint`,
+  ],
   ['avatar-inference', `${BLUEPRINT_ROOT}/avatar-inference-blueprint`],
   ['image-generation', `${BLUEPRINT_ROOT}/image-gen-inference-blueprint`],
   ['modal-inference', `${BLUEPRINT_ROOT}/modal-inference-blueprint`],
@@ -467,8 +481,12 @@ const applyLocalIframeOverride = (slug, metadata) => {
 };
 
 const loadCatalog = () =>
-  BLUEPRINTS.map(([slug, repoPath]) => {
+  BLUEPRINTS.flatMap(([slug, repoPath]) => {
     const sourcePath = resolve(repoPath, 'metadata/blueprint-metadata.json');
+    if (!existsSync(sourcePath)) {
+      console.warn(`skipping ${slug}: missing ${sourcePath}`);
+      return [];
+    }
     const sourceMetadata = JSON.parse(readFileSync(sourcePath, 'utf8'));
     const metadata = applyLocalIframeOverride(
       slug,
@@ -682,7 +700,11 @@ const signMetadata = async ({ item, blueprintId, ownerAccount }) => {
 // Idempotent: returns immediately if the operator is already active in
 // staking. Otherwise approves OPERATOR_BOND TNT and registers with asset.
 // We swallow duplicate-registration reverts so re-runs are safe.
-const ensureOperatorActiveInStaking = async (operator, wallet, publicClient) => {
+const ensureOperatorActiveInStaking = async (
+  operator,
+  wallet,
+  publicClient,
+) => {
   const active = await publicClient.readContract({
     address: STAKING_ADDRESS,
     abi: stakingAbi,
@@ -707,7 +729,9 @@ const ensureOperatorActiveInStaking = async (operator, wallet, publicClient) => 
       args: [TNT_TOKEN_ADDRESS, OPERATOR_BOND],
     });
     await waitForHash(publicClient, registerHash);
-    console.log(`  + staking: ${operator.address} bonded ${OPERATOR_BOND / 10n ** 18n} TNT`);
+    console.log(
+      `  + staking: ${operator.address} bonded ${OPERATOR_BOND / 10n ** 18n} TNT`,
+    );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     // Often this fails benignly because the operator is already
@@ -893,7 +917,10 @@ const seed = async () => {
       }
     }
 
-    if (requestId !== undefined && !activatedByRequest.has(requestId.toString())) {
+    if (
+      requestId !== undefined &&
+      !activatedByRequest.has(requestId.toString())
+    ) {
       console.log(`Approving service request ${requestId} for ${item.slug}`);
       const operatorWallet = createWalletClient({
         account: operators[0],
@@ -1183,7 +1210,9 @@ const deployBlueprintApps = async (filterSlugs) => {
       if (filterSlugs.length > 0 && !filterSlugs.includes(slug)) return null;
       const build = findUiSubdir(item.repoPath);
       if (!build) {
-        console.warn(`skipping ${slug}: no UI subdir with build script in ${item.repoPath}`);
+        console.warn(
+          `skipping ${slug}: no UI subdir with build script in ${item.repoPath}`,
+        );
         return null;
       }
       return { slug, hostname: host, repoPath: item.repoPath, build };


### PR DESCRIPTION
## Summary
- Parse both / and resource field variants so AI Trading metadata resolves to the intended product route/resource model in Tangle Cloud.
- Add AI Trading Arena iframe policy coverage and manifest parser coverage.
- Let the local blueprint UI catalog discover the sibling  checkout and skip optional missing blueprint repos instead of failing the whole catalog.
- Add test setup localStorage shim required by the published  package.
- Fix an existing claim migration test isolation issue by explicitly stubbing the migration env vars in the unconfigured-contract case.

## Verification
- 
-  from  passed: 12/12 tests.
-  from  passed: 4/4 tests.
- Prepared 1 metadata documents in /Users/drew/webb/dapp/scripts/local-env/blueprint-ui-catalog/generated generated  from .
-  passed for generated  and generated catalog manifest.
- Husky pre-push hook passed: lint + format + test + build.