### PR TITLE
Support AI Agent Sandbox blueprint app surface

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/iframe/manifest.spec.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/manifest.spec.ts
@@ -69,6 +69,40 @@ describe('iframe manifest parser', () => {
     expect(result?.allowPopups).toBe(false);
   });
 
+  it('parses the AI Agent Sandbox iframe policy shape', () => {
+    const result = parseIframePolicy({
+      url: 'https://agent-sandbox.blueprint.tangle.tools/',
+      iframe: {
+        appId: 'agent-sandbox',
+        allowedChainIds: [31337, 84532],
+        contracts: [
+          {
+            chainId: 31337,
+            address: ADDR,
+          },
+        ],
+        messages: [
+          {
+            chainId: 31337,
+          },
+          {
+            chainId: 84532,
+          },
+        ],
+        allowReadAccount: true,
+        allowChainSwitch: true,
+        allowPopups: false,
+      },
+    });
+
+    expect(result?.origin).toBe('https://agent-sandbox.blueprint.tangle.tools');
+    expect(result?.appId).toBe('agent-sandbox');
+    expect(result?.allowedChainIds).toEqual([31337, 84532]);
+    expect(result?.contracts).toHaveLength(1);
+    expect(result?.messages).toHaveLength(2);
+    expect(result?.allowReadAccount).toBe(true);
+  });
+
   it('drops malformed contract grants', () => {
     const result = parseIframePolicy({
       url: 'https://x.blueprint.tangle.tools/',

--- a/apps/tangle-cloud/src/blueprintApps/manifest.spec.ts
+++ b/apps/tangle-cloud/src/blueprintApps/manifest.spec.ts
@@ -271,4 +271,61 @@ describe('blueprint app manifest parsing', () => {
     expect(entry.manifest.resources.resourceRoute).toBe('bots');
     expect(entry.manifest.surfaces).toContain('chat');
   });
+
+  it('parses AI Agent Sandbox iframe metadata into the product app surface', () => {
+    const { entry, source } = buildBlueprintManifestFromMetadata({
+      id: '79',
+      blueprintId: 79n,
+      owner: '0x0000000000000000000000000000000000000001',
+      manager: null,
+      metadataUri: 'ipfs://ai-agent-sandbox',
+      active: true,
+      createdAt: 1n,
+      updatedAt: 1n,
+      operatorCount: 1n,
+      name: 'AI Agent Sandbox Blueprint',
+      description: 'Attested agent sandboxes',
+      author: 'Tangle Network',
+      category: 'AI Agents',
+      imageUrl: null,
+      codeUrl: null,
+      website: null,
+      metadataVerification: verifiedMetadata,
+      rawMetadata: {
+        blueprintUi: {
+          displayName: 'AI Agent Sandbox',
+          requestedSlug: 'ai-agent-sandbox',
+          publisher: {
+            name: 'Tangle Network',
+            namespace: 'tangle',
+            verification: 'verified',
+          },
+          resources: {
+            serviceLabel: 'Sandbox fleet',
+            itemLabel: 'Agent',
+            itemRoute: 'agents',
+          },
+          surfaces: ['generic-overview', 'metrics', 'resources'],
+          externalApp: {
+            url: 'https://agent-sandbox.blueprint.tangle.tools/',
+            mode: 'iframe',
+            label: 'Open Agent Sandbox',
+            iframe: {
+              appId: 'agent-sandbox',
+              allowedChainIds: [31337, 84532],
+              allowReadAccount: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(source).toBe('metadata');
+    expect(entry.slug).toBe('ai-agent-sandbox');
+    expect(entry.publisher.verification).toBe('verified');
+    expect(entry.manifest.displayName).toBe('AI Agent Sandbox');
+    expect(entry.manifest.resources.serviceNoun).toBe('Sandbox fleet');
+    expect(entry.manifest.resources.resourceNoun).toBe('Agent');
+    expect(entry.manifest.resources.resourceRoute).toBe('agents');
+  });
 });

--- a/scripts/local-env/blueprint-ui-catalog.mjs
+++ b/scripts/local-env/blueprint-ui-catalog.mjs
@@ -62,7 +62,14 @@ const WEBB_ROOT = resolve(DAPP_ROOT, '..');
 const firstExistingPath = (...paths) =>
   paths.find((path) => existsSync(path)) ?? paths[0];
 const BLUEPRINTS = [
-  ['ai-agent-sandbox', `${BLUEPRINT_ROOT}/ai-agent-sandbox-blueprint`],
+  [
+    'ai-agent-sandbox',
+    process.env.AI_AGENT_SANDBOX_BLUEPRINT_PATH ??
+      firstExistingPath(
+        `${WEBB_ROOT}/ai-agent-sandbox-blueprint`,
+        `${BLUEPRINT_ROOT}/ai-agent-sandbox-blueprint`,
+      ),
+  ],
   [
     'ai-trading',
     process.env.AI_TRADING_BLUEPRINT_PATH ??


### PR DESCRIPTION
## Summary
- add AI Agent Sandbox metadata parsing coverage for the Tangle Cloud product app surface
- add iframe policy coverage for `https://agent-sandbox.blueprint.tangle.tools`
- let the local blueprint UI catalog discover sibling `~/webb/ai-agent-sandbox-blueprint` via `AI_AGENT_SANDBOX_BLUEPRINT_PATH`

## Verification
- `../../node_modules/.bin/vitest run src/blueprintApps/manifest.spec.ts src/blueprintApps/iframe/manifest.spec.ts` from `apps/tangle-cloud` (14/14)
- `node scripts/local-env/blueprint-ui-catalog.mjs prepare` generated both `ai-agent-sandbox` and `ai-trading`
- full dapp pre-push gate passed: lint, format, test, build

Companion sandbox blueprint metadata PR: https://github.com/tangle-network/ai-agent-sandbox-blueprint/pull/70
