### PR TITLE
fix(blueprint-metadata): resolve bare github.com URIs to raw metadata JSON

### DIFF
--- a/libs/tangle-shared-ui/src/blueprintApps/authoring.spec.ts
+++ b/libs/tangle-shared-ui/src/blueprintApps/authoring.spec.ts
@@ -1,0 +1,50 @@
+import { resolveBlueprintMetadataFetchUrl } from './metadataFetchUrl';
+
+// `localPreview` reads `import.meta.env`, which @swc/jest leaves as-is and
+// then breaks Node's CommonJS parser. Stub it out — these tests never need
+// the localhost-rewrite branch since they only assert pass-through behavior
+// for non-localhost URLs.
+jest.mock('../utils/localPreview', () => ({
+  isLocalPreviewHost: () => false,
+  rewriteLocalhostUrlForBrowser: (value: string) => value,
+}));
+
+describe('resolveBlueprintMetadataFetchUrl', () => {
+  it('rewrites ipfs:// URIs to the public ipfs.io gateway', () => {
+    expect(resolveBlueprintMetadataFetchUrl('ipfs://abc')).toBe(
+      'https://ipfs.io/ipfs/abc',
+    );
+  });
+
+  it('translates a bare github.com repo URL to raw.githubusercontent.com/main/metadata/blueprint-metadata.json', () => {
+    expect(resolveBlueprintMetadataFetchUrl('https://github.com/foo/bar')).toBe(
+      'https://raw.githubusercontent.com/foo/bar/main/metadata/blueprint-metadata.json',
+    );
+  });
+
+  it('handles a bare github.com repo URL with a trailing slash', () => {
+    expect(
+      resolveBlueprintMetadataFetchUrl('https://github.com/foo/bar/'),
+    ).toBe(
+      'https://raw.githubusercontent.com/foo/bar/main/metadata/blueprint-metadata.json',
+    );
+  });
+
+  it('strips a .git suffix from a bare github.com repo URL', () => {
+    expect(
+      resolveBlueprintMetadataFetchUrl('https://github.com/foo/bar.git'),
+    ).toBe(
+      'https://raw.githubusercontent.com/foo/bar/main/metadata/blueprint-metadata.json',
+    );
+  });
+
+  it('returns github.com URLs with sub-paths unchanged (only bare repo URLs are translated)', () => {
+    const input = 'https://github.com/foo/bar/tree/main/something';
+    expect(resolveBlueprintMetadataFetchUrl(input)).toBe(input);
+  });
+
+  it('returns unrelated https URLs unchanged', () => {
+    const input = 'https://example.com/raw.json';
+    expect(resolveBlueprintMetadataFetchUrl(input)).toBe(input);
+  });
+});

--- a/libs/tangle-shared-ui/src/blueprintApps/authoring.ts
+++ b/libs/tangle-shared-ui/src/blueprintApps/authoring.ts
@@ -7,10 +7,7 @@ import {
   type Address,
   type Hex,
 } from 'viem';
-import {
-  isLocalPreviewHost,
-  rewriteLocalhostUrlForBrowser,
-} from '../utils/localPreview';
+import { isLocalPreviewHost } from '../utils/localPreview';
 import type {
   BlueprintMetadataAttestation,
   BlueprintMetadataVerification,
@@ -1075,16 +1072,7 @@ export const parseBlueprintMetadataJsonText = (
   };
 };
 
-export const resolveBlueprintMetadataFetchUrl = (
-  metadataUri: string,
-): string => {
-  if (!metadataUri.startsWith('ipfs://')) {
-    return rewriteLocalhostUrlForBrowser(metadataUri);
-  }
-
-  const cid = metadataUri.replace('ipfs://', '');
-  return `https://ipfs.io/ipfs/${cid}`;
-};
+export { resolveBlueprintMetadataFetchUrl } from './metadataFetchUrl';
 
 export const buildBlueprintUiMetadataDocument = ({
   name,

--- a/libs/tangle-shared-ui/src/blueprintApps/metadataFetchUrl.ts
+++ b/libs/tangle-shared-ui/src/blueprintApps/metadataFetchUrl.ts
@@ -1,0 +1,38 @@
+import { rewriteLocalhostUrlForBrowser } from '../utils/localPreview';
+
+// Matches a "bare" GitHub repo URL like `https://github.com/<owner>/<repo>`
+// (optionally with a trailing slash or `.git` suffix). URLs with any
+// additional path segments (e.g. `/tree/main/...`) intentionally do NOT
+// match — those are assumed to already point at a specific resource and are
+// returned untouched.
+const GITHUB_REPO_PATTERN =
+  /^https:\/\/github\.com\/([^/]+)\/([^/?#]+?)(?:\.git)?\/?$/;
+
+/**
+ * Translate an on-chain blueprint `metadataUri` into a URL the dapp can
+ * `fetch()` to retrieve the metadata JSON document.
+ *
+ * - `ipfs://CID` is rewritten to the public ipfs.io gateway.
+ * - A bare `https://github.com/<owner>/<repo>` URL is rewritten to the
+ *   canonical raw `metadata/blueprint-metadata.json` path on the `main`
+ *   branch. Repos that default to `master` will 404 — they can be fixed
+ *   on-chain via `updateBlueprint`.
+ * - Anything else (including GitHub URLs with sub-paths and arbitrary HTTPS
+ *   URLs) is passed through `rewriteLocalhostUrlForBrowser` unchanged.
+ */
+export const resolveBlueprintMetadataFetchUrl = (
+  metadataUri: string,
+): string => {
+  if (metadataUri.startsWith('ipfs://')) {
+    const cid = metadataUri.replace('ipfs://', '');
+    return `https://ipfs.io/ipfs/${cid}`;
+  }
+
+  const githubMatch = metadataUri.match(GITHUB_REPO_PATTERN);
+  if (githubMatch) {
+    const [, owner, repo] = githubMatch;
+    return `https://raw.githubusercontent.com/${owner}/${repo}/main/metadata/blueprint-metadata.json`;
+  }
+
+  return rewriteLocalhostUrlForBrowser(metadataUri);
+};


### PR DESCRIPTION
## Summary

- Several blueprints just registered on Base Sepolia (e.g. ai-agent-sandbox, llm-inference, modal-inference, image-gen-inference) carry an on-chain `metadataUri` that points at the repo's GitHub HTML page (`https://github.com/<owner>/<repo>`). The dapp `fetch()`-es that URL expecting JSON, receives HTML, `parseBlueprintMetadataJsonText` bails out, and every affected blueprint renders as unavailable.
- Teach `resolveBlueprintMetadataFetchUrl` to translate a bare `github.com/<owner>/<repo>` URL (optionally with a trailing slash or `.git` suffix) into `raw.githubusercontent.com/<owner>/<repo>/main/metadata/blueprint-metadata.json`. `ipfs://` handling is untouched, URLs with sub-paths (`/tree/main/...`) are passed through unchanged, and any other HTTPS URL still flows through `rewriteLocalhostUrlForBrowser`.
- Repos that default to `master` instead of `main` will 404 for now — that's accepted as a follow-up (fixable on-chain via `updateBlueprint`, or we can add a `main` → `master` fallback later). The four repos with on-chain registrations today all default to `main`.
- The resolver moves into its own `metadataFetchUrl.ts` so unit tests don't transitively pull in the authoring module's `import.meta.env` reference; `authoring.ts` re-exports the function so the public API is identical.

## Test plan

- [x] `yarn nx test tangle-shared-ui --testPathPattern=authoring` — 6 new cases (ipfs, bare GitHub, trailing slash, `.git`, sub-path passthrough, unrelated HTTPS passthrough), all pass.
- [x] `yarn nx test tangle-shared-ui` — full suite green (32 tests).
- [x] `yarn nx test tangle-cloud` — full suite green (109 tests).
- [x] `yarn nx lint tangle-shared-ui` — clean.
- [x] `yarn nx build tangle-cloud` — clean.
- [ ] Manual smoke on Base Sepolia: hit the four affected blueprint detail pages and confirm metadata loads.