### PR TITLE
fix(blueprint-metadata): fall back to master when main returns 404

### DIFF
--- a/libs/tangle-shared-ui/src/blueprintApps/authoring.spec.ts
+++ b/libs/tangle-shared-ui/src/blueprintApps/authoring.spec.ts
@@ -1,4 +1,7 @@
-import { resolveBlueprintMetadataFetchUrl } from './metadataFetchUrl';
+import {
+  resolveBlueprintMetadataFetchUrl,
+  resolveBlueprintMetadataFetchUrls,
+} from './metadataFetchUrl';
 
 // `localPreview` reads `import.meta.env`, which @swc/jest leaves as-is and
 // then breaks Node's CommonJS parser. Stub it out — these tests never need
@@ -46,5 +49,42 @@ describe('resolveBlueprintMetadataFetchUrl', () => {
   it('returns unrelated https URLs unchanged', () => {
     const input = 'https://example.com/raw.json';
     expect(resolveBlueprintMetadataFetchUrl(input)).toBe(input);
+  });
+});
+
+describe('resolveBlueprintMetadataFetchUrls (fallback candidates)', () => {
+  it('returns ipfs:// as a single-element list', () => {
+    expect(resolveBlueprintMetadataFetchUrls('ipfs://abc')).toEqual([
+      'https://ipfs.io/ipfs/abc',
+    ]);
+  });
+
+  it('expands a bare github.com URL to main first then master', () => {
+    expect(
+      resolveBlueprintMetadataFetchUrls('https://github.com/foo/bar'),
+    ).toEqual([
+      'https://raw.githubusercontent.com/foo/bar/main/metadata/blueprint-metadata.json',
+      'https://raw.githubusercontent.com/foo/bar/master/metadata/blueprint-metadata.json',
+    ]);
+  });
+
+  it('expands trailing-slash and .git variants identically', () => {
+    const fromTrail = resolveBlueprintMetadataFetchUrls(
+      'https://github.com/foo/bar/',
+    );
+    const fromGit = resolveBlueprintMetadataFetchUrls(
+      'https://github.com/foo/bar.git',
+    );
+    expect(fromTrail).toEqual([
+      'https://raw.githubusercontent.com/foo/bar/main/metadata/blueprint-metadata.json',
+      'https://raw.githubusercontent.com/foo/bar/master/metadata/blueprint-metadata.json',
+    ]);
+    expect(fromGit).toEqual(fromTrail);
+  });
+
+  it('returns unrelated https URLs as a single-element list', () => {
+    expect(
+      resolveBlueprintMetadataFetchUrls('https://example.com/raw.json'),
+    ).toEqual(['https://example.com/raw.json']);
   });
 });

--- a/libs/tangle-shared-ui/src/blueprintApps/authoring.ts
+++ b/libs/tangle-shared-ui/src/blueprintApps/authoring.ts
@@ -1072,7 +1072,10 @@ export const parseBlueprintMetadataJsonText = (
   };
 };
 
-export { resolveBlueprintMetadataFetchUrl } from './metadataFetchUrl';
+export {
+  resolveBlueprintMetadataFetchUrl,
+  resolveBlueprintMetadataFetchUrls,
+} from './metadataFetchUrl';
 
 export const buildBlueprintUiMetadataDocument = ({
   name,

--- a/libs/tangle-shared-ui/src/blueprintApps/metadataFetchUrl.ts
+++ b/libs/tangle-shared-ui/src/blueprintApps/metadataFetchUrl.ts
@@ -9,30 +9,47 @@ const GITHUB_REPO_PATTERN =
   /^https:\/\/github\.com\/([^/]+)\/([^/?#]+?)(?:\.git)?\/?$/;
 
 /**
- * Translate an on-chain blueprint `metadataUri` into a URL the dapp can
- * `fetch()` to retrieve the metadata JSON document.
+ * Translate an on-chain blueprint `metadataUri` into the ORDERED list of
+ * URLs the dapp should try in sequence to retrieve the metadata JSON
+ * document. The first URL that returns a successful response wins.
  *
- * - `ipfs://CID` is rewritten to the public ipfs.io gateway.
- * - A bare `https://github.com/<owner>/<repo>` URL is rewritten to the
- *   canonical raw `metadata/blueprint-metadata.json` path on the `main`
- *   branch. Repos that default to `master` will 404 — they can be fixed
- *   on-chain via `updateBlueprint`.
- * - Anything else (including GitHub URLs with sub-paths and arbitrary HTTPS
- *   URLs) is passed through `rewriteLocalhostUrlForBrowser` unchanged.
+ * - `ipfs://CID` is rewritten to a single public ipfs.io gateway URL.
+ * - A bare `https://github.com/<owner>/<repo>` URL expands to TWO
+ *   candidates: the `main` branch first, then `master` as a fallback. A
+ *   nontrivial fraction of org repos still default to `master`, and a
+ *   single hardcoded branch would 404 for them — the caller iterates so
+ *   we never need an extra round-trip when `main` exists.
+ * - Anything else (including GitHub URLs with sub-paths and arbitrary
+ *   HTTPS URLs) is passed through `rewriteLocalhostUrlForBrowser` and
+ *   returned as a single-element list.
  */
-export const resolveBlueprintMetadataFetchUrl = (
+export const resolveBlueprintMetadataFetchUrls = (
   metadataUri: string,
-): string => {
+): string[] => {
   if (metadataUri.startsWith('ipfs://')) {
     const cid = metadataUri.replace('ipfs://', '');
-    return `https://ipfs.io/ipfs/${cid}`;
+    return [`https://ipfs.io/ipfs/${cid}`];
   }
 
   const githubMatch = metadataUri.match(GITHUB_REPO_PATTERN);
   if (githubMatch) {
     const [, owner, repo] = githubMatch;
-    return `https://raw.githubusercontent.com/${owner}/${repo}/main/metadata/blueprint-metadata.json`;
+    return [
+      `https://raw.githubusercontent.com/${owner}/${repo}/main/metadata/blueprint-metadata.json`,
+      `https://raw.githubusercontent.com/${owner}/${repo}/master/metadata/blueprint-metadata.json`,
+    ];
   }
 
-  return rewriteLocalhostUrlForBrowser(metadataUri);
+  return [rewriteLocalhostUrlForBrowser(metadataUri)];
 };
+
+/**
+ * Backwards-compatible single-URL resolver. Returns the FIRST candidate
+ * URL from {@link resolveBlueprintMetadataFetchUrls}.
+ *
+ * Prefer {@link resolveBlueprintMetadataFetchUrls} at fetch sites — it
+ * returns the full fallback list so callers can try `master` after `main`
+ * for GitHub URLs.
+ */
+export const resolveBlueprintMetadataFetchUrl = (metadataUri: string): string =>
+  resolveBlueprintMetadataFetchUrls(metadataUri)[0];

--- a/libs/tangle-shared-ui/src/data/graphql/useBlueprints.ts
+++ b/libs/tangle-shared-ui/src/data/graphql/useBlueprints.ts
@@ -14,7 +14,7 @@ import useNetworkStore from '../../context/useNetworkStore';
 import type { Blueprint as AppBlueprint } from '../../types/blueprint';
 import {
   parseBlueprintMetadataJsonText,
-  resolveBlueprintMetadataFetchUrl,
+  resolveBlueprintMetadataFetchUrls,
   verifyBlueprintMetadataIntegrity,
 } from '../../blueprintApps/authoring';
 import type {
@@ -183,15 +183,25 @@ const fetchBlueprintMetadata = async ({
     return unavailableMetadata(metadataUri);
   }
 
+  // GitHub repo URIs expand to BOTH `main` and `master` candidates; try
+  // them in order so repos that default to `master` (legacy MPC blueprints,
+  // anything yarbed pre-2020) don't return as `unavailableMetadata`.
+  const candidates = resolveBlueprintMetadataFetchUrls(metadataUri);
   try {
-    const response = await fetch(
-      resolveBlueprintMetadataFetchUrl(metadataUri),
-      {
+    let response: Response | null = null;
+    let lastStatus = 0;
+    for (const candidate of candidates) {
+      const attempt = await fetch(candidate, {
         signal: AbortSignal.timeout(5000),
-      },
-    );
-    if (!response.ok) {
-      throw new Error(`Failed to fetch metadata: ${response.status}`);
+      });
+      if (attempt.ok) {
+        response = attempt;
+        break;
+      }
+      lastStatus = attempt.status;
+    }
+    if (response === null) {
+      throw new Error(`Failed to fetch metadata: ${lastStatus}`);
     }
 
     const metadataText = await response.text();


### PR DESCRIPTION
The GitHub-URL resolver added in #3219 hardcodes `main` as the branch. 2 of the 13 blueprints registered on Base Sepolia (`modal-inference-blueprint`, `voice-inference-blueprint`) default to `master` and 404 with the current resolver — the dapp shows them as unavailable.

## Fix

Change the resolver to return an **ordered list of candidate URLs** (`main` first, then `master` for bare GitHub URLs) and update the single fetch site in `useBlueprints.ts` to try each candidate in order until one returns a 200.

- New `resolveBlueprintMetadataFetchUrls` (plural) returns the candidate list.
- Kept singular `resolveBlueprintMetadataFetchUrl` returning the first candidate (preserves existing public API).
- `useBlueprints` iterates candidates, tracks last failing status for a sensible error if every candidate 404s.
- 4 new unit tests covering the plural function (ipfs, GitHub bare + trailing slash + .git, unrelated HTTPS). All existing tests still pass (10 total).

## Verified

- `https://raw.githubusercontent.com/tangle-network/voice-inference-blueprint/master/metadata/blueprint-metadata.json` → 200
- `https://raw.githubusercontent.com/tangle-network/modal-inference-blueprint/master/metadata/blueprint-metadata.json` → 200

After this lands on develop, all 13 Base Sepolia blueprints render in tangle-cloud staging.