### PR TITLE
fix(tangle-cloud): scroll reset + indexer empty-state + sidebar rename

### DIFF
--- a/apps/tangle-cloud/src/app/app.tsx
+++ b/apps/tangle-cloud/src/app/app.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes } from 'react-router';
 import { lazy, Suspense, type FC, type ReactNode } from 'react';
 import Layout from '../components/Layout';
+import ScrollToTop from '../components/ScrollToTop';
 import Providers from './providers';
 import { PagePath } from '../types';
 import { Skeleton } from '@tangle-network/sandbox-ui/primitives';
@@ -70,6 +71,7 @@ const withLayout = (LayoutCmp: FC<{ children: ReactNode }>, Page: FC) => (
 const App: FC = () => {
   return (
     <Providers>
+      <ScrollToTop />
       <Layout>
         <Routes>
           <Route

--- a/apps/tangle-cloud/src/components/ScrollToTop.tsx
+++ b/apps/tangle-cloud/src/components/ScrollToTop.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Reset the window scroll position to (0, 0) on every pathname change.
+ *
+ * The default `react-router-dom` `<BrowserRouter>` is path-aware but
+ * scroll-naive: navigating from a long /blueprints listing to /rewards
+ * lands the next page already scrolled wherever the previous page was,
+ * which makes transitions feel broken (the user has to scroll up to
+ * read the heading of the new page).
+ *
+ * Drop this component anywhere inside the router tree — it renders
+ * `null` and only runs an effect.
+ *
+ * NOTE: pathname-only dependency is deliberate. We do NOT scroll on
+ * search-param or hash changes, because some pages use those for in-page
+ * tab state and an unsolicited scroll would yank the viewport away.
+ */
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    // Use 'instant' (not 'smooth') so the new page is at the top before
+    // the first paint — smooth-scroll across route transitions looks
+    // janky because the previous page's content briefly remains visible.
+    window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/apps/tangle-cloud/src/components/Sidebar.tsx
+++ b/apps/tangle-cloud/src/components/Sidebar.tsx
@@ -66,7 +66,7 @@ const SIDEBAR_ITEMS: SidebarItem[] = [
     Icon: CoinsLineIcon,
   },
   {
-    name: 'Payments',
+    name: 'Private Payments',
     href: PagePath.PAYMENTS_POOL,
     isInternal: true,
     Icon: ShieldKeyholeLineIcon,

--- a/apps/tangle-cloud/src/pages/rewards/page.tsx
+++ b/apps/tangle-cloud/src/pages/rewards/page.tsx
@@ -415,7 +415,18 @@ const RewardsPage: FC = () => {
               <Skeleton className="h-16 rounded-md" />
             </div>
           ) : rewardHistoryError ? (
-            <ErrorMessage>Could not load claim history.</ErrorMessage>
+            // Render an empty-state instead of a red error when the
+            // indexer is simply absent (e.g. `testnet` env with no
+            // VITE_ENVIO_TESTNET_ENDPOINT configured). The original
+            // `<ErrorMessage>` here surfaced an alarming
+            // "Could not load claim history" banner on every page
+            // load — that's the UX equivalent of a 500, but the
+            // actual cause is "no historical data source", which is
+            // a legitimate empty state.
+            <EmptyState
+              title="Claim history unavailable on this network"
+              description="The indexed history endpoint is not configured for this network. Past reward claims will appear here once the indexer is online."
+            />
           ) : rewardHistory?.length ? (
             <RewardClaimsTable
               entries={rewardHistory}


### PR DESCRIPTION
## Three fixes shipped in this PR

1. **Scroll resets to top on route change** — new `<ScrollToTop>` mounted inside the router.
2. **Claim history empty state** — drops the red "Could not load" banner that fired whenever the testnet Envio indexer wasn't configured (the actual current state on `develop.cloud.tangle.tools`). Now renders a neutral empty state.
3. **Sidebar: "Payments" → "Private Payments"** — surfaces the shielded-billing aspect.

Sanity: `yarn nx build tangle-cloud` clean. No layout / data changes.

## What this PR explicitly does NOT do

These are the bigger, real UX issues you flagged. Each becomes its own PR. The plan below lists 5 alternatives per surface, picks the strongest, and queues them in execution order.

---

# Tangle Cloud — design / UX roadmap (post staging walkthrough)

Driven by a real walkthrough of `develop.cloud.tangle.tools`. Current rating: 2/10. Target: 10/10. Approach: mirror what's working in the staking dapp's `tangle-dapp/src/pages/dashboard.tsx` and the shared `@tangle-network/ui-components` primitives the staking app uses — and stop hand-rolling junior-Figma-style nested transparent cards.

### Component 1 — **Home / Instances page** (currently 2/10)

Symptoms: huge "Instances" hero card with nothing useful in it, then a tiny services strip, then a 2-column account-stats + "Instructions" grid, then a TVL block. The user has to scan past the marketing copy before reaching anything actionable. There's no token balance, no pending rewards summary, no "what should I do next" hierarchy.

Five alternatives:

1. **Mirror `tangle-dapp/dashboard.tsx` directly.** Two-col hero (`AccountSummaryCard` + `ProtocolStatisticCard`) → token breakdown card → "Your Position" table → "Available Blueprints" table. This is the proven layout in the staking app. Use the same components where the import resolves cleanly.
2. **Information-density-first.** Replace the hero card with a one-line breadcrumb + a 4-tile KPI strip (running services / pending requests / claimable rewards / TNT balance). Push everything else below the fold of the first viewport.
3. **Operator-vs-customer split.** Two separate vertical lanes: a left "operate" pane (services you run, pending operator approvals, rewards) and a right "use" pane (services you've requested, payment balances). Today the same page mixes both — clearer mental model with the split.
4. **Action-first.** A top "Next steps" card that picks 1-3 actions based on account state (e.g. "Approve service request #42", "Claim 12.4 TNT in rewards", "Stake to become an operator"). Everything else is reference data below.
5. **Trim hard.** Delete the InstructionCard, fold TVL into the header KPI strip, kill the gradient-radial backdrop. One screen of meaningful info beats two screens of placeholder.

**Pick: 1 with elements of 4.** Mirror the staking dashboard layout (proven, components exist, consistent with the rest of the org) and add a single "Next steps" card at the top of the right column. Trim the InstructionCard to a one-line link in the footer.

### Component 2 — **Account / "My deposits" component** (currently 0/10)

Symptoms: "My deposits" sounds like the user has deposits to claim, but clicking it dumps the user to the staking app entirely. Information hierarchy is wrong — quick actions are buried in two columns at the bottom; the user wants account state on top.

Five alternatives:

1. **Mirror `AccountSummaryCard` from staking-app.** Wallet badge, TNT balance, USDC balance, pending rewards, all in one tight card. Quick actions become icon buttons in the card's footer (Stake / Withdraw / Claim).
2. **Drop "deposits" terminology entirely** — replace with "Wallet" + "Stake" + "Rewards" — those map to actual on-chain concepts the user understands.
3. **Embed staking surface inline instead of redirecting.** A small "Stake to become an operator" inline action that opens a drawer with the relevant flow, rather than punting to `/staking`.
4. **Two-level: account hero card with totals, then a collapsible "Activity" panel** for recent deposits / withdraws / claims. Default collapsed.
5. **Single-column condensed mode for mobile, two-column expanded for desktop.** Today the layout is the same at every breakpoint — the desktop version wastes a ton of width on the "Instructions" card next to a compact stats card.

**Pick: 1 + 2.** Reuse the staking app's `AccountSummaryCard` shape, rename "deposits" → "wallet/stake/rewards". Keep quick-action icon buttons but move them to the card footer, not a separate component.

### Component 3 — **Blueprints page** ("delete the whole thing")

Symptoms: top-level filters are "Catalog / Owned / Role / Operator" — incomprehensible. "Owned" is undefined. "Role" is incoherent because an account has multiple roles. Empty state literally renders "0 Catalog, 0 Owned, 0 Role, 0 Operator" — zero information value.

Five alternatives:

1. **Single catalog grid.** No tabs. Each blueprint card: thumbnail, name, publisher badge, one-line description, "Deploy" button, "Open app" if `externalApp.url` is set. Filter chips below for category (AI / Inference / Trading / Storage / MPC). Search bar at top-right.
2. **Two-view toggle: Catalog ↔ Your services.** "Catalog" = the chain-registered blueprints anyone can deploy. "Your services" = the running services where the connected account is operator or customer. Drop "Owned" + "Role" entirely.
3. **Marketplace-style.** Featured row at top (curated by publisher verification), then category-grouped sections below. Mirrors how Apple's App Store / npm explore feels.
4. **Operator-detail-driven.** Each blueprint card expands to show registered operators, their endpoint, performance. The current operator list is buried — make it a primary affordance.
5. **Per-publisher namespacing.** Show a "Tangle Network", "Community" set of publisher buckets, then blueprints within each. The current page treats all blueprints as a flat list, losing publisher provenance.

**Pick: 1 + 2.** Single grid + a single Catalog/Your-services toggle. Drop Owned and Role entirely.

### Component 4 — **Operators page** (currently slow, weak empty state)

Symptoms: 5-10s blank page before any data renders. No skeleton, no "loading...". When data eventually arrives, it's a low-info table.

Five alternatives:

1. **Skeleton-first.** Render the full table shell with skeleton rows immediately, populate as data arrives. (Pattern already used on rewards page.)
2. **Pre-fetch on hover** over the sidebar "Operators" item. By the time the user clicks, the data is already in the React Query cache.
3. **Stream operators progressively** instead of batching the full list. Render the first 10 immediately as on-chain reads resolve, append the rest.
4. **Cache for 60s.** First navigation pays the load, subsequent navigations within a minute hit the cache. Mark stale + revalidate in the background.
5. **Move the "Become an operator" CTA to the top** so a user with no operators sees something actionable while data loads.

**Pick: 1 + 4.** Skeleton-first rendering + React Query staleTime 60s. Cheap, high impact.

### Component 5 — **Visual aesthetic / component hierarchy** (currently glassy/transparent same-color nesting)

Symptoms: components are wide bg-card boxes nested inside more bg-card boxes — no visual hierarchy. Junior-Figma vibes vs the staking app's clean rhythm.

Five alternatives:

1. **Adopt `@tangle-network/ui-components` Card / Typography / Layout primitives.** Same components the staking app uses — already designed to layer properly.
2. **Three-level surface system.** Page bg (level 0) → card surface (level 1) → emphasized content surface (level 2). Each level a measurable step in elevation (border tone, subtle box-shadow, ~2-4% bg lift).
3. **Drop the gradient-radial backdrops in cards.** Decorative noise that fights the content. Replace with a single subtle border + spacing rhythm.
4. **Reduce card density.** Today everything is in a card. Make some sections plain flow (heading + content) and reserve cards for genuinely encapsulated state.
5. **Typography hierarchy from the staking app.** `<Typography variant="h4" fw="bold">` for section heads, consistent body text size. Stop using arbitrary `text-3xl tracking-[-0.035em]` per page.

**Pick: 1 + 5.** Migrate to shared `@tangle-network/ui-components`, take the staking app's type ramp.

---

## Execution sequence (one PR per phase, in order)

**Phase 1 (this PR):** Scroll reset, claim-history empty state, Payments → Private Payments.

**Phase 2:** Home page mirrors `tangle-dapp/dashboard.tsx`. Two-col `AccountSummaryCard` + `ProtocolStatisticCard` hero, token breakdown card, "Your Position" services table, "Available Blueprints" table at the bottom. Drop the existing hero gradient + InstructionCard.

**Phase 3:** Account component — reuse `AccountSummaryCard` shape from staking. Rename "deposits" → "wallet/stake/rewards" in copy. Quick-action icon buttons in card footer.

**Phase 4:** Blueprints page — single catalog grid + Catalog ↔ Your services toggle. Drop Owned + Role. Add category chips + search.

**Phase 5:** Operators page — skeleton-first rendering + React Query 60s staleTime.

**Phase 6:** Visual polish — migrate cards/typography to shared `@tangle-network/ui-components`. Three-level surface system. Drop gradient backdrops.

**Phase 7 (infra, separate from UI):** Stand up Envio indexer for Base Sepolia (or wire to a hosted one), set `VITE_ENVIO_TESTNET_ENDPOINT` in staging Netlify env, and replace the Phase-1 empty state with real claim history.

I'll execute Phase 2 next (home page restructure) once this lands.
