### PR TITLE
feat(sandbox): runtime backend selector in create wizard

### DIFF
--- a/apps/tangle-cloud/src/components/ScrollToTop.tsx
+++ b/apps/tangle-cloud/src/components/ScrollToTop.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 /**
  * Reset the window scroll position to (0, 0) on every pathname change.

--- a/apps/tangle-cloud/src/components/stats/Stat.tsx
+++ b/apps/tangle-cloud/src/components/stats/Stat.tsx
@@ -1,6 +1,6 @@
-import type { FC, ReactNode } from 'react'
-import { Skeleton } from '@tangle-network/sandbox-ui/primitives'
-import { twMerge } from 'tailwind-merge'
+import type { FC, ReactNode } from 'react';
+import { Skeleton } from '@tangle-network/sandbox-ui/primitives';
+import { twMerge } from 'tailwind-merge';
 
 /**
  * Canonical small-tile stat used across hero strips, table headers, blueprint
@@ -20,24 +20,24 @@ import { twMerge } from 'tailwind-merge'
  *   - success : positive (healthy / operators online)
  *   - warning : needs attention (capacity / pending)
  */
-export type StatTone = 'default' | 'accent' | 'success' | 'warning'
-export type StatSize = 'sm' | 'md' | 'lg'
+export type StatTone = 'default' | 'accent' | 'success' | 'warning';
+export type StatSize = 'sm' | 'md' | 'lg';
 
 export type StatProps = {
-  label: string
-  value: ReactNode
-  sublabel?: ReactNode
-  icon?: ReactNode
-  size?: StatSize
-  tone?: StatTone
-  isLoading?: boolean
-  className?: string
+  label: string;
+  value: ReactNode;
+  sublabel?: ReactNode;
+  icon?: ReactNode;
+  size?: StatSize;
+  tone?: StatTone;
+  isLoading?: boolean;
+  className?: string;
   /**
    * Inline detail rendered next to the value (e.g. "5 / 12" denominator).
    * Smaller, muted, on the same baseline.
    */
-  inlineDetail?: ReactNode
-}
+  inlineDetail?: ReactNode;
+};
 
 const SIZE_STYLES: Record<
   StatSize,
@@ -58,22 +58,21 @@ const SIZE_STYLES: Record<
     label: 'text-[11px]',
     value: 'text-2xl',
   },
-}
+};
 
 const TONE_STYLES: Record<StatTone, string> = {
   default: 'border-border bg-[var(--bg-card)]',
-  accent:
-    'border-[color:var(--border-accent)] bg-[var(--accent-surface-soft)]',
+  accent: 'border-[color:var(--border-accent)] bg-[var(--accent-surface-soft)]',
   success: 'border-emerald-500/30 bg-emerald-500/10',
   warning: 'border-amber-500/30 bg-amber-500/10',
-}
+};
 
 const VALUE_TONE: Record<StatTone, string> = {
   default: 'text-foreground',
   accent: 'text-foreground',
   success: 'text-emerald-200',
   warning: 'text-amber-200',
-}
+};
 
 export const Stat: FC<StatProps> = ({
   label,
@@ -86,7 +85,7 @@ export const Stat: FC<StatProps> = ({
   inlineDetail,
   className,
 }) => {
-  const sizing = SIZE_STYLES[size]
+  const sizing = SIZE_STYLES[size];
   return (
     <div
       className={twMerge(
@@ -115,7 +114,11 @@ export const Stat: FC<StatProps> = ({
         <Skeleton
           className={twMerge(
             'mt-1',
-            size === 'lg' ? 'h-8 w-32' : size === 'md' ? 'h-6 w-24' : 'h-5 w-20',
+            size === 'lg'
+              ? 'h-8 w-32'
+              : size === 'md'
+                ? 'h-6 w-24'
+                : 'h-5 w-20',
           )}
         />
       ) : (
@@ -142,10 +145,10 @@ export const Stat: FC<StatProps> = ({
         </p>
       ) : null}
     </div>
-  )
-}
+  );
+};
 
-Stat.displayName = 'Stat'
+Stat.displayName = 'Stat';
 
 /**
  * StatRow — opinionated horizontal cluster of Stats used at the top of pages.
@@ -154,10 +157,10 @@ Stat.displayName = 'Stat'
  * drops cleanly into hero panels.
  */
 export const StatRow: FC<{
-  items: StatProps[]
-  className?: string
+  items: StatProps[];
+  className?: string;
 }> = ({ items, className }) => {
-  const cols = Math.min(items.length, 6)
+  const cols = Math.min(items.length, 6);
   const desktopCols: Record<number, string> = {
     1: 'sm:grid-cols-1',
     2: 'sm:grid-cols-2',
@@ -165,7 +168,7 @@ export const StatRow: FC<{
     4: 'sm:grid-cols-2 lg:grid-cols-4',
     5: 'sm:grid-cols-3 lg:grid-cols-5',
     6: 'sm:grid-cols-3 lg:grid-cols-6',
-  }
+  };
   return (
     <div
       className={twMerge(
@@ -178,7 +181,7 @@ export const StatRow: FC<{
         <Stat key={`${item.label}-${idx}`} {...item} />
       ))}
     </div>
-  )
-}
+  );
+};
 
-StatRow.displayName = 'StatRow'
+StatRow.displayName = 'StatRow';

--- a/apps/tangle-cloud/src/pages/instances/AccountStatsCard.tsx
+++ b/apps/tangle-cloud/src/pages/instances/AccountStatsCard.tsx
@@ -148,10 +148,7 @@ export const AccountStatsCard: FC<AccountStatsCardProps> = (props) => {
   }
 
   return (
-    <Card
-      variant="sandbox"
-      className={twMerge('w-full', rootProps?.className)}
-    >
+    <Card variant="sandbox" className={twMerge('w-full', rootProps?.className)}>
       <CardContent className="space-y-5 p-5 md:p-6">
         <div className="flex items-start justify-between gap-4">
           <div className="flex min-w-0 items-center gap-4">

--- a/apps/tangle-cloud/src/pages/instances/InstructionCard.tsx
+++ b/apps/tangle-cloud/src/pages/instances/InstructionCard.tsx
@@ -57,7 +57,8 @@ const buildConnectedSteps = (params: {
       title: `Approve ${params.pendingApprovals} service ${
         params.pendingApprovals === 1 ? 'request' : 'requests'
       }`,
-      description: 'Operators must approve incoming requests for the service to activate.',
+      description:
+        'Operators must approve incoming requests for the service to activate.',
       icon: TimeLineIcon,
       to: PagePath.INSTANCES,
       tone: 'action',
@@ -92,7 +93,8 @@ const buildConnectedSteps = (params: {
       title: `${params.runningServices} ${
         params.runningServices === 1 ? 'service' : 'services'
       } running`,
-      description: 'Job submissions and runtime records are available on the service page.',
+      description:
+        'Job submissions and runtime records are available on the service page.',
       icon: CheckboxCircleFill,
       to: PagePath.INSTANCES,
       tone: 'success',

--- a/apps/tangle-cloud/src/pages/instances/page.tsx
+++ b/apps/tangle-cloud/src/pages/instances/page.tsx
@@ -1,5 +1,9 @@
 import { useState } from 'react';
-import { Button, Card, CardContent } from '@tangle-network/sandbox-ui/primitives';
+import {
+  Button,
+  Card,
+  CardContent,
+} from '@tangle-network/sandbox-ui/primitives';
 import { Link } from 'react-router';
 import { useAccount } from 'wagmi';
 import { AccountStatsCard } from './AccountStatsCard';

--- a/apps/tangle-cloud/src/pages/operators/page.tsx
+++ b/apps/tangle-cloud/src/pages/operators/page.tsx
@@ -358,9 +358,7 @@ const SortableHead = ({
     {label}
     <span
       aria-hidden
-      className={
-        isActive ? 'text-foreground' : 'text-muted-foreground/40'
-      }
+      className={isActive ? 'text-foreground' : 'text-muted-foreground/40'}
     >
       {isActive ? (direction === 'desc' ? '↓' : '↑') : '↕'}
     </span>

--- a/apps/tangle-cloud/src/pages/services/[id]/MetadataJsonInput.spec.ts
+++ b/apps/tangle-cloud/src/pages/services/[id]/MetadataJsonInput.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * Pin the exact `metadata_json` splice semantics the operator depends on.
+ *
+ * Regressions these tests would catch:
+ *  - docker selection accidentally writing `"runtime_backend":"docker"` into
+ *    the payload (operator's default — adding the field bloats job inputs
+ *    and creates noisy diffs in the indexer).
+ *  - Firecracker/TEE selection clobbering other user-authored fields (image,
+ *    env, ports) instead of merging cleanly.
+ *  - Aliases like `container`/`microvm`/`confidential` not being normalised
+ *    back to the canonical operator-side token.
+ *  - Invalid JSON being silently rewritten when the user toggles the
+ *    selector (must stay verbatim until the user fixes parse errors).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  applyRuntimeBackendToMetadata,
+  isMetadataJsonField,
+  normalizeRuntimeBackend,
+  parseMetadata,
+  RUNTIME_BACKEND_DEFAULT,
+} from './metadataJson';
+
+describe('isMetadataJsonField', () => {
+  it('matches exactly metadata_json', () => {
+    expect(isMetadataJsonField('metadata_json')).toBe(true);
+  });
+
+  it('rejects camelCase, prefixes, suffixes', () => {
+    expect(isMetadataJsonField('metadataJson')).toBe(false);
+    expect(isMetadataJsonField('sandbox_metadata_json')).toBe(false);
+    expect(isMetadataJsonField('metadata_json_v2')).toBe(false);
+    expect(isMetadataJsonField('')).toBe(false);
+  });
+});
+
+describe('normalizeRuntimeBackend', () => {
+  it('canonicalises the operator-side aliases', () => {
+    expect(normalizeRuntimeBackend('docker')).toBe('docker');
+    expect(normalizeRuntimeBackend('container')).toBe('docker');
+    expect(normalizeRuntimeBackend('firecracker')).toBe('firecracker');
+    expect(normalizeRuntimeBackend('microvm')).toBe('firecracker');
+    expect(normalizeRuntimeBackend('tee')).toBe('tee');
+    expect(normalizeRuntimeBackend('confidential')).toBe('tee');
+  });
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(normalizeRuntimeBackend('  DOCKER ')).toBe('docker');
+    expect(normalizeRuntimeBackend('MicroVM')).toBe('firecracker');
+  });
+
+  it('returns null for unknown / non-string values', () => {
+    expect(normalizeRuntimeBackend('kata')).toBeNull();
+    expect(normalizeRuntimeBackend('')).toBeNull();
+    expect(normalizeRuntimeBackend(undefined)).toBeNull();
+    expect(normalizeRuntimeBackend(42)).toBeNull();
+    expect(normalizeRuntimeBackend({ runtime: 'docker' })).toBeNull();
+  });
+});
+
+describe('parseMetadata', () => {
+  it('treats empty input as ok+empty (operator falls back to defaults)', () => {
+    const result = parseMetadata('   ');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.empty).toBe(true);
+      expect(result.object).toBeNull();
+    }
+  });
+
+  it('accepts JSON objects', () => {
+    const result = parseMetadata('{"image":"x","env":{"FOO":"bar"}}');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.empty).toBe(false);
+      expect(result.object).toEqual({ image: 'x', env: { FOO: 'bar' } });
+    }
+  });
+
+  it('rejects arrays and primitives', () => {
+    expect(parseMetadata('[1,2]').ok).toBe(false);
+    expect(parseMetadata('"just a string"').ok).toBe(false);
+    expect(parseMetadata('42').ok).toBe(false);
+    expect(parseMetadata('null').ok).toBe(false);
+  });
+
+  it('rejects malformed JSON with a helpful error', () => {
+    const result = parseMetadata('{not: json}');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/invalid json/i);
+    }
+  });
+});
+
+describe('applyRuntimeBackendToMetadata', () => {
+  it('omits runtime_backend when docker (the operator default) is selected', () => {
+    expect(applyRuntimeBackendToMetadata('', 'docker')).toBe('');
+    expect(
+      applyRuntimeBackendToMetadata(
+        '{"runtime_backend":"firecracker"}',
+        'docker',
+      ),
+    ).toBe('');
+  });
+
+  it('preserves the user-authored object body when picking firecracker', () => {
+    const out = applyRuntimeBackendToMetadata(
+      '{"image":"ghcr.io/agent:latest","env":{"FOO":"bar"}}',
+      'firecracker',
+    );
+    const parsed = JSON.parse(out);
+    expect(parsed).toEqual({
+      image: 'ghcr.io/agent:latest',
+      env: { FOO: 'bar' },
+      runtime_backend: 'firecracker',
+    });
+  });
+
+  it('overwrites a previous runtime_backend selection rather than appending', () => {
+    const out = applyRuntimeBackendToMetadata(
+      '{"runtime_backend":"firecracker","image":"x"}',
+      'tee',
+    );
+    const parsed = JSON.parse(out);
+    expect(parsed).toEqual({ runtime_backend: 'tee', image: 'x' });
+  });
+
+  it('seeds an object when starting from empty input + non-default backend', () => {
+    const out = applyRuntimeBackendToMetadata('   ', 'tee');
+    expect(JSON.parse(out)).toEqual({ runtime_backend: 'tee' });
+  });
+
+  it('leaves invalid JSON untouched so the user can fix parse errors', () => {
+    const raw = '{ this is not json';
+    expect(applyRuntimeBackendToMetadata(raw, 'firecracker')).toBe(raw);
+    expect(applyRuntimeBackendToMetadata(raw, 'docker')).toBe(raw);
+  });
+
+  it('default constant is docker (matches operator default + UI default)', () => {
+    expect(RUNTIME_BACKEND_DEFAULT).toBe('docker');
+  });
+});

--- a/apps/tangle-cloud/src/pages/services/[id]/MetadataJsonInput.tsx
+++ b/apps/tangle-cloud/src/pages/services/[id]/MetadataJsonInput.tsx
@@ -1,0 +1,205 @@
+/**
+ * Richer editor for `metadata_json` string params.
+ *
+ * The sandbox blueprint takes a single `metadata_json: string` job param;
+ * the operator parses that JSON server-side to choose a runtime backend.
+ * Until now the UI presented metadata_json as an opaque <input>, forcing
+ * customers to hand-craft JSON if they wanted Firecracker or TEE isolation.
+ *
+ * This component layers a structured selector + free-form JSON body on top
+ * of the same string field:
+ *
+ *   - Container (docker) stays the default and produces a minimal payload —
+ *     `runtime_backend` is omitted when docker is selected to keep on-chain
+ *     job inputs small (the operator already defaults to docker).
+ *   - Firecracker and TEE selections splice `runtime_backend` into the JSON
+ *     object the user is composing, preserving every other field they typed.
+ *   - The raw JSON stays editable; the selector reads back from the JSON,
+ *     so power users can still drop in a complete payload by hand.
+ *
+ * Behaviour is unit-tested in MetadataJsonInput.spec.ts.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { ChangeEvent, FC } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+} from '@tangle-network/sandbox-ui/primitives';
+import { Text } from '../../../components/sandbox/SandboxUi';
+import {
+  applyRuntimeBackendToMetadata,
+  normalizeRuntimeBackend,
+  parseMetadata,
+  RUNTIME_BACKEND_DEFAULT,
+  RUNTIME_BACKEND_OPTIONS,
+  type RuntimeBackend,
+} from './metadataJson';
+
+interface Props {
+  label: string;
+  path: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export const MetadataJsonInput: FC<Props> = ({
+  label,
+  path,
+  value,
+  onChange,
+}) => {
+  const [draftJson, setDraftJson] = useState<string>(value ?? '');
+
+  // Resync the editor when the parent resets the form (e.g. after a successful
+  // submit). The string compare avoids clobbering in-progress edits while the
+  // user is typing.
+  useEffect(() => {
+    setDraftJson((current) => (current === value ? current : (value ?? '')));
+  }, [value]);
+
+  const parsed = useMemo(() => parseMetadata(draftJson), [draftJson]);
+
+  const currentBackend = useMemo<RuntimeBackend>(() => {
+    if (!parsed.ok || parsed.empty || parsed.object === null) {
+      return RUNTIME_BACKEND_DEFAULT;
+    }
+    return (
+      normalizeRuntimeBackend(parsed.object.runtime_backend) ??
+      RUNTIME_BACKEND_DEFAULT
+    );
+  }, [parsed]);
+
+  const propagate = useCallback(
+    (next: string) => {
+      setDraftJson(next);
+      onChange(next);
+    },
+    [onChange],
+  );
+
+  const handleBackendChange = useCallback(
+    (next: RuntimeBackend) => {
+      // If the JSON is invalid we leave the textarea untouched so the user
+      // sees their parse error and can correct it. applyRuntimeBackendToMetadata
+      // returns the raw string verbatim in that case, but checking up-front
+      // also stops us pushing duplicate change events when nothing differs.
+      if (!parsed.ok) {
+        return;
+      }
+      propagate(applyRuntimeBackendToMetadata(draftJson, next));
+    },
+    [draftJson, parsed.ok, propagate],
+  );
+
+  const handleJsonChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      propagate(event.currentTarget.value);
+    },
+    [propagate],
+  );
+
+  const activeOption =
+    RUNTIME_BACKEND_OPTIONS.find((opt) => opt.value === currentBackend) ??
+    RUNTIME_BACKEND_OPTIONS[0];
+
+  return (
+    <div className="py-1 space-y-3">
+      <div>
+        <Text variant="body2" className="mb-1">
+          {label}{' '}
+          <span className="text-muted-foreground text-xs">(metadata_json)</span>
+        </Text>
+        <Text variant="body3" className="text-muted-foreground">
+          The operator parses this JSON server-side. Pick a runtime backend and
+          add any extra fields (image, env, ports, ...) the blueprint
+          recognises.
+        </Text>
+      </div>
+
+      <div>
+        <Text variant="body3" className="mb-1 text-muted-foreground">
+          Runtime Backend
+        </Text>
+        <Select
+          value={currentBackend}
+          onValueChange={(v: string) =>
+            handleBackendChange(v as RuntimeBackend)
+          }
+        >
+          <SelectTrigger
+            id={`${path}-runtime-backend`}
+            className="w-full"
+            aria-label="Runtime backend"
+          >
+            <SelectValue placeholder="Select runtime backend" />
+          </SelectTrigger>
+          <SelectContent>
+            {RUNTIME_BACKEND_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Text variant="body3" className="mt-1 text-muted-foreground">
+          {activeOption.description}
+        </Text>
+      </div>
+
+      {currentBackend === 'firecracker' && (
+        <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3">
+          <Text variant="body3" className="text-yellow-300">
+            Firecracker requires the selected operator to have MicroVM support
+            enabled. If the operator runs Docker only, the CreateSandbox job
+            will fail. Firecracker also forces <code>tee_required=false</code>;
+            Firecracker + TEE composition is not supported.
+          </Text>
+        </div>
+      )}
+
+      {currentBackend === 'tee' && (
+        <div className="rounded-lg border border-primary/30 bg-primary/10 p-3">
+          <Text variant="body3" className="text-primary">
+            TEE-backed sandboxes provision into a confidential VM. The operator
+            forces <code>tee_required=true</code> for this request; only
+            TEE-capable operators will accept it.
+          </Text>
+        </div>
+      )}
+
+      <div>
+        <Text variant="body3" className="mb-1 text-muted-foreground">
+          Raw JSON (advanced)
+        </Text>
+        <Textarea
+          id={path}
+          className="w-full h-32 p-3 rounded-lg border border-border bg-background font-mono text-sm resize-none focus:outline-none focus:ring-2 focus:ring-ring"
+          placeholder='{ "image": "ghcr.io/...", "env": { "FOO": "bar" } }'
+          value={draftJson}
+          onChange={handleJsonChange}
+          aria-invalid={!parsed.ok ? 'true' : undefined}
+        />
+        {!parsed.ok ? (
+          <Text variant="body3" className="mt-1 text-destructive">
+            {parsed.error}
+          </Text>
+        ) : (
+          <Text variant="body3" className="mt-1 text-muted-foreground">
+            {parsed.empty
+              ? 'Empty metadata is sent as an empty string. The operator will use its defaults.'
+              : currentBackend === RUNTIME_BACKEND_DEFAULT
+                ? 'runtime_backend is omitted from this payload (operator default is docker).'
+                : `runtime_backend = "${currentBackend}" will be included in the payload.`}
+          </Text>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MetadataJsonInput;

--- a/apps/tangle-cloud/src/pages/services/[id]/SchemaFieldInput.tsx
+++ b/apps/tangle-cloud/src/pages/services/[id]/SchemaFieldInput.tsx
@@ -21,6 +21,8 @@ import {
   type SchemaField,
 } from '@tangle-network/tangle-shared-ui/codec';
 import { isAddress } from 'viem';
+import { MetadataJsonInput } from './MetadataJsonInput';
+import { isMetadataJsonField } from './metadataJson';
 
 interface SchemaFieldInputProps {
   field: SchemaField;
@@ -255,6 +257,21 @@ export const SchemaFieldInput: FC<SchemaFieldInputProps> = ({
   }
 
   if (kind === BlueprintFieldKind.String) {
+    // Sandbox-class blueprints (ai-agent-sandbox + ai-agent-instance) take a
+    // `metadata_json: string` param the operator parses to pick a runtime
+    // backend. Render the structured editor so customers can pick MicroVM or
+    // TEE without hand-writing JSON.
+    if (isMetadataJsonField(name)) {
+      return (
+        <MetadataJsonInput
+          label={label}
+          path={path}
+          value={(value as string) ?? ''}
+          onChange={(v) => onChange(v)}
+        />
+      );
+    }
+
     return (
       <div className="py-1">
         <Text variant="body2" className="mb-1">

--- a/apps/tangle-cloud/src/pages/services/[id]/metadataJson.ts
+++ b/apps/tangle-cloud/src/pages/services/[id]/metadataJson.ts
@@ -1,0 +1,147 @@
+/**
+ * Pure helpers + constants for the `metadata_json` runtime backend selector.
+ *
+ * Kept in a non-component module so the React component file can stay
+ * fast-refresh friendly (lint: react-refresh/only-export-components).
+ *
+ * The sandbox blueprint (and the ai-agent-instance variant) take a single
+ * `metadata_json: string` job param. The operator parses that JSON and
+ * dispatches to one of three runtime backends:
+ *
+ *   "docker" | "container"   -> Docker
+ *   "firecracker" | "microvm" -> Firecracker
+ *   "tee" | "confidential"   -> TEE (confidential VM)
+ */
+
+export const RUNTIME_BACKEND_DEFAULT = 'docker' as const;
+
+export type RuntimeBackend = 'docker' | 'firecracker' | 'tee';
+
+export const RUNTIME_BACKEND_OPTIONS: ReadonlyArray<{
+  value: RuntimeBackend;
+  label: string;
+  short: string;
+  description: string;
+}> = [
+  {
+    value: 'docker',
+    label: 'Container (Docker)',
+    short: 'Container',
+    description:
+      'Default. Recommended for most workloads. Fastest provisioning, broadest operator support.',
+  },
+  {
+    value: 'firecracker',
+    label: 'MicroVM (Firecracker)',
+    short: 'MicroVM',
+    description:
+      'Firecracker microVM isolation. Requires operators with Firecracker enabled. Stronger boundary than containers.',
+  },
+  {
+    value: 'tee',
+    label: 'Confidential VM (TEE)',
+    short: 'Confidential VM',
+    description:
+      'TEE-backed confidential compute. Slowest provisioning, strongest isolation. Requires TEE-capable operators.',
+  },
+];
+
+const RUNTIME_BACKEND_ALIASES: Record<string, RuntimeBackend> = {
+  docker: 'docker',
+  container: 'docker',
+  firecracker: 'firecracker',
+  microvm: 'firecracker',
+  tee: 'tee',
+  confidential: 'tee',
+};
+
+export const normalizeRuntimeBackend = (
+  raw: unknown,
+): RuntimeBackend | null => {
+  if (typeof raw !== 'string') return null;
+  const key = raw.trim().toLowerCase();
+  return RUNTIME_BACKEND_ALIASES[key] ?? null;
+};
+
+export type ParsedMetadata =
+  | { ok: true; object: Record<string, unknown> | null; empty: boolean }
+  | { ok: false; error: string };
+
+export const parseMetadata = (raw: string): ParsedMetadata => {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return { ok: true, object: null, empty: true };
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed)
+    ) {
+      return {
+        ok: true,
+        object: parsed as Record<string, unknown>,
+        empty: false,
+      };
+    }
+    return {
+      ok: false,
+      error: 'metadata_json must be a JSON object (e.g. { "image": "..." }).',
+    };
+  } catch (e) {
+    return {
+      ok: false,
+      error:
+        e instanceof Error ? `Invalid JSON: ${e.message}` : 'Invalid JSON.',
+    };
+  }
+};
+
+/**
+ * Serialize an object back into a metadata_json string. Returns the empty
+ * string when the object has no keys, so we never emit `{}` and bloat the
+ * job payload unnecessarily.
+ */
+export const serializeMetadata = (object: Record<string, unknown>): string => {
+  const keys = Object.keys(object);
+  if (keys.length === 0) return '';
+  return JSON.stringify(object, null, 2);
+};
+
+/**
+ * Apply a runtime backend selection to a raw metadata_json string and return
+ * the new string. Behaviour pinned by MetadataJsonInput.spec.ts:
+ *  - docker (the operator default) is omitted from the payload entirely.
+ *  - firecracker / tee are spliced in next to whatever the user typed.
+ *  - invalid JSON is returned verbatim so the user can see + fix the error.
+ */
+export const applyRuntimeBackendToMetadata = (
+  raw: string,
+  next: RuntimeBackend,
+): string => {
+  const parsed = parseMetadata(raw);
+  if (!parsed.ok) {
+    return raw;
+  }
+
+  const base: Record<string, unknown> =
+    parsed.object === null ? {} : { ...parsed.object };
+
+  if (next === RUNTIME_BACKEND_DEFAULT) {
+    delete base.runtime_backend;
+  } else {
+    base.runtime_backend = next;
+  }
+
+  return serializeMetadata(base);
+};
+
+/**
+ * True when the schema field should render the structured metadata editor.
+ *
+ * Matches exactly `metadata_json` (snake_case is the on-chain convention for
+ * sandbox blueprints) to avoid hijacking unrelated string fields.
+ */
+export const isMetadataJsonField = (name: string): boolean =>
+  name === 'metadata_json';


### PR DESCRIPTION
## Summary

CreateSandbox takes a `metadata_json: string` job param that the operator parses server-side to dispatch to one of three runtime backends (`docker`/`firecracker`/`tee`). The dapp previously rendered that field as a generic `<input>`, so anyone wanting Firecracker (MicroVM) or TEE isolation had to hand-craft the JSON. This wires a structured selector into the job submission form for every blueprint whose `String` param is named exactly `metadata_json` — that covers the canonical `ai-agent-sandbox` blueprint and the `ai-agent-instance` variant the cloud module replicates per operator.

What's new:

- New ``apps/tangle-cloud/src/pages/services/[id]/MetadataJsonInput.tsx`` renders a Runtime Backend `<Select>` (Container / MicroVM / Confidential VM) on top of a free-form JSON textarea, with the two views kept in sync.
- Pure helpers (`parseMetadata`, `applyRuntimeBackendToMetadata`, alias normalisation, `isMetadataJsonField`) live in a non-component module (``metadataJson.ts``) so the component file stays react-refresh friendly and the splice semantics are unit-testable in isolation.
- `SchemaFieldInput.tsx` activates the new editor when a `String` field is named exactly `metadata_json`; every other string field renders unchanged.
- Container (`docker`) selection **omits** `runtime_backend` from the payload entirely — the operator already defaults to docker, no need to bloat on-chain job inputs.
- Firecracker selection shows an info banner: requires operator MicroVM support, and the operator forces `tee_required=false` (Firecracker + TEE composition is unsupported).
- TEE selection shows an info banner: operator forces `tee_required=true`; only TEE-capable operators will accept the request.
- Invalid JSON is left verbatim so the user can fix parse errors without losing in-progress edits.
- 15-case vitest spec pins alias normalisation, omit-on-default, key merging, and invalid-JSON pass-through.

Two unrelated cleanups bundled in the same branch because they were blocking `yarn pre-push`:

- `style(tangle-cloud): apply prettier to stats + instances + operators pages` — pre-existing formatting drift the project's own `prettier --check` was refusing.
- `fix(tangle-cloud): use react-router import in ScrollToTop` — `ScrollToTop` imported `useLocation` from `react-router-dom` while every test (and every other component) uses `react-router`. Under Vitest the two packages resolve to separate context providers, so `useLocation()` threw `'may be used only in the context of a <Router> component'` and broke all 23 routing assertions in `app.spec.tsx`. `react-router-dom@7` just re-exports `react-router`; using the canonical import fixes the suite.

## Behaviour matrix

| User picks | metadata_json sent | Operator dispatch | Notes |
|---|---|---|---|
| Container (default) | omits `runtime_backend` | Docker | Matches operator default; minimal payload |
| MicroVM | `{"runtime_backend":"firecracker", ...}` | Firecracker | Operator must run microvm-runtime 0.4 + warm pool; `tee_required` forced false |
| Confidential VM | `{"runtime_backend":"tee", ...}` | TEE | `tee_required` forced true; only TEE-capable operators accept |
| Power user types `"container"` / `"microvm"` / `"confidential"` by hand | passes through verbatim | resolved by operator alias map | Selector reflects normalised choice on next render |
| Power user types invalid JSON | passes through verbatim | n/a (UI blocks submit-time encoding via existing form path) | Selector is disabled-effective; textarea shows parse error inline |

## Test plan

- [x] ``yarn nx typecheck tangle-cloud`` clean
- [x] ``yarn nx lint tangle-cloud`` clean
- [x] ``yarn nx test tangle-cloud`` clean (159/159, including the 15 new MetadataJsonInput cases and the previously-broken 23 routing cases)
- [x] ``yarn nx build tangle-cloud`` clean
- [ ] Manual: load a service for the ai-agent-sandbox blueprint, open Submit Job, select `CreateSandbox`, confirm Runtime Backend selector renders for the `metadata_json` field and not for unrelated string fields.
- [ ] Manual: pick MicroVM, type `{ "image": "ghcr.io/foo:latest" }` — confirm submitted payload becomes `{ "image": "ghcr.io/foo:latest", "runtime_backend": "firecracker" }`.
- [ ] Manual: switch back to Container — confirm `runtime_backend` key is removed and payload reverts to `{ "image": "ghcr.io/foo:latest" }`.
- [ ] Manual: pick Confidential VM with empty JSON — confirm payload is `{ "runtime_backend": "tee" }`.