### PR TITLE
fix(tangle-cloud): center wallet modal in visible content area, not viewport

### DIFF
--- a/apps/tangle-cloud/src/components/Layout.tsx
+++ b/apps/tangle-cloud/src/components/Layout.tsx
@@ -44,6 +44,19 @@ const Layout: FC<PropsWithChildren<Props>> = ({
     window.localStorage.setItem('tangle-cloud-theme', theme);
   }, [theme]);
 
+  // Publish the current sidebar width as a CSS variable on the root element so
+  // Radix-portaled dialogs (rendered to `<body>`, outside the layout shell) can
+  // offset their viewport-centered position by half the sidebar to land
+  // visually centered in the content area. See `.tangle-wallet-modal` rule in
+  // styles.css. Without this, the wallet modal sits left of center because
+  // viewport center is left of content-area center.
+  useEffect(() => {
+    document.documentElement.style.setProperty(
+      '--cloud-sidebar-width',
+      isSidebarExpanded ? '16rem' : '4rem',
+    );
+  }, [isSidebarExpanded]);
+
   return (
     <div
       data-sandbox-ui

--- a/apps/tangle-cloud/src/styles.css
+++ b/apps/tangle-cloud/src/styles.css
@@ -312,18 +312,18 @@ body {
 /* Dialog content rendered via Radix portal goes to <body>, outside the
    `.tangle-cloud-shell` div. Default centering (`left-1/2 -translate-x-1/2`)
    anchors to the viewport, which looks LEFT-shifted of the visible content
-   area because of the fixed sidebar (16–64rem on lg+). Compensate by
-   shifting the dialog right by half the sidebar width. Mobile (< lg) has no
-   sidebar so the override is no-op there. */
+   area because of the fixed sidebar (4rem collapsed / 16rem expanded on lg+).
+   Compensate by shifting the dialog right by half the sidebar width.
+   Mobile (< lg) has no sidebar so the override is no-op there.
+
+   `--cloud-sidebar-width` is published by `Layout.tsx` on `<html>` and stays
+   in sync with the collapsed/expanded state, so the dialog moves with the
+   sidebar instead of using a hardcoded compromise that was visibly off when
+   the sidebar was expanded (the default for new sessions). */
 @media (min-width: 1024px) {
   [data-state='open'][role='dialog'],
   [data-state='closed'][role='dialog'] {
-    /* Tailwind's `lg:left-16` on the sidebar = 4rem ≈ half is 2rem.
-       The expanded sidebar at `lg:left-64` = 16rem ≈ half is 8rem.
-       Use 4rem as a compromise — covers the collapsed default and looks
-       balanced even when expanded. The math doesn't need to be perfect;
-       the goal is "looks centered in the visible page area." */
-    margin-left: 2rem;
+    margin-left: calc(var(--cloud-sidebar-width, 16rem) / 2);
   }
 }
 


### PR DESCRIPTION
**Visible bug**: wallet connect modal shows up roughly halfway between center and the top-left of the page, not centered in the visible area.

**Root cause**: Radix dialog portal renders to `<body>`, so its default viewport-centered position is left of the visible content area (the fixed sidebar eats 4-16rem of the left side). The previous fix used a hardcoded `margin-left: 2rem` — correct for the collapsed sidebar (4rem / 2), but off by 6rem when expanded (default for new sessions).

**Fix**: `Layout.tsx` publishes `--cloud-sidebar-width` on `<html>` (16rem expanded / 4rem collapsed); `styles.css` dialog rule uses `margin-left: calc(var(--cloud-sidebar-width, 16rem) / 2)`. The modal now moves with the sidebar. Default fallback `16rem` matches the default-expanded sidebar so first paint is correct even before the effect fires.

## Test plan

- [x] `yarn nx typecheck tangle-cloud` clean
- [x] `yarn nx lint tangle-cloud` clean
- [ ] Visual: open dapp, click Connect Wallet → modal centers in visible content area
- [ ] Collapse sidebar → modal re-centers to match the smaller offset
- [ ] Mobile (< lg) → no offset applied (sidebar isn't fixed)