### PR TITLE
fix(tangle-cloud): show trading iframe + improve text contrast on blueprint pages

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppLandingPage.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppLandingPage.tsx
@@ -9,6 +9,7 @@ import { Link } from 'react-router';
 import { resolveBlueprintAppView } from '../resolver';
 import type { BlueprintAppEntry } from '../types';
 import type { TangleBlueprintAppEntry } from '../manifest';
+import type { BlueprintIframeConfig } from '../iframe/types';
 import BlueprintAppFrameHost from './BlueprintAppFrameHost';
 import BlueprintModePicker from './BlueprintModePicker';
 import { useBlueprint } from '@tangle-network/tangle-shared-ui/data/graphql';
@@ -20,11 +21,17 @@ type Props = {
 
 const BlueprintAppLandingPage: FC<Props> = ({ entry }) => {
   const view = resolveBlueprintAppView(entry);
+  // Iframe is rendered when the entry carries a parsed iframe policy AND its
+  // manifest declares the externalApp as a trusted iframe handoff. Both the
+  // metadata-driven path (`buildBlueprintManifestFromMetadata`) and the
+  // curated-registry path (registry.ts) populate these in tandem so the
+  // landing page never has to know which path produced the entry.
+  const entryIframe = (entry as { iframe?: BlueprintIframeConfig }).iframe;
   const iframeConfig =
-    'iframe' in entry &&
+    entryIframe !== undefined &&
     view.manifest.externalApp?.mode === 'iframe' &&
     view.manifest.externalApp?.trust === 'trusted'
-      ? entry.iframe
+      ? entryIframe
       : undefined;
   // For curated entries we still need a blueprint object to ask the
   // modes hook for siblings — the entry only carries the canonical id.
@@ -49,24 +56,30 @@ const BlueprintAppLandingPage: FC<Props> = ({ entry }) => {
   const resourceNoun = view.manifest.resources.resourceNoun;
 
   return (
-    <div data-sandbox-ui className="space-y-6">
+    // The shell `<div>` rendered by Layout already declares
+    // `data-sandbox-ui` + `data-sandbox-theme`, and the sandbox-ui CSS resets
+    // every token via `:root, [data-sandbox-ui]`. Re-declaring `data-sandbox-ui`
+    // on an inner wrapper would re-apply those defaults under the inner element
+    // and break theme inheritance (e.g. vault `--hsl-card` snapping back to the
+    // dark default). Inner wrappers must NOT carry `data-sandbox-ui`.
+    <div className="space-y-6">
       <Card variant="sandbox" className="overflow-hidden rounded-[32px]">
         <CardContent className="relative p-6 md:p-8">
-          <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/35 to-transparent" />
+          <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[color:var(--border-accent-hover)] to-transparent" />
           <div className="absolute -right-16 -top-20 h-56 w-56 rounded-full bg-[var(--brand-purple)]/20 blur-3xl" />
 
           <div className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
             <div className="max-w-3xl space-y-4">
               <div className="space-y-2">
-                <h1 className="font-display text-4xl font-extrabold leading-tight tracking-[-0.04em] text-white md:text-5xl">
+                <h1 className="font-display text-4xl font-extrabold leading-tight tracking-[-0.04em] text-foreground md:text-5xl">
                   {view.manifest.displayName}
                 </h1>
-                <p className="max-w-2xl text-base leading-7 text-white/70">
+                <p className="max-w-2xl text-base leading-7 text-muted-foreground">
                   {view.manifest.tagline}
                 </p>
               </div>
 
-              <p className="max-w-3xl text-base leading-7 text-white/82">
+              <p className="max-w-3xl text-base leading-7 text-foreground/90">
                 {view.manifest.description}
               </p>
 
@@ -77,17 +90,22 @@ const BlueprintAppLandingPage: FC<Props> = ({ entry }) => {
                 <Button asChild variant="secondary" size="lg">
                   <Link to="/blueprints">Browse blueprints</Link>
                 </Button>
-                {view.manifest.externalApp?.trust === 'trusted' && (
-                  <Button asChild variant="secondary" size="lg">
-                    <a
-                      href={view.manifest.externalApp.url}
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      {view.manifest.externalApp.label ?? 'Publisher console'}
-                    </a>
-                  </Button>
-                )}
+                {view.manifest.externalApp?.trust === 'trusted' &&
+                  // When we're already embedding the publisher's iframe inline
+                  // below, the "open in new tab" button duplicates the same
+                  // destination and confuses operators. Only show it for the
+                  // link-only handoff path.
+                  !iframeConfig && (
+                    <Button asChild variant="secondary" size="lg">
+                      <a
+                        href={view.manifest.externalApp.url}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        {view.manifest.externalApp.label ?? 'Publisher console'}
+                      </a>
+                    </Button>
+                  )}
                 {(activeMode || view.blueprintId !== undefined) && (
                   // Power-user escape hatch: jump to the protocol-generic
                   // per-id detail page for the picked mode (or canonical
@@ -104,8 +122,8 @@ const BlueprintAppLandingPage: FC<Props> = ({ entry }) => {
               </div>
             </div>
 
-            <div className="space-y-4 rounded-3xl border border-white/10 bg-white/[0.04] p-5">
-              <h2 className="font-display text-xl font-extrabold tracking-tight text-white">
+            <div className="space-y-4 rounded-3xl border border-border bg-[color:var(--bg-elevated)] p-5">
+              <h2 className="font-display text-xl font-extrabold tracking-tight text-foreground">
                 Checkout path
               </h2>
               <div className="grid gap-3">
@@ -158,11 +176,11 @@ const BlueprintAppLandingPage: FC<Props> = ({ entry }) => {
 };
 
 const Step = ({ index, title }: { index: string; title: string }) => (
-  <div className="flex items-center gap-3 rounded-xl border border-white/10 bg-white/[0.035] p-3">
-    <span className="grid h-7 w-7 place-items-center rounded-full bg-background text-xs font-bold text-foreground">
+  <div className="flex items-center gap-3 rounded-xl border border-border bg-[color:var(--bg-card)] p-3">
+    <span className="grid h-7 w-7 place-items-center rounded-full bg-primary text-xs font-bold text-primary-foreground">
       {index}
     </span>
-    <p className="text-sm font-semibold text-white/78">{title}</p>
+    <p className="text-sm font-semibold text-foreground">{title}</p>
   </div>
 );
 
@@ -178,7 +196,7 @@ const SummaryCard = ({
       <Badge variant="sandbox" className="w-fit">
         {title}
       </Badge>
-      <p className="text-sm leading-6 text-white/66">{description}</p>
+      <p className="text-sm leading-6 text-muted-foreground">{description}</p>
     </CardContent>
   </Card>
 );

--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppServicePage.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppServicePage.tsx
@@ -88,10 +88,13 @@ const BlueprintAppServicePage: FC<Props> = ({
   const resourceNoun = view.manifest.resources.resourceNoun;
 
   return (
-    <div data-sandbox-ui className="space-y-6">
+    // See BlueprintAppLandingPage: don't re-declare `data-sandbox-ui` on an
+    // inner wrapper or sandbox-ui will reset every token under this subtree
+    // and the current theme (vault/tangle) on the shell stops applying.
+    <div className="space-y-6">
       <Card variant="sandbox" className="overflow-hidden rounded-[32px]">
         <CardContent className="relative p-6 md:p-8">
-          <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/35 to-transparent" />
+          <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[color:var(--border-accent-hover)] to-transparent" />
           <div className="absolute -right-16 -top-20 h-56 w-56 rounded-full bg-[var(--brand-purple)]/20 blur-3xl" />
 
           <div className="relative max-w-4xl space-y-5">
@@ -100,10 +103,10 @@ const BlueprintAppServicePage: FC<Props> = ({
             </Badge>
 
             <div className="space-y-3">
-              <h1 className="font-display text-4xl font-extrabold leading-tight tracking-[-0.04em] text-white md:text-5xl">
+              <h1 className="font-display text-4xl font-extrabold leading-tight tracking-[-0.04em] text-foreground md:text-5xl">
                 {view.manifest.displayName} service #{serviceId}
               </h1>
-              <p className="max-w-3xl text-base leading-7 text-white/70">
+              <p className="max-w-3xl text-base leading-7 text-muted-foreground">
                 Manage this live {serviceNoun.toLowerCase()}: check access,
                 inspect callable jobs, review recent activity, and open the full
                 service console when you need to operate the instance.
@@ -164,47 +167,47 @@ const BlueprintAppServicePage: FC<Props> = ({
           {liveDetails && (
             <Card variant="sandbox" className="rounded-3xl">
               <CardContent className="p-6">
-                <h2 className="font-display text-2xl font-extrabold tracking-tight text-white">
+                <h2 className="font-display text-2xl font-extrabold tracking-tight text-foreground">
                   Live service access
                 </h2>
                 <div className="mt-4 grid gap-3 sm:grid-cols-2">
                   <div>
-                    <p className="text-xs font-bold uppercase tracking-widest text-white/42">
+                    <p className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
                       Status
                     </p>
-                    <p className="mt-1 text-sm font-semibold text-white">
+                    <p className="mt-1 text-sm font-semibold text-foreground">
                       {liveDetails.status}
                     </p>
                   </div>
                   <div>
-                    <p className="text-xs font-bold uppercase tracking-widest text-white/42">
+                    <p className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
                       Owner
                     </p>
-                    <p className="mt-1 break-all text-sm font-semibold text-white">
+                    <p className="mt-1 break-all text-sm font-semibold text-foreground">
                       {liveDetails.owner}
                     </p>
                   </div>
                   <div>
-                    <p className="text-xs font-bold uppercase tracking-widest text-white/42">
+                    <p className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
                       Operators
                     </p>
-                    <p className="mt-1 text-sm font-semibold text-white">
+                    <p className="mt-1 text-sm font-semibold text-foreground">
                       {liveDetails.operators.length}
                     </p>
                   </div>
                   <div>
-                    <p className="text-xs font-bold uppercase tracking-widest text-white/42">
+                    <p className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
                       Permitted callers
                     </p>
-                    <p className="mt-1 text-sm font-semibold text-white">
+                    <p className="mt-1 text-sm font-semibold text-foreground">
                       {liveDetails.permittedCallers.length}
                     </p>
                   </div>
                   <div className="sm:col-span-2">
-                    <p className="text-xs font-bold uppercase tracking-widest text-white/42">
+                    <p className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
                       Connected wallet access
                     </p>
-                    <p className="mt-1 text-sm font-semibold capitalize text-white">
+                    <p className="mt-1 text-sm font-semibold capitalize text-foreground">
                       {liveDetails.viewerAccess ?? 'public'}
                     </p>
                   </div>
@@ -216,16 +219,16 @@ const BlueprintAppServicePage: FC<Props> = ({
           {requestSchemaFields && requestSchemaFields.length > 0 && (
             <Card variant="sandbox" className="rounded-3xl">
               <CardContent className="p-6">
-                <h2 className="font-display text-2xl font-extrabold tracking-tight text-white">
+                <h2 className="font-display text-2xl font-extrabold tracking-tight text-foreground">
                   Request schema
                 </h2>
                 <div className="mt-4 flex flex-col gap-2">
                   {requestSchemaFields.map((field) => (
                     <div
                       key={`${field.name}-${field.kind}-${field.arrayLength}`}
-                      className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3"
+                      className="rounded-xl border border-border bg-[color:var(--bg-elevated)] px-4 py-3"
                     >
-                      <p className="text-sm font-semibold text-white">
+                      <p className="text-sm font-semibold text-foreground">
                         {formatSchemaField(field)}
                       </p>
                     </div>
@@ -242,10 +245,10 @@ const BlueprintAppServicePage: FC<Props> = ({
           <CardContent className="p-6">
             <div className="flex items-center justify-between gap-3">
               <div>
-                <h2 className="font-display text-2xl font-extrabold tracking-tight text-white">
+                <h2 className="font-display text-2xl font-extrabold tracking-tight text-foreground">
                   Supported actions
                 </h2>
-                <p className="mt-2 max-w-2xl text-sm leading-6 text-white/62">
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
                   Valid onchain jobs are callable from the service console. A
                   richer blueprint module can improve the form later, but the
                   service remains operable now.
@@ -259,21 +262,21 @@ const BlueprintAppServicePage: FC<Props> = ({
               {jobs.map((job, index) => (
                 <div
                   key={`${job.name}-${index}`}
-                  className="rounded-xl border border-white/10 bg-white/[0.04] p-4"
+                  className="rounded-xl border border-border bg-[color:var(--bg-elevated)] p-4"
                 >
-                  <h3 className="font-display text-lg font-bold text-white">
+                  <h3 className="font-display text-lg font-bold text-foreground">
                     {job.name || `Job #${index}`}
                   </h3>
-                  <p className="mt-2 text-sm leading-6 text-white/62">
+                  <p className="mt-2 text-sm leading-6 text-muted-foreground">
                     {job.description || 'No job description published.'}
                   </p>
                   <div className="mt-3 space-y-2">
-                    <p className="text-xs font-semibold text-white/50">
+                    <p className="text-xs font-semibold text-muted-foreground">
                       Params:{' '}
                       {job.hasParamsSchema ? job.parsedParamsSchema.length : 0}{' '}
                       fields
                     </p>
-                    <p className="text-xs font-semibold text-white/50">
+                    <p className="text-xs font-semibold text-muted-foreground">
                       Result:{' '}
                       {job.hasResultSchema ? job.parsedResultSchema.length : 0}{' '}
                       fields
@@ -291,10 +294,10 @@ const BlueprintAppServicePage: FC<Props> = ({
           <CardContent className="p-6">
             <div className="flex items-center justify-between gap-3">
               <div>
-                <h2 className="font-display text-2xl font-extrabold tracking-tight text-white">
+                <h2 className="font-display text-2xl font-extrabold tracking-tight text-foreground">
                   Recent service activity
                 </h2>
-                <p className="mt-2 max-w-2xl text-sm leading-6 text-white/62">
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
                   Indexed job traffic gives generic blueprint pages enough
                   signal to show whether a service is idle or actively being
                   used.
@@ -308,19 +311,19 @@ const BlueprintAppServicePage: FC<Props> = ({
               {recentCalls.slice(0, 5).map((call) => (
                 <div
                   key={call.id}
-                  className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3"
+                  className="rounded-xl border border-border bg-[color:var(--bg-elevated)] px-4 py-3"
                 >
                   <div className="flex flex-wrap items-center justify-between gap-3">
-                    <p className="text-sm font-semibold text-white">
+                    <p className="text-sm font-semibold text-foreground">
                       Job #{call.jobIndex} · Call {call.callId.toString()}
                     </p>
-                    <p className="text-xs font-semibold text-white/50">
+                    <p className="text-xs font-semibold text-muted-foreground">
                       {call.completed ? 'Completed' : 'Pending'} ·{' '}
                       {call.resultCount} result
                       {call.resultCount === 1 ? '' : 's'}
                     </p>
                   </div>
-                  <p className="mt-2 break-all text-xs font-semibold text-white/50">
+                  <p className="mt-2 break-all text-xs font-semibold text-muted-foreground">
                     Submitter: {call.submitter}
                   </p>
                 </div>
@@ -334,11 +337,14 @@ const BlueprintAppServicePage: FC<Props> = ({
 };
 
 const ServiceMetric = ({ label, value }: { label: string; value: string }) => (
-  <div className="rounded-xl border border-white/10 bg-white/[0.04] p-4">
-    <p className="text-xs font-bold uppercase tracking-widest text-white/42">
+  <div className="rounded-xl border border-border bg-[color:var(--bg-elevated)] p-4">
+    <p className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
       {label}
     </p>
-    <p className="mt-2 truncate text-sm font-semibold text-white" title={value}>
+    <p
+      className="mt-2 truncate text-sm font-semibold text-foreground"
+      title={value}
+    >
       {value}
     </p>
   </div>
@@ -353,10 +359,10 @@ const ServiceCard = ({
 }) => (
   <Card variant="sandbox" className="rounded-3xl">
     <CardContent className="space-y-3 p-6">
-      <h2 className="font-display text-xl font-extrabold tracking-tight text-white">
+      <h2 className="font-display text-xl font-extrabold tracking-tight text-foreground">
         {title}
       </h2>
-      <p className="text-sm leading-6 text-white/62">{description}</p>
+      <p className="text-sm leading-6 text-muted-foreground">{description}</p>
     </CardContent>
   </Card>
 );

--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintModePicker.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintModePicker.tsx
@@ -36,7 +36,9 @@ const BlueprintModePicker: FC<Props> = ({
   }
 
   return (
-    <section aria-label="Deployment mode" data-sandbox-ui className="space-y-3">
+    // Shell carries `data-sandbox-ui`; re-applying here would reset the
+    // current theme's tokens under this section.
+    <section aria-label="Deployment mode" className="space-y-3">
       <header className="space-y-1">
         <p className="font-semibold text-muted-foreground text-[11px] uppercase tracking-wider">
           Deployment mode

--- a/apps/tangle-cloud/src/blueprintApps/modules/sandbox/SandboxBlueprintLandingPage.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/modules/sandbox/SandboxBlueprintLandingPage.tsx
@@ -62,7 +62,11 @@ const SandboxBlueprintLandingPage: FC<Props> = ({ entry }) => {
   );
 
   return (
-    <div data-sandbox-ui className="space-y-6">
+    // The shell `<div>` already carries `data-sandbox-ui`. Re-declaring it
+    // here would re-apply sandbox-ui's dark token defaults via the
+    // `:root, [data-sandbox-ui]` rule and clobber the active vault/tangle
+    // theme on this subtree.
+    <div className="space-y-6">
       {modes.length > 1 && activeMode && (
         <BlueprintModePicker
           modes={modes}

--- a/apps/tangle-cloud/src/blueprintApps/modules/sandbox/SandboxBlueprintServicePage.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/modules/sandbox/SandboxBlueprintServicePage.tsx
@@ -92,7 +92,10 @@ const SandboxBlueprintServicePage: FC<Props> = ({ entry, serviceId }) => {
   };
 
   return (
-    <div data-sandbox-ui className="space-y-6">
+    // Shell already sets `data-sandbox-ui`. Re-declaring here resets the
+    // sandbox-ui token defaults under the subtree (dark theme bleeds into
+    // vault). Inner wrappers stay attribute-free.
+    <div className="space-y-6">
       {sandbox && (
         <SandboxCard
           sandbox={sandbox}

--- a/apps/tangle-cloud/src/blueprintApps/registry.ts
+++ b/apps/tangle-cloud/src/blueprintApps/registry.ts
@@ -1,5 +1,6 @@
 import { resolveBlueprintAppView } from './resolver';
 import type { BlueprintAppEntry } from './types';
+import type { BlueprintIframeConfig } from './iframe/types';
 
 /**
  * Identity that the curated registry matches against the blueprint's parsed
@@ -16,8 +17,23 @@ type CuratedBlueprintMatcher = {
   requestedSlug?: string;
 };
 
+/**
+ * Curated entries may carry an `iframe` block to embed the publisher's hosted
+ * app (e.g. trading-arena.blueprint.tangle.tools). The block mirrors what the
+ * metadata-driven parser produces for declarative blueprints — same shape, same
+ * downstream consumers (`BlueprintAppLandingPage`, `BlueprintAppFrameHost`) —
+ * so curated and metadata paths share the iframe surface without bespoke code.
+ *
+ * Curated iframe entries skip the on-chain `metadataVerification` gate (the
+ * dapp itself is the source of truth for first-party apps) but the runtime
+ * still enforces the manifest host suffix allowlist and the iframe sandbox
+ * policy in `iframe/policy.ts`. Set `manifest.externalApp` in tandem so the
+ * landing page's existing iframe gate (`mode === 'iframe'` && `trust ===
+ * 'trusted'`) trips correctly.
+ */
 type CuratedRegistryEntry = BlueprintAppEntry & {
   match?: CuratedBlueprintMatcher;
+  iframe?: BlueprintIframeConfig;
 };
 
 const entries = [
@@ -72,6 +88,32 @@ const entries = [
           scope: 'resource',
         },
       ],
+      // First-party external app handoff. The host suffix is already on the
+      // iframe policy allowlist (.blueprint.tangle.tools), and curated entries
+      // are trusted-by-default — no on-chain metadata attestation needed.
+      externalApp: {
+        url: 'https://trading-arena.blueprint.tangle.tools/',
+        mode: 'iframe',
+        host: 'trading-arena.blueprint.tangle.tools',
+        trust: 'trusted',
+        label: 'AI Trading',
+      },
+    },
+    // Iframe runtime policy. Empty allowedChainIds / contracts on purpose:
+    // the trading-arena UI doesn't issue tangle.app.signTransaction yet, so
+    // we don't grant transaction surface. allowReadAccount surfaces the
+    // connected wallet to the iframe for read-only views (positions,
+    // balances) without unlocking signing.
+    iframe: {
+      url: 'https://trading-arena.blueprint.tangle.tools/',
+      origin: 'https://trading-arena.blueprint.tangle.tools',
+      appId: 'trading-arena',
+      allowedChainIds: [],
+      contracts: [],
+      messages: [],
+      allowReadAccount: true,
+      allowChainSwitch: false,
+      allowPopups: false,
     },
   },
   {


### PR DESCRIPTION
## Summary

Two production UX fixes for `develop.cloud.tangle.tools` blueprint surfaces.

### Trading iframe missing

`/blueprints/trading` previously rendered the generic `BlueprintAppLandingPage` with no iframe — the curated registry entry for trading had no iframe configuration, so `BlueprintAppLandingPage`'s iframe gate (`'iframe' in entry && manifest.externalApp.mode === 'iframe' && trust === 'trusted'`) was unreachable.

- Added `iframe` (parsed `BlueprintIframeConfig`) + `manifest.externalApp` (trusted iframe handoff) to the trading curated registry entry pointing at `https://trading-arena.blueprint.tangle.tools/`.
- Widened `CuratedRegistryEntry` to allow the optional `iframe` field.
- `BlueprintAppLandingPage` now reads `entry.iframe` via a typed widening (works for both curated and metadata-derived entries).
- Hid the duplicate "Publisher console" external-tab button when the iframe is already embedded (same destination).

### Light/dark contrast on blueprint pages

`BlueprintAppLandingPage`, `BlueprintAppServicePage`, `BlueprintModePicker`, and the sandbox curated module all declared `data-sandbox-ui` on their root `<div>`. sandbox-ui's `:root, [data-sandbox-ui]` CSS rule resets every color/surface token to the dark default, so any element nested in those wrappers got tangle-theme tokens regardless of the shell's `data-sandbox-theme="vault"` attribute. The shell already carries `data-sandbox-ui`, so the inner declarations were redundant and broke theme inheritance.

- Removed the redundant `data-sandbox-ui` from inner wrappers.
- Replaced hardcoded `text-white` / `text-white/N` / `border-white/10` / `bg-white/[0.04]` in the landing + service page components with theme-aware tokens (`text-foreground`, `text-muted-foreground`, `border-border`, `bg-[color:var(--bg-elevated)]`).
- Left `BlueprintHostCard`'s `data-sandbox-ui` in place — it intentionally forces a dark hero independent of the active theme.

## Test plan

- [x] `yarn nx typecheck tangle-cloud` clean
- [x] `yarn nx lint tangle-cloud` clean
- [x] `yarn nx test tangle-cloud` clean (159/159 passing)
- [x] `yarn nx build tangle-cloud` clean
- [x] Playwright probe against the local build confirms `<iframe src="https://trading-arena.blueprint.tangle.tools/?mode=default">` is present in the DOM on `/blueprints/trading`.
- [x] Screenshots in both `tangle` (dark) and `vault` (light) themes show legible contrast on hero copy, descriptions, summary card titles, and step labels across `/blueprints/trading`, `/blueprints/sandbox`, and `/blueprints`.

## Follow-up note (separate repo)

The trading-arena iframe app serves a `Content-Security-Policy: frame-ancestors https://cloud.tangle.tools https://app.tangle.tools https://apps.tangle.tools` header — it does **not** allow `https://develop.cloud.tangle.tools`. The dapp side is now correct; once this PR deploys, the iframe element will appear in the DOM on develop but the browser will refuse to render its contents until the iframe app's CSP is updated to include the develop host. The fix is end-to-end on production `cloud.tangle.tools` immediately. Same situation already applies to the sandbox iframe.