### PR TITLE
style(tangle-cloud): tokenize 6 residual hardcoded colors

### DIFF
--- a/apps/tangle-cloud/src/components/blueprints/BlueprintVisual.tsx
+++ b/apps/tangle-cloud/src/components/blueprints/BlueprintVisual.tsx
@@ -57,7 +57,7 @@ export const BlueprintVisual = ({
         <GeneratedBlueprintDiagram name={displayName} category={category} />
       )}
 
-      <div className="tangle-cloud-visual-badge absolute bottom-4 right-4 grid h-10 w-10 shrink-0 place-items-center rounded-lg border border-white/20 bg-slate-950 font-display font-extrabold text-white shadow-[0_10px_24px_rgba(0,0,0,0.35)]">
+      <div className="tangle-cloud-visual-badge absolute bottom-4 right-4 grid h-10 w-10 shrink-0 place-items-center rounded-lg border border-border bg-card font-display font-extrabold text-foreground shadow-[var(--shadow-card)]">
         {displayName.slice(0, 1).toUpperCase()}
       </div>
     </div>

--- a/apps/tangle-cloud/src/containers/payments/SpendAuthContainer.tsx
+++ b/apps/tangle-cloud/src/containers/payments/SpendAuthContainer.tsx
@@ -340,7 +340,7 @@ const SpendAuthContainer: FC = () => {
               !isValidOperator ||
               !domainSeparator
             }
-            className="w-full px-4 py-3 text-sm font-semibold text-white rounded-lg bg-primary hover:bg-primary/80 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="w-full px-4 py-3 text-sm font-semibold text-primary-foreground rounded-lg bg-primary hover:bg-primary/80 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {!domainSeparator
               ? 'Waiting for contract...'

--- a/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
@@ -761,7 +761,7 @@ const BlueprintCard = ({
 
         {isSelectable && (
           <label
-            className="absolute right-7 top-7 z-20 flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-md border border-white/15 bg-black/35 transition-colors hover:bg-black/50"
+            className="absolute right-7 top-7 z-20 flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-md border border-border bg-card/80 backdrop-blur transition-colors hover:bg-card"
             onClick={(event) => event.stopPropagation()}
           >
             <span className="sr-only">Select {blueprint.name}</span>

--- a/apps/tangle-cloud/src/pages/blueprints/[id]/page.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/[id]/page.tsx
@@ -558,7 +558,10 @@ const OperatorIdenticon = ({ address }: { address: string }) => {
 
   return (
     <div
-      className="grid h-12 w-12 shrink-0 place-items-center rounded-lg border border-border font-display font-extrabold text-white"
+      // Saturated-hue gradient background needs a contrast-stable foreground
+      // regardless of theme. `text-primary-foreground` resolves to the same
+      // white in both dark + light themes (it's the on-primary color).
+      className="grid h-12 w-12 shrink-0 place-items-center rounded-lg border border-border font-display font-extrabold text-primary-foreground"
       style={{
         background: `linear-gradient(135deg, hsl(${hue} 82% 58%), hsl(${(hue + 48) % 360} 82% 50%))`,
       }}

--- a/apps/tangle-cloud/src/pages/blueprints/create/page.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/create/page.tsx
@@ -707,7 +707,7 @@ const CreateBlueprintPage: FC = () => {
                 index === step
                   ? 'bg-primary text-primary-foreground'
                   : index < step
-                    ? 'bg-green-500 text-white'
+                    ? 'bg-success text-primary-foreground'
                     : 'bg-muted text-muted-foreground'
               }`}
             >

--- a/apps/tangle-cloud/src/pages/operators/page.tsx
+++ b/apps/tangle-cloud/src/pages/operators/page.tsx
@@ -453,7 +453,11 @@ const OperatorTableRow = ({
 
 const OperatorIdenticon = ({ address }: { address: string }) => (
   <div
-    className="grid h-9 w-9 shrink-0 place-items-center rounded-lg border border-border bg-slate-950 font-display font-extrabold text-white text-xs shadow-[var(--shadow-card)]"
+    // The inline `style` from `getOperatorIdenticonStyle` paints a saturated
+    // hue gradient as the actual background, so the `bg-card` fallback only
+    // shows for the brief render before the style applies. `text-primary-
+    // foreground` keeps the contrast stable across both themes.
+    className="grid h-9 w-9 shrink-0 place-items-center rounded-lg border border-border bg-card font-display font-extrabold text-primary-foreground text-xs shadow-[var(--shadow-card)]"
     style={getOperatorIdenticonStyle(address)}
   >
     {address.slice(2, 4).toUpperCase()}


### PR DESCRIPTION
Surgical follow-up to PR #3228. Sweeps the 8 `text-white` / `bg-white` / `border-white/N` / `bg-slate-950` / `bg-green-500` usages outside `BlueprintHostCard.tsx` (which has its own parallel PR for the 42-site rewrite).

## Affected

- `components/blueprints/BlueprintVisual.tsx` — badge tokens
- `pages/blueprints/[id]/page.tsx` — hue-gradient badge foreground
- `pages/operators/page.tsx` — operator identicon
- `pages/blueprints/BlueprintListing.tsx` — select-card close button
- `pages/blueprints/create/page.tsx` — step indicator done state
- `containers/payments/SpendAuthContainer.tsx` — primary button foreground

## Kept (intentional)

- `Sidebar.tsx:154` mobile drawer scrim
- `TxHistoryDrawer.tsx:112` TX history scrim

Modal backdrops must visibly darken the underlying page regardless of theme; `bg-black/N` is the correct choice.

## Verification

- `yarn nx typecheck tangle-cloud` ✓
- `yarn nx lint tangle-cloud` ✓
- `yarn nx test tangle-cloud` ✓