### PR TITLE
feat(blueprintApps): forward parent theme to iframe via ?theme=light|dark

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrame.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrame.tsx
@@ -1,5 +1,7 @@
 import {
   forwardRef,
+  useEffect,
+  useState,
   type CSSProperties,
   type ForwardedRef,
   type IframeHTMLAttributes,
@@ -28,6 +30,34 @@ type Props = {
   blueprintId?: bigint | number;
   // Tests / non-DOM environments may want to render with a stub.
   iframeProps?: Pick<IframeHTMLAttributes<HTMLIFrameElement>, 'name'>;
+};
+
+/**
+ * Read the parent shell's current theme from `<html data-sandbox-theme>`.
+ * The Layout component publishes this attribute alongside the dark/light
+ * class. Iframes embed sub-apps that maintain their own theme state, so
+ * without forwarding the parent's theme they render a black void on a
+ * vault (light) parent. Forwarded via `?theme=light|dark` so the iframe
+ * app's first paint matches the dapp shell.
+ */
+const useParentTheme = (): 'light' | 'dark' => {
+  const read = () => {
+    if (typeof document === 'undefined') return 'dark' as const;
+    const themeAttr =
+      document.documentElement.getAttribute('data-sandbox-theme');
+    return themeAttr === 'vault' ? ('light' as const) : ('dark' as const);
+  };
+  const [theme, setTheme] = useState<'light' | 'dark'>(read);
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const observer = new MutationObserver(() => setTheme(read()));
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-sandbox-theme'],
+    });
+    return () => observer.disconnect();
+  }, []);
+  return theme;
 };
 
 // Hardened iframe sandbox. We deliberately omit:
@@ -59,27 +89,30 @@ const PERMISSIONS_POLICY_DENY_ALL = '';
 const BlueprintAppFrameInner = (
   { config, title, className, style, mode, blueprintId, iframeProps }: Props,
   ref: ForwardedRef<HTMLIFrameElement>,
-) => (
-  <iframe
-    ref={ref}
-    title={title}
-    src={buildBlueprintIframeUrl(config.url, { mode, blueprintId })}
-    sandbox={buildSandbox(config)}
-    allow={PERMISSIONS_POLICY_DENY_ALL}
-    referrerPolicy="no-referrer"
-    loading="lazy"
-    className={className}
-    style={{
-      // Default to a sensible aspect; consumer can override.
-      width: '100%',
-      minHeight: '720px',
-      border: '0',
-      borderRadius: '16px',
-      ...style,
-    }}
-    {...iframeProps}
-  />
-);
+) => {
+  const theme = useParentTheme();
+  return (
+    <iframe
+      ref={ref}
+      title={title}
+      src={buildBlueprintIframeUrl(config.url, { mode, blueprintId, theme })}
+      sandbox={buildSandbox(config)}
+      allow={PERMISSIONS_POLICY_DENY_ALL}
+      referrerPolicy="no-referrer"
+      loading="lazy"
+      className={className}
+      style={{
+        // Default to a sensible aspect; consumer can override.
+        width: '100%',
+        minHeight: '720px',
+        border: '0',
+        borderRadius: '16px',
+        ...style,
+      }}
+      {...iframeProps}
+    />
+  );
+};
 
 const BlueprintAppFrame = forwardRef(BlueprintAppFrameInner);
 BlueprintAppFrame.displayName = 'BlueprintAppFrame';

--- a/apps/tangle-cloud/src/blueprintApps/dedupe.spec.ts
+++ b/apps/tangle-cloud/src/blueprintApps/dedupe.spec.ts
@@ -292,4 +292,30 @@ describe('buildBlueprintIframeUrl', () => {
       buildBlueprintIframeUrl('not a url', { mode: 'cloud', blueprintId: 1 }),
     ).toBe('not a url');
   });
+
+  it("forwards the parent shell's light theme as ?theme=light", () => {
+    const url = buildBlueprintIframeUrl('https://x.blueprint.tangle.tools/', {
+      mode: 'default',
+      blueprintId: 7,
+      theme: 'light',
+    });
+    expect(new URL(url).searchParams.get('theme')).toBe('light');
+  });
+
+  it("forwards the parent shell's dark theme as ?theme=dark", () => {
+    const url = buildBlueprintIframeUrl('https://x.blueprint.tangle.tools/', {
+      mode: 'default',
+      blueprintId: 7,
+      theme: 'dark',
+    });
+    expect(new URL(url).searchParams.get('theme')).toBe('dark');
+  });
+
+  it('omits the theme param when caller does not supply one (back-compat)', () => {
+    const url = buildBlueprintIframeUrl('https://x.blueprint.tangle.tools/', {
+      mode: 'default',
+      blueprintId: 7,
+    });
+    expect(new URL(url).searchParams.has('theme')).toBe(false);
+  });
 });

--- a/apps/tangle-cloud/src/blueprintApps/iframe/url.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/url.ts
@@ -1,10 +1,17 @@
 /**
- * Append the mode + blueprintId query params to the iframe URL. The
- * iframe contract reserves `mode` and `blueprintId` query names. When
- * the manifest URL already declares one of them (publishers shouldn't
- * but we don't want to silently drop signed intent for non-reserved
- * params), we leave OTHER existing params alone — the parent's picked
- * mode replaces the reserved params only.
+ * Append the iframe contract's reserved query params to the iframe URL.
+ *
+ * Reserved names (publishers must not collide):
+ *   - `mode`         — which on-chain blueprint variant the user picked
+ *   - `blueprintId`  — that variant's numeric ID, for the iframe app to
+ *                      read without round-tripping the chain
+ *   - `theme`        — `'light' | 'dark'`, so the iframe app's own
+ *                      `data-sandbox-theme` can match the parent shell
+ *                      instead of rendering a dark void on a light dapp
+ *                      (or vice versa)
+ *
+ * Other (non-reserved) params on the manifest URL are preserved verbatim —
+ * publishers may sign intent into them and we shouldn't drop that.
  *
  * Returning a pure function (separate from the iframe component) means
  * the URL contract has a unit-testable surface and `BlueprintAppFrame`
@@ -13,7 +20,11 @@
  */
 export const buildBlueprintIframeUrl = (
   baseUrl: string,
-  options: { mode?: string; blueprintId?: bigint | number },
+  options: {
+    mode?: string;
+    blueprintId?: bigint | number;
+    theme?: 'light' | 'dark';
+  },
 ): string => {
   let url: URL;
   try {
@@ -28,6 +39,9 @@ export const buildBlueprintIframeUrl = (
   url.searchParams.set('mode', modeId);
   if (options.blueprintId !== undefined) {
     url.searchParams.set('blueprintId', options.blueprintId.toString());
+  }
+  if (options.theme === 'light' || options.theme === 'dark') {
+    url.searchParams.set('theme', options.theme);
   }
   return url.toString();
 };


### PR DESCRIPTION
Visible bug: trading iframe renders as a solid black rectangle on `develop.cloud.tangle.tools/blueprints/trading` when the dapp shell is in vault (light) mode. The iframe sub-apps run their own theme state — they default to dark on first paint even when the parent is light.

## Fix (dapp side)

- `buildBlueprintIframeUrl` accepts `theme: 'light' | 'dark'` and emits `?theme=...` as a reserved iframe contract query param.
- New `useParentTheme` hook in `BlueprintAppFrame` reads `<html data-sandbox-theme>` and MutationObserves it so the iframe `src` updates when the user toggles theme.
- 3 new spec cases pin the forward / back-compat behavior.

## Companion iframe-app changes

Iframe apps must read `?theme=` and apply it. Shipping in parallel against ai-agent-sandbox-blueprint + ai-trading-blueprint.

Back-compat: when `theme` is unset (older iframe apps), the param is omitted; iframe apps keep their current default behavior.

## Test plan

- [x] `yarn nx typecheck tangle-cloud` clean
- [x] `yarn nx test tangle-cloud` clean
- [x] `yarn nx lint tangle-cloud` clean
- [ ] After iframe app PRs deploy: trading iframe renders with parent-matching background on develop.