### PR TITLE
feat(tangle-cloud): chrome system — 5 type roles, page primitives, ⌘K palette, URL state

### DIFF
--- a/apps/tangle-cloud/src/components/Layout.tsx
+++ b/apps/tangle-cloud/src/components/Layout.tsx
@@ -1,9 +1,12 @@
 import TxConfirmationModal from '@tangle-network/tangle-shared-ui/components/TxConfirmationModal';
 import Sidebar from './Sidebar';
-import { FC, PropsWithChildren, useEffect, useState } from 'react';
+import { FC, PropsWithChildren, useCallback, useEffect, useState } from 'react';
 import TxHistoryNotifier from './TxHistoryNotifier';
 import Header from './Header';
 import { twMerge } from 'tailwind-merge';
+import CommandPalette from './chrome/CommandPalette';
+import ShortcutsHelp from './chrome/ShortcutsHelp';
+import { useKeyboardShortcuts } from './chrome/useKeyboardShortcuts';
 
 type Props = {
   isSidebarInitiallyExpanded?: boolean;
@@ -57,6 +60,15 @@ const Layout: FC<PropsWithChildren<Props>> = ({
     );
   }, [isSidebarExpanded]);
 
+  // Global ⌘K palette + ? help overlay + g-prefix navigation. Mounted once
+  // at the layout root so every page inherits the keyboard surface.
+  const [isPaletteOpen, setIsPaletteOpen] = useState(false);
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
+  useKeyboardShortcuts({
+    onOpenPalette: useCallback(() => setIsPaletteOpen(true), []),
+    onOpenHelp: useCallback(() => setIsHelpOpen(true), []),
+  });
+
   return (
     <div
       data-sandbox-ui
@@ -81,6 +93,8 @@ const Layout: FC<PropsWithChildren<Props>> = ({
       >
         <TxHistoryNotifier />
         <TxConfirmationModal />
+        <CommandPalette open={isPaletteOpen} onOpenChange={setIsPaletteOpen} />
+        <ShortcutsHelp open={isHelpOpen} onOpenChange={setIsHelpOpen} />
 
         <main className="flex-1">{children}</main>
       </div>

--- a/apps/tangle-cloud/src/components/chrome/CommandPalette.tsx
+++ b/apps/tangle-cloud/src/components/chrome/CommandPalette.tsx
@@ -1,0 +1,295 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from '@tangle-network/sandbox-ui/primitives';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FC,
+  type ReactNode,
+} from 'react';
+import { useNavigate } from 'react-router';
+import { twMerge } from 'tailwind-merge';
+import { focus, typeRole } from '../../styles/chrome';
+import { PagePath } from '../../types';
+
+export type Command = {
+  /** Unique stable id for keying + persistence. */
+  id: string;
+  /** Primary label shown in the palette. */
+  label: string;
+  /** Optional secondary text, e.g. "Catalog" or "Operator action". */
+  group?: string;
+  /** Optional leading glyph (rendered 16px). */
+  icon?: ReactNode;
+  /** Optional keyboard hint (e.g. "g b"). */
+  shortcut?: string;
+  /** What to do when chosen. Either navigate to a path or run a side-effect. */
+  perform: () => void;
+  /** Tokens that match a query against this command. Auto-derived if absent. */
+  keywords?: string[];
+};
+
+type Props = {
+  /** Open state. Controlled — caller decides when to show. */
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Caller-supplied commands. Built-in nav commands are prepended automatically. */
+  extra?: Command[];
+};
+
+/** Built-in navigation commands available everywhere. */
+const useBuiltinCommands = (close: () => void): Command[] => {
+  const navigate = useNavigate();
+  return useMemo(
+    () => [
+      {
+        id: 'nav:blueprints',
+        label: 'Go to Blueprints',
+        group: 'Navigate',
+        shortcut: 'g b',
+        keywords: ['blueprints', 'catalog'],
+        perform: () => {
+          navigate(PagePath.BLUEPRINTS);
+          close();
+        },
+      },
+      {
+        id: 'nav:operators',
+        label: 'Go to Operators',
+        group: 'Navigate',
+        shortcut: 'g o',
+        keywords: ['operators', 'directory'],
+        perform: () => {
+          navigate(PagePath.OPERATORS);
+          close();
+        },
+      },
+      {
+        id: 'nav:rewards',
+        label: 'Go to Rewards',
+        group: 'Navigate',
+        shortcut: 'g r',
+        keywords: ['rewards', 'claims'],
+        perform: () => {
+          navigate(PagePath.REWARDS);
+          close();
+        },
+      },
+      {
+        id: 'nav:earnings',
+        label: 'Go to Earnings',
+        group: 'Navigate',
+        shortcut: 'g e',
+        keywords: ['earnings', 'payouts'],
+        perform: () => {
+          navigate(PagePath.EARNINGS);
+          close();
+        },
+      },
+      {
+        id: 'nav:instances',
+        label: 'Go to Instances',
+        group: 'Navigate',
+        shortcut: 'g i',
+        keywords: ['instances', 'services', 'dashboard'],
+        perform: () => {
+          navigate(PagePath.INSTANCES);
+          close();
+        },
+      },
+      {
+        id: 'nav:blueprints-manage',
+        label: 'Manage your blueprints',
+        group: 'Navigate',
+        keywords: ['manage', 'publish', 'admin'],
+        perform: () => {
+          navigate(PagePath.BLUEPRINTS_MANAGE);
+          close();
+        },
+      },
+    ],
+    [navigate, close],
+  );
+};
+
+const matches = (cmd: Command, query: string) => {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  if (cmd.label.toLowerCase().includes(q)) return true;
+  if (cmd.group?.toLowerCase().includes(q)) return true;
+  if (cmd.keywords?.some((k) => k.toLowerCase().includes(q))) return true;
+  return false;
+};
+
+/**
+ * ⌘K command palette. The primary navigation surface at this product tier —
+ * every page is one keystroke away, every action a publisher or operator can
+ * take is searchable.
+ *
+ * Implementation is intentionally cmdk-free — `cmdk` would be one more dep
+ * for a thin layer on top of Dialog + filtered list. The palette already does
+ * everything we need: case-insensitive label/group/keyword match, j/k +
+ * arrow-key navigation, Enter to execute, Esc to close.
+ */
+const CommandPalette: FC<Props> = ({ open, onOpenChange, extra = [] }) => {
+  const close = useCallback(() => onOpenChange(false), [onOpenChange]);
+  const builtins = useBuiltinCommands(close);
+  const all = useMemo(() => [...builtins, ...extra], [builtins, extra]);
+
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const filtered = useMemo(
+    () => all.filter((cmd) => matches(cmd, query)),
+    [all, query],
+  );
+
+  // Reset on open / collapse on close so the next invocation starts fresh.
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setActiveIndex(0);
+      // Focus on next tick so the Dialog's autofocus doesn't steal it.
+      const id = window.setTimeout(() => inputRef.current?.focus(), 10);
+      return () => window.clearTimeout(id);
+    }
+    return undefined;
+  }, [open]);
+
+  useEffect(() => {
+    setActiveIndex((i) => Math.min(i, Math.max(0, filtered.length - 1)));
+  }, [filtered.length]);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown' || (e.key === 'j' && e.ctrlKey)) {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(filtered.length - 1, i + 1));
+    } else if (e.key === 'ArrowUp' || (e.key === 'k' && e.ctrlKey)) {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(0, i - 1));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const chosen = filtered[activeIndex];
+      if (chosen) chosen.perform();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    }
+  };
+
+  // Group commands by `group`, preserving insertion order. Ungrouped commands
+  // end up under "Actions".
+  const grouped = useMemo(() => {
+    const out = new Map<string, Command[]>();
+    for (const cmd of filtered) {
+      const key = cmd.group ?? 'Actions';
+      const list = out.get(key) ?? [];
+      list.push(cmd);
+      out.set(key, list);
+    }
+    return Array.from(out.entries());
+  }, [filtered]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className={twMerge(
+          'top-[20%] max-w-[640px] translate-y-0 gap-0 overflow-hidden p-0',
+          'border border-border bg-[color:var(--bg-card)]',
+        )}
+        onKeyDown={onKeyDown}
+      >
+        <DialogTitle className="sr-only">Command palette</DialogTitle>
+        <input
+          ref={inputRef}
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search for an action, page, or blueprint…"
+          className={twMerge(
+            'h-12 w-full border-b border-border bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/70',
+            focus.ring,
+          )}
+        />
+        <div className="max-h-[60vh] overflow-y-auto py-2">
+          {filtered.length === 0 ? (
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              No matching actions.
+            </div>
+          ) : (
+            grouped.map(([group, cmds]) => (
+              <div key={group} className="pb-2">
+                <div className={twMerge(typeRole.label, 'px-4 py-1.5')}>
+                  {group}
+                </div>
+                {cmds.map((cmd) => {
+                  const cmdIndex = filtered.indexOf(cmd);
+                  const active = cmdIndex === activeIndex;
+                  return (
+                    <button
+                      key={cmd.id}
+                      type="button"
+                      onMouseEnter={() => setActiveIndex(cmdIndex)}
+                      onClick={() => cmd.perform()}
+                      className={twMerge(
+                        'flex w-full items-center gap-3 px-4 py-2 text-left text-sm transition-colors',
+                        active
+                          ? 'bg-[color:var(--bg-hover)] text-foreground'
+                          : 'text-muted-foreground hover:text-foreground',
+                      )}
+                    >
+                      {cmd.icon !== undefined && (
+                        <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
+                          {cmd.icon}
+                        </span>
+                      )}
+                      <span className="flex-1 truncate">{cmd.label}</span>
+                      {cmd.shortcut !== undefined && (
+                        <kbd className="hidden rounded border border-border bg-[color:var(--bg-elevated)]/60 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground sm:inline-block">
+                          {cmd.shortcut}
+                        </kbd>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            ))
+          )}
+        </div>
+        <div className="flex items-center justify-between border-t border-border px-4 py-2 text-[11px] text-muted-foreground">
+          <div className="flex items-center gap-3">
+            <span>
+              <kbd className="rounded border border-border bg-[color:var(--bg-elevated)]/60 px-1 font-mono">
+                ↑↓
+              </kbd>{' '}
+              navigate
+            </span>
+            <span>
+              <kbd className="rounded border border-border bg-[color:var(--bg-elevated)]/60 px-1 font-mono">
+                ↵
+              </kbd>{' '}
+              execute
+            </span>
+            <span>
+              <kbd className="rounded border border-border bg-[color:var(--bg-elevated)]/60 px-1 font-mono">
+                esc
+              </kbd>{' '}
+              close
+            </span>
+          </div>
+          <span className="font-mono">
+            {filtered.length} / {all.length}
+          </span>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CommandPalette;

--- a/apps/tangle-cloud/src/components/chrome/EmptyState.tsx
+++ b/apps/tangle-cloud/src/components/chrome/EmptyState.tsx
@@ -1,0 +1,128 @@
+import type { FC, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { typeRole } from '../../styles/chrome';
+
+export type EmptyKind =
+  | 'no-data'
+  | 'no-match'
+  | 'error'
+  | 'loading'
+  | 'no-permission'
+  | 'no-network';
+
+type Props = {
+  kind: EmptyKind;
+  /** Display title — defaults are kind-specific and rarely need overriding. */
+  title?: string;
+  /** Body copy — defaults are kind-specific. */
+  description?: ReactNode;
+  /** Optional glyph rendered above the title. Falls back to a kind-specific dot. */
+  icon?: ReactNode;
+  /** Primary action — typically the recovery affordance for `no-match` /
+   * `error`, or the onboarding affordance for `no-data`. */
+  primary?: ReactNode;
+  /** Secondary action — escape hatch, "go back", "view docs". */
+  secondary?: ReactNode;
+  /** Surrounding container styles. Empty states usually live where the result
+   * grid would have rendered, so layout class is the caller's choice. */
+  className?: string;
+};
+
+const KIND_DEFAULTS: Record<
+  EmptyKind,
+  { title: string; description: string; dotClass: string }
+> = {
+  'no-data': {
+    title: 'Nothing here yet',
+    description: 'There is no data for this view. Get started below.',
+    dotClass: 'bg-muted-foreground/40',
+  },
+  'no-match': {
+    title: 'No matches',
+    description: 'Try removing a filter or broadening your search.',
+    dotClass: 'bg-[color:var(--border-accent-hover)]',
+  },
+  error: {
+    title: 'Something went wrong',
+    description: 'The request failed. Retry or refresh the page.',
+    dotClass: 'bg-[color:var(--md3-error,#ef4444)]',
+  },
+  loading: {
+    title: 'Loading',
+    description: 'Fetching data from the indexer.',
+    dotClass: 'bg-muted-foreground/40',
+  },
+  'no-permission': {
+    title: 'No access',
+    description: 'You need additional permissions to view this surface.',
+    dotClass: 'bg-[color:var(--md3-warning,#f59e0b)]',
+  },
+  'no-network': {
+    title: 'Network unavailable',
+    description: 'Switch networks or check your wallet connection.',
+    dotClass: 'bg-[color:var(--md3-warning,#f59e0b)]',
+  },
+};
+
+/**
+ * Hand-crafted empty states, one per kind. Most cloud-app empties used to read
+ * "no X found" with a tiny gray icon — that's slop. This component owns the
+ * canonical shape (icon + title + description + primary + secondary) and the
+ * kind-specific copy, so a caller writes:
+ *
+ *   <EmptyState
+ *     kind="no-match"
+ *     primary={<Button onClick={clearFilters}>Clear filters</Button>}
+ *   />
+ *
+ * and gets recoverable, on-brand chrome. Pages can override `title`/`description`
+ * for kind-specific context (e.g. `/operators` no-data: "Register your first
+ * operator to get listed here.") but the kind drives the visual language.
+ */
+const EmptyState: FC<Props> = ({
+  kind,
+  title,
+  description,
+  icon,
+  primary,
+  secondary,
+  className,
+}) => {
+  const defaults = KIND_DEFAULTS[kind];
+  const finalTitle = title ?? defaults.title;
+  const finalDescription = description ?? defaults.description;
+  return (
+    <div
+      role={kind === 'error' ? 'alert' : 'status'}
+      className={twMerge(
+        'flex min-h-[280px] flex-col items-center justify-center gap-4 rounded-lg border border-dashed border-border bg-[color:var(--bg-card)]/40 p-8 text-center',
+        className,
+      )}
+    >
+      <div className="flex h-12 w-12 items-center justify-center rounded-full border border-border bg-background">
+        {icon ?? (
+          <span
+            aria-hidden
+            className={twMerge('h-2.5 w-2.5 rounded-full', defaults.dotClass)}
+          />
+        )}
+      </div>
+      <div className="max-w-md space-y-1.5">
+        <h2 className={twMerge(typeRole.section, 'text-foreground')}>
+          {finalTitle}
+        </h2>
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          {finalDescription}
+        </p>
+      </div>
+      {(primary !== undefined || secondary !== undefined) && (
+        <div className="flex flex-wrap items-center justify-center gap-2 pt-1">
+          {primary}
+          {secondary}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EmptyState;

--- a/apps/tangle-cloud/src/components/chrome/FilterTray.tsx
+++ b/apps/tangle-cloud/src/components/chrome/FilterTray.tsx
@@ -1,0 +1,95 @@
+import * as Popover from '@radix-ui/react-popover';
+import { FilterIcon2 } from '@tangle-network/icons';
+import { Button } from '@tangle-network/sandbox-ui/primitives';
+import type { FC, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { chromeHeight, focus, typeRole } from '../../styles/chrome';
+
+type Props = {
+  children: ReactNode;
+  /** Number of active (non-default) filters. Renders as a badge on the trigger. */
+  activeCount?: number;
+  /** Callback when the user clicks "Clear all" inside the tray. */
+  onClear?: () => void;
+  /** Trigger label override (default: "Filters"). */
+  label?: string;
+  /** Optional title shown at the top of the tray. */
+  trayTitle?: string;
+};
+
+/**
+ * Secondary filters live here, not on the toolbar surface. The toolbar gets a
+ * single "Filters" pill with an active-count badge; clicking opens a popover
+ * tray with the full set of selects, toggles, and chips.
+ *
+ * Why a tray instead of inline:
+ *   - Most operators don't change filters per session — surfacing 4 dropdowns
+ *     permanently was tax on every visit.
+ *   - The tray is shared across catalog pages (blueprints, operators, services),
+ *     so the operator's muscle memory transfers.
+ *
+ * Children are arbitrary form controls; this component owns the surface and
+ * the "Clear all" affordance, not the filter semantics.
+ */
+const FilterTray: FC<Props> = ({
+  children,
+  activeCount = 0,
+  onClear,
+  label = 'Filters',
+  trayTitle,
+}) => {
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          className={twMerge(
+            'inline-flex h-9 items-center gap-2 rounded-md border border-border bg-transparent px-3 text-sm font-medium text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
+            focus.ring,
+          )}
+        >
+          <FilterIcon2 className="h-4 w-4 fill-current" />
+          <span>{label}</span>
+          {activeCount > 0 && (
+            <span
+              className={twMerge(
+                typeRole.mono,
+                'flex h-5 min-w-[20px] items-center justify-center rounded-full bg-[color:var(--border-accent)] px-1.5 text-[11px] text-foreground',
+              )}
+            >
+              {activeCount}
+            </span>
+          )}
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="end"
+          sideOffset={8}
+          className={twMerge(
+            chromeHeight.tray,
+            'z-50 rounded-lg border border-border bg-[color:var(--bg-card)] p-4 shadow-[var(--shadow-dropdown)]',
+            'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+          )}
+        >
+          <div className="mb-3 flex items-center justify-between">
+            <span className={typeRole.label}>{trayTitle ?? 'Filters'}</span>
+            {onClear && activeCount > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onClear}
+                className="h-7 px-2 text-xs"
+              >
+                Clear all
+              </Button>
+            )}
+          </div>
+          <div className="space-y-4">{children}</div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+};
+
+export default FilterTray;

--- a/apps/tangle-cloud/src/components/chrome/MetricStrip.tsx
+++ b/apps/tangle-cloud/src/components/chrome/MetricStrip.tsx
@@ -1,0 +1,109 @@
+import { Skeleton } from '@tangle-network/sandbox-ui/primitives';
+import type { FC, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { chromeHeight, typeRole } from '../../styles/chrome';
+
+export type MetricTone = 'neutral' | 'accent' | 'success' | 'warning';
+
+export type Metric = {
+  label: string;
+  value: ReactNode;
+  sublabel?: ReactNode;
+  tone?: MetricTone;
+  loading?: boolean;
+};
+
+type Props = {
+  metrics: Metric[];
+  className?: string;
+  /** Compact mode renders smaller numerals (used in toolbars). */
+  density?: 'default' | 'compact';
+};
+
+const TONE_VALUE_CLASS: Record<MetricTone, string> = {
+  neutral: 'text-foreground',
+  accent: 'text-foreground',
+  success: 'text-[color:var(--md3-tertiary,#10b981)]',
+  warning: 'text-[color:var(--md3-warning,#f59e0b)]',
+};
+
+const TONE_DOT_CLASS: Record<MetricTone, string> = {
+  neutral: 'bg-muted-foreground/30',
+  accent: 'bg-[color:var(--border-accent-hover)]',
+  success: 'bg-[color:var(--md3-tertiary,#10b981)]',
+  warning: 'bg-[color:var(--md3-warning,#f59e0b)]',
+};
+
+/**
+ * Compact horizontal strip of 2–4 metrics. **Off by default** on most pages —
+ * only opt in where a small dose of context above the content earns its space
+ * (the home dashboard, the operator-detail page header). Catalog pages don't
+ * get this; the count badge in the toolbar already conveys catalog size.
+ *
+ * Numerals are mono and tabular so columns align when values change. Each
+ * metric is one line; sublabels are demoted to the label tier so the eye
+ * tracks values, not adornments.
+ */
+const MetricStrip: FC<Props> = ({
+  metrics,
+  className,
+  density = 'default',
+}) => {
+  if (metrics.length === 0) return null;
+  const valueSize =
+    density === 'compact' ? 'text-lg' : 'text-2xl md:text-[26px]';
+  return (
+    <div
+      className={twMerge(
+        chromeHeight.metricStrip,
+        'flex flex-wrap items-stretch gap-x-8 gap-y-3 border-b border-border',
+        className,
+      )}
+      role="group"
+      aria-label="Page metrics"
+    >
+      {metrics.map((metric, i) => {
+        const tone = metric.tone ?? 'neutral';
+        return (
+          <div
+            key={`${metric.label}-${i}`}
+            className="flex min-w-[140px] flex-col justify-center"
+          >
+            <div
+              className={twMerge(typeRole.label, 'flex items-center gap-1.5')}
+            >
+              <span
+                aria-hidden
+                className={twMerge(
+                  'inline-block h-1.5 w-1.5 rounded-full',
+                  TONE_DOT_CLASS[tone],
+                )}
+              />
+              {metric.label}
+            </div>
+            {metric.loading ? (
+              <Skeleton className="mt-1 h-7 w-20" />
+            ) : (
+              <div
+                className={twMerge(
+                  'font-mono font-semibold leading-tight tabular-nums',
+                  valueSize,
+                  TONE_VALUE_CLASS[tone],
+                )}
+              >
+                {metric.value}
+              </div>
+            )}
+            {metric.sublabel !== undefined && (
+              <div className="mt-0.5 text-xs text-muted-foreground">
+                {metric.sublabel}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default MetricStrip;

--- a/apps/tangle-cloud/src/components/chrome/PageHeader.tsx
+++ b/apps/tangle-cloud/src/components/chrome/PageHeader.tsx
@@ -1,0 +1,71 @@
+import type { FC, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { chromeHeight, typeRole } from '../../styles/chrome';
+
+type Density = 'compact' | 'default' | 'hero';
+
+type Props = {
+  title: string;
+  subtitle?: ReactNode;
+  /** Right-aligned primary action(s). Keep it to one button on most pages. */
+  action?: ReactNode;
+  /** Optional small breadcrumb / context above the title. */
+  eyebrow?: ReactNode;
+  density?: Density;
+  className?: string;
+};
+
+const DENSITY_CLASS: Record<Density, string> = {
+  compact: chromeHeight.headerCompact,
+  default: chromeHeight.headerDefault,
+  hero: chromeHeight.headerHero,
+};
+
+/**
+ * The header pattern for every cloud-app page. Composes a single H1, an
+ * optional subtitle, an optional eyebrow, and a slot for right-aligned
+ * actions. Three density modes — `compact` (60px) for tool-heavy pages
+ * where the page title fights for space, `default` (80px) for most pages,
+ * `hero` (120px) for the rare landing-y surface that earns the room.
+ *
+ * Replaces the bespoke `cloud-hero-card` + `cloud-compact-header` chrome that
+ * each cloud-app page used to invent for itself. No card wrapping, no gradient
+ * backdrop, no shadow ramp — header is typography on the page background.
+ */
+const PageHeader: FC<Props> = ({
+  title,
+  subtitle,
+  action,
+  eyebrow,
+  density = 'default',
+  className,
+}) => {
+  return (
+    <header
+      className={twMerge(
+        'flex flex-col gap-3 md:flex-row md:items-center md:justify-between',
+        DENSITY_CLASS[density],
+        className,
+      )}
+    >
+      <div className="min-w-0 space-y-1">
+        {eyebrow !== undefined && (
+          <div className={typeRole.label}>{eyebrow}</div>
+        )}
+        <h1 className={typeRole.display}>{title}</h1>
+        {subtitle !== undefined && (
+          <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+            {subtitle}
+          </p>
+        )}
+      </div>
+      {action !== undefined && (
+        <div className="flex shrink-0 flex-wrap items-center gap-2 md:gap-3">
+          {action}
+        </div>
+      )}
+    </header>
+  );
+};
+
+export default PageHeader;

--- a/apps/tangle-cloud/src/components/chrome/PageToolbar.tsx
+++ b/apps/tangle-cloud/src/components/chrome/PageToolbar.tsx
@@ -1,0 +1,104 @@
+import { Search } from '@tangle-network/icons';
+import type { FC, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { chromeHeight, focus, typeRole } from '../../styles/chrome';
+
+type Props = {
+  /** Bound to the search input. Required — the toolbar's reason for existing. */
+  search: {
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+    /** Auto-focus on mount (use on dedicated catalog pages). */
+    autoFocus?: boolean;
+  };
+  /** Inline filter chips/segments rendered between search and the trailing slot. */
+  filters?: ReactNode;
+  /** Right-aligned trailing slot — view toggle, "Filters" button, count badge. */
+  trailing?: ReactNode;
+  /** Optional total/match count, rendered as mono numerals next to search. */
+  count?: { matches: number; total: number; noun?: string };
+  /** Make the toolbar stick to the top of the page on scroll. Default true. */
+  sticky?: boolean;
+  className?: string;
+};
+
+/**
+ * Search + filter + view-toggle row. 44px tall. No card wrapping, no shadow,
+ * no `variant="sandbox"` tinted surface — it's a typography-and-controls row
+ * over the page background. Sticky by default so the toolbar stays available
+ * as the operator scrolls a long catalog.
+ *
+ * Replaces the per-page filter card (the one that used to consume 320px of
+ * vertical space on `/blueprints`). Every list/catalog page in the cloud-app
+ * composes this same component so the operator's eye trains on one bar shape.
+ */
+const PageToolbar: FC<Props> = ({
+  search,
+  filters,
+  trailing,
+  count,
+  sticky = true,
+  className,
+}) => {
+  return (
+    <div
+      className={twMerge(
+        chromeHeight.toolbar,
+        'flex w-full items-center gap-3 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/70',
+        sticky && 'sticky top-0 z-20',
+        className,
+      )}
+    >
+      <div className="relative flex min-w-0 flex-1 items-center">
+        <Search
+          className="pointer-events-none absolute left-3 h-4 w-4 fill-current text-muted-foreground"
+          aria-hidden
+        />
+        <input
+          type="search"
+          value={search.value}
+          onChange={(event) => search.onChange(event.currentTarget.value)}
+          placeholder={search.placeholder}
+          autoFocus={search.autoFocus}
+          className={twMerge(
+            'h-9 w-full rounded-md border border-transparent bg-transparent pl-9 pr-3 text-sm leading-tight text-foreground placeholder:text-muted-foreground/70',
+            'hover:border-border',
+            focus.ring,
+          )}
+        />
+      </div>
+
+      {count !== undefined && (
+        <span
+          className={twMerge(
+            typeRole.mono,
+            'shrink-0 text-muted-foreground tabular-nums',
+          )}
+          aria-live="polite"
+        >
+          {count.matches.toLocaleString()}
+          {count.matches !== count.total && (
+            <span className="opacity-60">
+              {' / '}
+              {count.total.toLocaleString()}
+            </span>
+          )}
+          {count.noun !== undefined && (
+            <span className="ml-1 opacity-60">{count.noun}</span>
+          )}
+        </span>
+      )}
+
+      {filters !== undefined && (
+        <div className="flex shrink-0 items-center gap-2">{filters}</div>
+      )}
+
+      {trailing !== undefined && (
+        <div className="flex shrink-0 items-center gap-2">{trailing}</div>
+      )}
+    </div>
+  );
+};
+
+export default PageToolbar;

--- a/apps/tangle-cloud/src/components/chrome/ResultGrid.tsx
+++ b/apps/tangle-cloud/src/components/chrome/ResultGrid.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+type Props<T> = {
+  items: T[];
+  renderItem: (item: T, index: number) => ReactNode;
+  /** Tailwind columns spec for sm/md/lg/xl/2xl. Default: responsive 1→2→3→3→4. */
+  columns?: string;
+  className?: string;
+};
+
+/**
+ * Tokenized grid surface. Catalog pages compose this with a `renderItem` that
+ * returns the card. No card wrapper, no padding — the grid is just layout.
+ * Per-item visual treatment lives on the card component the caller passes in.
+ *
+ * Columns default scale up to four on 2xl viewports — wider catalogs reward
+ * higher density, but never more than four cards in a row because card titles
+ * become illegible past that.
+ */
+function ResultGrid<T>({
+  items,
+  renderItem,
+  columns = 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4',
+  className,
+}: Props<T>) {
+  return (
+    <div
+      className={twMerge(
+        'grid gap-4 content-start',
+        columns,
+        // `content-visibility: auto` lets the browser skip rendering off-screen
+        // cards — meaningful on a catalog with hundreds of blueprints.
+        '[content-visibility:auto] [contain-intrinsic-size:800px]',
+        className,
+      )}
+    >
+      {items.map((item, i) => (
+        <div key={i}>{renderItem(item, i)}</div>
+      ))}
+    </div>
+  );
+}
+
+export default ResultGrid;

--- a/apps/tangle-cloud/src/components/chrome/ResultList.tsx
+++ b/apps/tangle-cloud/src/components/chrome/ResultList.tsx
@@ -1,0 +1,125 @@
+import type { ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { focus, typeRole } from '../../styles/chrome';
+
+export type ResultColumn<T> = {
+  /** Column header rendered above the rows. */
+  header: ReactNode;
+  /** How to render each cell for this column. */
+  render: (item: T, index: number) => ReactNode;
+  /** Tailwind class for the column width. Default: `flex-1`. */
+  className?: string;
+  /** Hide on narrower viewports — used for secondary columns that can fold. */
+  hideBelow?: 'sm' | 'md' | 'lg' | 'xl';
+};
+
+type Props<T> = {
+  items: T[];
+  columns: ResultColumn<T>[];
+  /** Optional row click handler (entire row becomes clickable). */
+  onRowClick?: (item: T, index: number) => void;
+  /** Stable key for each row — used as React key + for aria. */
+  rowKey: (item: T, index: number) => string;
+  className?: string;
+};
+
+/**
+ * Dense row list — the senior move for catalog pages. Cards are pretty for
+ * heterogeneous content but terrible when the operator needs to compare 8
+ * inference blueprints by operator count, audit state, and price.
+ *
+ * The shape is a column-driven table without `<table>` semantics — every row
+ * is a flex container so a column can render arbitrary content (status pills,
+ * mono numerals, avatars). Hide-below classes let secondary columns fold on
+ * narrow viewports without surrendering the primary scan axis.
+ */
+const HIDE_CLASS: Record<
+  NonNullable<ResultColumn<unknown>['hideBelow']>,
+  string
+> = {
+  sm: 'hidden sm:flex',
+  md: 'hidden md:flex',
+  lg: 'hidden lg:flex',
+  xl: 'hidden xl:flex',
+};
+
+function ResultList<T>({
+  items,
+  columns,
+  onRowClick,
+  rowKey,
+  className,
+}: Props<T>) {
+  return (
+    <div
+      className={twMerge(
+        'overflow-hidden rounded-lg border border-border',
+        className,
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center border-b border-border bg-[color:var(--bg-card)]/40 px-4 py-2">
+        {columns.map((col, i) => (
+          <div
+            key={i}
+            className={twMerge(
+              typeRole.label,
+              'flex items-center',
+              col.className ?? 'flex-1',
+              col.hideBelow && HIDE_CLASS[col.hideBelow],
+            )}
+          >
+            {col.header}
+          </div>
+        ))}
+      </div>
+
+      {/* Rows */}
+      <div role="list">
+        {items.map((item, index) => {
+          const key = rowKey(item, index);
+          const interactive = onRowClick !== undefined;
+          return (
+            <div
+              key={key}
+              role="listitem"
+              tabIndex={interactive ? 0 : undefined}
+              onClick={interactive ? () => onRowClick(item, index) : undefined}
+              onKeyDown={
+                interactive
+                  ? (e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        onRowClick(item, index);
+                      }
+                    }
+                  : undefined
+              }
+              className={twMerge(
+                'flex items-center border-b border-border/60 px-4 py-3 text-sm last:border-b-0',
+                interactive &&
+                  'cursor-pointer transition-colors hover:bg-[color:var(--bg-hover)]/60',
+                interactive && focus.ring,
+              )}
+            >
+              {columns.map((col, i) => (
+                <div
+                  key={i}
+                  className={twMerge(
+                    'flex min-w-0 items-center',
+                    col.className ?? 'flex-1',
+                    col.hideBelow && HIDE_CLASS[col.hideBelow],
+                  )}
+                >
+                  {col.render(item, index)}
+                </div>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default ResultList;

--- a/apps/tangle-cloud/src/components/chrome/ShortcutsHelp.tsx
+++ b/apps/tangle-cloud/src/components/chrome/ShortcutsHelp.tsx
@@ -1,0 +1,96 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@tangle-network/sandbox-ui/primitives';
+import type { FC } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { typeRole } from '../../styles/chrome';
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+const SHORTCUTS: Array<{
+  group: string;
+  rows: Array<{ keys: string[]; label: string }>;
+}> = [
+  {
+    group: 'Navigate',
+    rows: [
+      { keys: ['g', 'b'], label: 'Blueprints' },
+      { keys: ['g', 'o'], label: 'Operators' },
+      { keys: ['g', 'i'], label: 'Instances' },
+      { keys: ['g', 'r'], label: 'Rewards' },
+      { keys: ['g', 'e'], label: 'Earnings' },
+      { keys: ['g', 'm'], label: 'Manage your blueprints' },
+    ],
+  },
+  {
+    group: 'Actions',
+    rows: [
+      { keys: ['⌘', 'K'], label: 'Command palette (anywhere)' },
+      { keys: ['/'], label: 'Focus page search' },
+      { keys: ['?'], label: 'This help overlay' },
+    ],
+  },
+  {
+    group: 'Lists & catalogs',
+    rows: [
+      { keys: ['↑', '↓'], label: 'Move selection' },
+      { keys: ['↵'], label: 'Open selected item' },
+      { keys: ['esc'], label: 'Close overlay / clear focus' },
+    ],
+  },
+];
+
+const Kbd: FC<{ children: string }> = ({ children }) => (
+  <kbd className="inline-flex h-6 min-w-[24px] items-center justify-center rounded border border-border bg-[color:var(--bg-elevated)]/60 px-1.5 font-mono text-[11px] text-foreground">
+    {children}
+  </kbd>
+);
+
+/**
+ * `?`-summoned reference. Lists the entire keyboard surface so an operator
+ * doesn't have to read code to discover the shortcuts. Mirrors the palette's
+ * shape (groups + rows + mono key chips) so the visual language is consistent.
+ */
+const ShortcutsHelp: FC<Props> = ({ open, onOpenChange }) => (
+  <Dialog open={open} onOpenChange={onOpenChange}>
+    <DialogContent className="max-w-[480px] gap-0 border border-border bg-[color:var(--bg-card)] p-6">
+      <DialogHeader>
+        <DialogTitle className={twMerge(typeRole.section)}>
+          Keyboard shortcuts
+        </DialogTitle>
+      </DialogHeader>
+      <div className="mt-4 space-y-5">
+        {SHORTCUTS.map((section) => (
+          <div key={section.group}>
+            <div className={twMerge(typeRole.label, 'mb-2')}>
+              {section.group}
+            </div>
+            <div className="space-y-1.5">
+              {section.rows.map((row, i) => (
+                <div
+                  key={i}
+                  className="flex items-center justify-between gap-3 rounded-md px-2 py-1 text-sm text-foreground"
+                >
+                  <span>{row.label}</span>
+                  <span className="flex items-center gap-1">
+                    {row.keys.map((k, j) => (
+                      <Kbd key={j}>{k}</Kbd>
+                    ))}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </DialogContent>
+  </Dialog>
+);
+
+export default ShortcutsHelp;

--- a/apps/tangle-cloud/src/components/chrome/StatusPill.tsx
+++ b/apps/tangle-cloud/src/components/chrome/StatusPill.tsx
@@ -1,0 +1,41 @@
+import type { FC, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { statusPill, type StatusTone } from '../../styles/chrome';
+
+type Props = {
+  tone?: StatusTone;
+  children: ReactNode;
+  className?: string;
+  /** Optional leading icon (sized 12px). */
+  icon?: ReactNode;
+};
+
+/**
+ * Outlined status pill — single tone per status, never filled. Use for
+ * service state, audit state, capacity state, network state. **Not** for
+ * decoration; pills should always reflect a model field the operator can act
+ * on.
+ */
+const StatusPill: FC<Props> = ({
+  tone = 'neutral',
+  children,
+  className,
+  icon,
+}) => (
+  <span
+    className={twMerge(
+      'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold leading-none',
+      statusPill[tone],
+      className,
+    )}
+  >
+    {icon !== undefined && (
+      <span className="inline-flex h-3 w-3 items-center justify-center">
+        {icon}
+      </span>
+    )}
+    {children}
+  </span>
+);
+
+export default StatusPill;

--- a/apps/tangle-cloud/src/components/chrome/ViewToggle.tsx
+++ b/apps/tangle-cloud/src/components/chrome/ViewToggle.tsx
@@ -1,0 +1,97 @@
+import type { FC } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { focus } from '../../styles/chrome';
+
+// Inline SVGs — @tangle-network/icons ships GridFillIcon but no matching
+// list-view icon. Tiny inline SVG is cheaper than adding an icon entry that
+// only the view toggle uses.
+const GridIcon: FC<{ className?: string }> = ({ className }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className}
+    aria-hidden
+  >
+    <path d="M3 3h7v7H3V3zm11 0h7v7h-7V3zM3 14h7v7H3v-7zm11 0h7v7h-7v-7z" />
+  </svg>
+);
+
+const ListIconLocal: FC<{ className?: string }> = ({ className }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className}
+    aria-hidden
+  >
+    <path d="M3 5h18v3H3V5zm0 5h18v3H3v-3zm0 5h18v3H3v-3z" />
+  </svg>
+);
+
+export type ResultView = 'grid' | 'list';
+
+type Props = {
+  value: ResultView;
+  onChange: (view: ResultView) => void;
+  className?: string;
+};
+
+/**
+ * Two-mode segmented control for switching catalog views between cards (grid)
+ * and dense rows (list). Lives in the toolbar `trailing` slot. The list view
+ * is the senior move — operators comparing N similar items scan rows faster
+ * than cards.
+ */
+const ViewToggle: FC<Props> = ({ value, onChange, className }) => {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="View"
+      className={twMerge(
+        'inline-flex h-9 items-center rounded-md border border-border bg-transparent p-0.5',
+        className,
+      )}
+    >
+      <ViewButton
+        kind="grid"
+        active={value === 'grid'}
+        onClick={() => onChange('grid')}
+      />
+      <ViewButton
+        kind="list"
+        active={value === 'list'}
+        onClick={() => onChange('list')}
+      />
+    </div>
+  );
+};
+
+const ViewButton: FC<{
+  kind: ResultView;
+  active: boolean;
+  onClick: () => void;
+}> = ({ kind, active, onClick }) => {
+  const Icon = kind === 'grid' ? GridIcon : ListIconLocal;
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={active}
+      onClick={onClick}
+      title={kind === 'grid' ? 'Grid view' : 'List view'}
+      className={twMerge(
+        'inline-flex h-7 w-8 items-center justify-center rounded transition-colors',
+        active
+          ? 'bg-[color:var(--bg-hover)] text-foreground'
+          : 'text-muted-foreground hover:text-foreground',
+        focus.ring,
+      )}
+    >
+      <Icon className="h-4 w-4" />
+      <span className="sr-only">
+        {kind === 'grid' ? 'Grid view' : 'List view'}
+      </span>
+    </button>
+  );
+};
+
+export default ViewToggle;

--- a/apps/tangle-cloud/src/components/chrome/index.ts
+++ b/apps/tangle-cloud/src/components/chrome/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Chrome system — page composition primitives for tangle-cloud.
+ *
+ * Compose every cloud-app page from these six (plus the small helpers).
+ * Anything else — bespoke hero cards, gradient backdrops, custom filter
+ * cards — is the bug, not the rule.
+ *
+ * Mental model:
+ *   <PageLayout>
+ *     <PageHeader title="…" action={…} />
+ *     <MetricStrip metrics={…} />            // opt-in only
+ *     <PageToolbar search={…} trailing={…} /> // catalog pages only
+ *     {hasResults ? (
+ *       view === 'grid'
+ *         ? <ResultGrid items={…} renderItem={…} />
+ *         : <ResultList items={…} columns={…} rowKey={…} />
+ *     ) : (
+ *       <EmptyState kind={…} primary={…} />
+ *     )}
+ *   </PageLayout>
+ */
+
+export { default as EmptyState } from './EmptyState';
+export type { EmptyKind } from './EmptyState';
+
+export { default as FilterTray } from './FilterTray';
+
+export { default as MetricStrip } from './MetricStrip';
+export type { Metric, MetricTone } from './MetricStrip';
+
+export { default as PageHeader } from './PageHeader';
+
+export { default as PageToolbar } from './PageToolbar';
+
+export { default as ResultGrid } from './ResultGrid';
+
+export { default as ResultList } from './ResultList';
+export type { ResultColumn } from './ResultList';
+
+export { default as StatusPill } from './StatusPill';
+
+export { default as ViewToggle } from './ViewToggle';
+export type { ResultView } from './ViewToggle';

--- a/apps/tangle-cloud/src/components/chrome/useKeyboardShortcuts.ts
+++ b/apps/tangle-cloud/src/components/chrome/useKeyboardShortcuts.ts
@@ -1,0 +1,120 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router';
+import { PagePath } from '../../types';
+
+/**
+ * Wire global keyboard shortcuts:
+ *
+ *   ⌘K / Ctrl+K  → open command palette
+ *   /            → focus the page search input (if one is mounted)
+ *   g b          → navigate to /blueprints
+ *   g o          → /operators
+ *   g r          → /rewards
+ *   g e          → /earnings
+ *   g i          → /instances
+ *   ?            → open keyboard-shortcuts help overlay
+ *
+ * Shortcuts only fire when no input/textarea/contenteditable element is
+ * focused — never hijack typing.
+ */
+export function useKeyboardShortcuts({
+  onOpenPalette,
+  onOpenHelp,
+}: {
+  onOpenPalette: () => void;
+  onOpenHelp: () => void;
+}) {
+  const navigate = useNavigate();
+  // "g" prefix state — once g is pressed we wait briefly for the next key.
+  const gPending = useRef<{ at: number; timer: number } | null>(null);
+
+  useEffect(() => {
+    const clearGPending = () => {
+      if (gPending.current) {
+        window.clearTimeout(gPending.current.timer);
+        gPending.current = null;
+      }
+    };
+
+    const isEditableTarget = (target: EventTarget | null): boolean => {
+      if (!(target instanceof HTMLElement)) return false;
+      const tag = target.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT')
+        return true;
+      if (target.isContentEditable) return true;
+      return false;
+    };
+
+    const handler = (e: KeyboardEvent) => {
+      // ⌘K / Ctrl+K — opens regardless of focus (so the user can summon the
+      // palette from anywhere, including while typing in an input).
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        clearGPending();
+        onOpenPalette();
+        return;
+      }
+
+      // Everything else only fires outside text inputs.
+      if (isEditableTarget(e.target)) return;
+
+      // `?` (shift+/) opens the help overlay.
+      if (e.key === '?' || (e.key === '/' && e.shiftKey)) {
+        e.preventDefault();
+        clearGPending();
+        onOpenHelp();
+        return;
+      }
+
+      // `/` focuses the first <input type="search"> on the page (page toolbar).
+      if (e.key === '/' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+        const search = document.querySelector<HTMLInputElement>(
+          'input[type="search"]',
+        );
+        if (search) {
+          e.preventDefault();
+          clearGPending();
+          search.focus();
+          return;
+        }
+      }
+
+      // `g` starts a navigation prefix (g b, g o, ...).
+      if (e.key === 'g' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        clearGPending();
+        gPending.current = {
+          at: Date.now(),
+          timer: window.setTimeout(clearGPending, 800),
+        };
+        return;
+      }
+
+      // Second key in g-prefix sequence.
+      if (gPending.current !== null) {
+        const path = (
+          {
+            b: PagePath.BLUEPRINTS,
+            o: PagePath.OPERATORS,
+            r: PagePath.REWARDS,
+            e: PagePath.EARNINGS,
+            i: PagePath.INSTANCES,
+            m: PagePath.BLUEPRINTS_MANAGE,
+          } as Record<string, string>
+        )[e.key.toLowerCase()];
+        if (path !== undefined) {
+          e.preventDefault();
+          clearGPending();
+          navigate(path);
+          return;
+        }
+        clearGPending();
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => {
+      window.removeEventListener('keydown', handler);
+      clearGPending();
+    };
+  }, [navigate, onOpenPalette, onOpenHelp]);
+}

--- a/apps/tangle-cloud/src/components/chrome/useUrlState.ts
+++ b/apps/tangle-cloud/src/components/chrome/useUrlState.ts
@@ -1,0 +1,82 @@
+import { useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router';
+
+type Codec<T> = {
+  parse: (raw: string | null) => T;
+  serialize: (value: T) => string | null;
+};
+
+/**
+ * Two-way bind a piece of UI state to a URL query parameter. Returns a tuple
+ * shaped like `useState` so callers can drop it in.
+ *
+ *   const [search, setSearch] = useUrlState('q', stringCodec(''));
+ *
+ * The codec's `serialize` returns `null` when the value should be removed
+ * from the URL (typically the default — keeps share-links tidy).
+ *
+ * URL state is the right home for anything the user expects to persist
+ * across refresh or share with a teammate: search query, filter selections,
+ * view mode, density, page index. Component-local state stays in component
+ * state; "is this drawer open" doesn't belong in the URL.
+ */
+export function useUrlState<T>(
+  key: string,
+  codec: Codec<T>,
+): [T, (next: T | ((prev: T) => T)) => void] {
+  const [params, setParams] = useSearchParams();
+  const raw = params.get(key);
+  const value = useMemo(() => codec.parse(raw), [raw, codec]);
+  const setValue = useCallback(
+    (next: T | ((prev: T) => T)) => {
+      const resolved =
+        typeof next === 'function' ? (next as (prev: T) => T)(value) : next;
+      const serialized = codec.serialize(resolved);
+      const updated = new URLSearchParams(params);
+      if (serialized === null) {
+        updated.delete(key);
+      } else {
+        updated.set(key, serialized);
+      }
+      setParams(updated, { replace: true });
+    },
+    [params, setParams, key, codec, value],
+  );
+  return [value, setValue];
+}
+
+/** String codec with a configurable default. Empty string → param removed. */
+export function stringCodec(defaultValue = ''): Codec<string> {
+  return {
+    parse: (raw) => raw ?? defaultValue,
+    serialize: (value) =>
+      value === defaultValue || value === '' ? null : value,
+  };
+}
+
+/** Enum codec — restricts to a known set and falls back to the default. */
+export function enumCodec<T extends string>(
+  values: readonly T[],
+  defaultValue: T,
+): Codec<T> {
+  return {
+    parse: (raw) =>
+      raw && (values as readonly string[]).includes(raw)
+        ? (raw as T)
+        : defaultValue,
+    serialize: (value) => (value === defaultValue ? null : value),
+  };
+}
+
+/** Integer codec with a default. Negative numbers are allowed but invalid input
+ * resolves to the default. */
+export function intCodec(defaultValue = 0): Codec<number> {
+  return {
+    parse: (raw) => {
+      if (raw === null) return defaultValue;
+      const n = Number.parseInt(raw, 10);
+      return Number.isFinite(n) ? n : defaultValue;
+    },
+    serialize: (value) => (value === defaultValue ? null : String(value)),
+  };
+}

--- a/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
@@ -3,14 +3,20 @@ import {
   Button,
   Card,
   CardContent,
-  Input,
   Skeleton,
 } from '../../components/sandbox/SandboxUi';
 import {
   SegmentedControl,
   type SegmentedControlOption,
 } from '@tangle-network/sandbox-ui/primitives';
-import { Search } from '@tangle-network/icons';
+import { EmptyState, FilterTray, PageToolbar } from '../../components/chrome';
+import {
+  enumCodec,
+  intCodec,
+  stringCodec,
+  useUrlState,
+} from '../../components/chrome/useUrlState';
+import { typeRole } from '../../styles/chrome';
 import type { UseAllBlueprintsReturn } from '@tangle-network/tangle-shared-ui/data/graphql';
 import type { Blueprint } from '@tangle-network/tangle-shared-ui/types/blueprint';
 import {
@@ -20,7 +26,6 @@ import {
   useDeferredValue,
   useEffect,
   useMemo,
-  useState,
 } from 'react';
 import { useQueries } from '@tanstack/react-query';
 import { useChainId, usePublicClient } from 'wagmi';
@@ -148,12 +153,28 @@ const BlueprintListing: FC<Props> = ({
   error,
   onRegisterBlueprint,
 }) => {
-  const [page, setPage] = useState(0);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [selectedCategory, setSelectedCategory] = useState(ALL_CATEGORIES);
-  const [audienceFilter, setAudienceFilter] = useState<AudienceFilter>('all');
-  const [manifestFilter, setManifestFilter] = useState<ManifestFilter>('all');
-  const [auditFilter, setAuditFilter] = useState<AuditFilter>('all');
+  // Filter state lives in the URL — refresh persists the view, deep-links are
+  // shareable, the back button works. Defaults are omitted from the URL so a
+  // bare /blueprints stays clean. `replace: true` (in `useUrlState`) means
+  // every keystroke doesn't pollute the history stack.
+  const [page, setPage] = useUrlState('page', intCodec(0));
+  const [searchQuery, setSearchQuery] = useUrlState('q', stringCodec(''));
+  const [selectedCategory, setSelectedCategory] = useUrlState(
+    'category',
+    stringCodec(ALL_CATEGORIES),
+  );
+  const [audienceFilter, setAudienceFilter] = useUrlState<AudienceFilter>(
+    'avail',
+    enumCodec(['all', 'customers', 'operators'] as const, 'all'),
+  );
+  const [manifestFilter, setManifestFilter] = useUrlState<ManifestFilter>(
+    'source',
+    enumCodec(['all', 'verified', 'fallback'] as const, 'all'),
+  );
+  const [auditFilter, setAuditFilter] = useUrlState<AuditFilter>(
+    'trust',
+    enumCodec(['all', 'audited'] as const, 'all'),
+  );
   const deferredSearchQuery = useDeferredValue(
     searchQuery.trim().toLowerCase(),
   );
@@ -299,44 +320,56 @@ const BlueprintListing: FC<Props> = ({
 
   if (blueprintItems.length === 0) {
     return (
-      <Card variant="sandbox">
-        <CardContent className="flex min-h-52 flex-col items-center justify-center p-8 text-center">
-          <h2 className="font-display font-bold text-foreground text-xl">
-            No blueprints on this network
-          </h2>
-          <p className="mt-2 max-w-md text-muted-foreground text-sm">
-            Register an operator, switch networks, or publish a blueprint to
-            make it available for deployment.
-          </p>
-        </CardContent>
-      </Card>
+      <EmptyState
+        kind="no-data"
+        title="No blueprints on this network"
+        description="Register an operator, switch networks, or publish a blueprint to make it available for deployment."
+      />
     );
   }
 
+  // Count active non-default filters — drives the FilterTray's active badge
+  // so the operator sees at a glance how many constraints they have on.
+  const activeFilterCount =
+    (audienceFilter !== 'all' ? 1 : 0) +
+    (manifestFilter !== 'all' ? 1 : 0) +
+    (auditFilter !== 'all' ? 1 : 0);
+
+  const resetAllFilters = () => {
+    setSearchQuery('');
+    setSelectedCategory(ALL_CATEGORIES);
+    setAudienceFilter('all');
+    setManifestFilter('all');
+    setAuditFilter('all');
+  };
+
   return (
     <div className="space-y-5">
-      <Card variant="elevated" className="catalog-controls">
-        <CardContent className="space-y-4 p-4 md:p-5">
-          <div className="grid gap-4 xl:grid-cols-[minmax(360px,1fr)_auto_auto] xl:items-center">
-            <Input
-              value={searchQuery}
-              onChange={setSearchQuery}
-              leftIcon={<Search className="h-4 w-4 fill-current" />}
-              placeholder="Search blueprints, services, publishers, or IDs"
-              className="w-full"
-              inputClassName="h-11 bg-background text-sm"
-            />
-
-            <label className="grid gap-1">
-              <span className="font-semibold text-muted-foreground text-[10px] uppercase tracking-wider">
-                Availability
-              </span>
+      <PageToolbar
+        search={{
+          value: searchQuery,
+          onChange: setSearchQuery,
+          placeholder: 'Search blueprints, services, publishers, or IDs',
+        }}
+        count={{
+          matches: dedupedRows.length,
+          total: blueprintItems.length,
+          noun: 'matches',
+        }}
+        trailing={
+          <FilterTray
+            activeCount={activeFilterCount}
+            onClear={resetAllFilters}
+            trayTitle="Catalog filters"
+          >
+            <label className="block space-y-1.5">
+              <span className={typeRole.label}>Availability</span>
               <select
                 value={audienceFilter}
                 onChange={(event) =>
                   setAudienceFilter(event.currentTarget.value as AudienceFilter)
                 }
-                className="h-10 min-w-40 rounded-md border border-border bg-background px-3 font-semibold text-foreground text-sm outline-none transition-colors hover:bg-muted focus:border-primary"
+                className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none hover:bg-[color:var(--bg-hover)] focus:border-[color:var(--border-accent-hover)]"
               >
                 <option value="all">All availability</option>
                 <option value="customers">Has operators</option>
@@ -344,16 +377,14 @@ const BlueprintListing: FC<Props> = ({
               </select>
             </label>
 
-            <label className="grid gap-1">
-              <span className="font-semibold text-muted-foreground text-[10px] uppercase tracking-wider">
-                Source
-              </span>
+            <label className="block space-y-1.5">
+              <span className={typeRole.label}>Source</span>
               <select
                 value={manifestFilter}
                 onChange={(event) =>
                   setManifestFilter(event.currentTarget.value as ManifestFilter)
                 }
-                className="h-10 min-w-36 rounded-md border border-border bg-background px-3 font-semibold text-foreground text-sm outline-none transition-colors hover:bg-muted focus:border-primary"
+                className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none hover:bg-[color:var(--bg-hover)] focus:border-[color:var(--border-accent-hover)]"
               >
                 <option value="all">All sources</option>
                 <option value="verified">Pinned source</option>
@@ -361,95 +392,68 @@ const BlueprintListing: FC<Props> = ({
               </select>
             </label>
 
-            <label className="grid gap-1">
-              <span className="font-semibold text-muted-foreground text-[10px] uppercase tracking-wider">
-                Trust
-              </span>
+            <label className="block space-y-1.5">
+              <span className={typeRole.label}>Trust</span>
               <select
                 value={auditFilter}
                 onChange={(event) =>
                   setAuditFilter(event.currentTarget.value as AuditFilter)
                 }
-                className="h-10 min-w-36 rounded-md border border-border bg-background px-3 font-semibold text-foreground text-sm outline-none transition-colors hover:bg-muted focus:border-primary"
+                className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none hover:bg-[color:var(--bg-hover)] focus:border-[color:var(--border-accent-hover)]"
               >
                 <option value="all">All blueprints</option>
                 <option value="audited">Audited only</option>
               </select>
             </label>
-          </div>
+          </FilterTray>
+        }
+      />
 
-          <div className="flex flex-col gap-3 border-border border-t pt-4 lg:flex-row lg:items-center lg:justify-between">
-            <div className="flex items-center gap-2 overflow-x-auto pb-0.5">
-              <span className="hidden shrink-0 items-center pr-1 font-semibold text-muted-foreground text-[10px] uppercase tracking-wider sm:inline-flex">
-                Category
-              </span>
-              <SegmentedControl<string>
-                aria-label="Filter blueprints by category"
-                value={selectedCategory}
-                onValueChange={setSelectedCategory}
-                options={[
-                  {
-                    value: ALL_CATEGORIES,
-                    label: 'All',
-                    adornment: (
-                      <span className="rounded-full bg-background/70 px-2 py-0.5 font-mono text-[10px] text-foreground">
-                        {blueprintItems.length}
-                      </span>
-                    ),
-                  } satisfies SegmentedControlOption<string>,
-                  ...categories.map(
-                    ({ category, count }) =>
-                      ({
-                        value: category,
-                        label: category.replace(/^AI /, ''),
-                        adornment: (
-                          <span className="rounded-full bg-background/70 px-2 py-0.5 font-mono text-[10px] text-foreground">
-                            {count}
-                          </span>
-                        ),
-                      }) satisfies SegmentedControlOption<string>,
+      {/* Category strip — a thin row above the grid. Not wrapped in a card,
+       * not bordered. Categories live on-chain when present; otherwise they
+       * fall back to the regex-derived buckets in getBlueprintCategory until
+       * the metadata schema grows `blueprintUi.tags[]`. */}
+      <div className="overflow-x-auto pb-0.5">
+        <SegmentedControl<string>
+          aria-label="Filter blueprints by category"
+          value={selectedCategory}
+          onValueChange={setSelectedCategory}
+          options={[
+            {
+              value: ALL_CATEGORIES,
+              label: 'All',
+              adornment: (
+                <span className="rounded-full bg-background/70 px-2 py-0.5 font-mono text-[10px] text-foreground">
+                  {blueprintItems.length}
+                </span>
+              ),
+            } satisfies SegmentedControlOption<string>,
+            ...categories.map(
+              ({ category, count }) =>
+                ({
+                  value: category,
+                  label: category.replace(/^AI /, ''),
+                  adornment: (
+                    <span className="rounded-full bg-background/70 px-2 py-0.5 font-mono text-[10px] text-foreground">
+                      {count}
+                    </span>
                   ),
-                ]}
-              />
-            </div>
-
-            <div className="flex shrink-0 items-center gap-3 text-muted-foreground text-xs">
-              <span className="text-muted-foreground text-xs">
-                {dedupedRows.length} matches
-              </span>
-              {hasActiveFilters && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-8 px-2"
-                  onClick={() => {
-                    setSearchQuery('');
-                    setSelectedCategory(ALL_CATEGORIES);
-                    setAudienceFilter('all');
-                    setManifestFilter('all');
-                    setAuditFilter('all');
-                  }}
-                >
-                  Clear
-                </Button>
-              )}
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+                }) satisfies SegmentedControlOption<string>,
+            ),
+          ]}
+        />
+      </div>
 
       {dedupedRows.length === 0 ? (
-        <Card variant="sandbox">
-          <CardContent className="flex min-h-52 flex-col items-center justify-center p-8 text-center">
-            <h3 className="font-display font-bold text-foreground text-lg">
-              No blueprints match these filters
-            </h3>
-            <p className="mt-2 max-w-md text-muted-foreground text-sm">
-              Try a broader category, remove the source filter, or search by the
-              blueprint name, publisher, or protocol ID.
-            </p>
-          </CardContent>
-        </Card>
+        <EmptyState
+          kind="no-match"
+          description="Try a broader category, remove the source filter, or search by the blueprint name, publisher, or protocol ID."
+          primary={
+            hasActiveFilters && (
+              <Button onClick={resetAllFilters}>Clear all filters</Button>
+            )
+          }
+        />
       ) : (
         <div className="results-grid grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
           {visibleRows.map((row) => (

--- a/apps/tangle-cloud/src/pages/blueprints/page.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/page.tsx
@@ -1,9 +1,5 @@
 import { RowSelectionState } from '@tanstack/table-core';
-import {
-  Button,
-  Card,
-  CardContent,
-} from '@tangle-network/sandbox-ui/primitives';
+import { Button } from '@tangle-network/sandbox-ui/primitives';
 import {
   useAllBlueprints,
   useBlueprintsByOwner,
@@ -19,7 +15,8 @@ import { PagePath } from '../../types';
 import pollWithBackoff from '../../utils/pollWithBackoff';
 import BlueprintListing from './BlueprintListing';
 import RegistrationDrawer from './RegistrationDrawer';
-import { StatRow } from '../../components/stats/Stat';
+import { MetricStrip, PageHeader } from '../../components/chrome';
+import type { Metric } from '../../components/chrome';
 
 const BLUEPRINT_DOCS_LINK =
   'https://docs.tangle.tools/developers/blueprints/introduction';
@@ -179,95 +176,76 @@ const Page: FC = () => {
   ).length;
   const needsCapacityCount = blueprintList.length - readyToDeployCount;
 
+  const metrics: Metric[] = useMemo(
+    () => [
+      {
+        label: 'Catalog',
+        value: blueprintList.length.toLocaleString(),
+        sublabel: 'indexed',
+      },
+      {
+        label: 'Ready to deploy',
+        value: readyToDeployCount.toLocaleString(),
+        tone: readyToDeployCount > 0 ? 'success' : 'neutral',
+        sublabel: 'has operators',
+      },
+      {
+        label: 'Needs capacity',
+        value: needsCapacityCount.toLocaleString(),
+        tone: needsCapacityCount > 0 ? 'warning' : 'neutral',
+        sublabel: 'recruiting',
+      },
+      {
+        label: 'Your registrations',
+        value: (ownedBlueprints?.length ?? 0).toLocaleString(),
+        tone: hasOwnedBlueprints ? 'accent' : 'neutral',
+        sublabel: role === Role.OPERATOR ? 'as operator' : 'as deployer',
+      },
+    ],
+    [
+      blueprintList.length,
+      readyToDeployCount,
+      needsCapacityCount,
+      ownedBlueprints?.length,
+      hasOwnedBlueprints,
+      role,
+    ],
+  );
+
+  const title = hasOwnedBlueprints ? HAS_BLUEPRINTS_TITLE : ROLE_TITLE[role];
+  const subtitle = hasOwnedBlueprints
+    ? HAS_BLUEPRINTS_DESCRIPTION
+    : ROLE_DESCRIPTION[role];
+
   return (
     <div className="space-y-6">
-      <Card
-        variant="sandbox"
-        className="cloud-hero-card cloud-compact-header overflow-hidden"
-      >
-        <CardContent className="relative p-4 md:p-5">
-          <div className="pointer-events-none absolute inset-0 opacity-70 [background:radial-gradient(circle_at_12%_8%,rgba(99,102,241,0.22),transparent_32%),radial-gradient(circle_at_86%_12%,rgba(16,185,129,0.12),transparent_28%)]" />
+      <PageHeader
+        density="compact"
+        title={title}
+        subtitle={subtitle}
+        action={
+          <>
+            <Button asChild variant="ghost" size="sm">
+              <Link to={PagePath.OPERATORS}>Browse operators</Link>
+            </Button>
+            <Button variant="sandbox" asChild size="sm">
+              <a
+                href={
+                  hasOwnedBlueprints
+                    ? PagePath.BLUEPRINTS_MANAGE
+                    : BLUEPRINT_DOCS_LINK
+                }
+                target={hasOwnedBlueprints ? undefined : '_blank'}
+                rel={hasOwnedBlueprints ? undefined : 'noreferrer'}
+              >
+                {hasOwnedBlueprints ? 'Manage blueprints' : 'Publish blueprint'}
+              </a>
+            </Button>
+          </>
+        }
+      />
 
-          <div className="relative grid gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(380px,460px)] xl:items-center">
-            <div>
-              <h1 className="max-w-4xl font-display font-extrabold text-3xl text-foreground leading-[1.05] tracking-[-0.035em] sm:text-4xl">
-                {hasOwnedBlueprints ? HAS_BLUEPRINTS_TITLE : ROLE_TITLE[role]}
-              </h1>
-
-              <p className="mt-3 max-w-2xl text-muted-foreground text-sm leading-relaxed">
-                {hasOwnedBlueprints
-                  ? HAS_BLUEPRINTS_DESCRIPTION
-                  : ROLE_DESCRIPTION[role]}
-              </p>
-
-              <StatRow
-                className="mt-5 max-w-2xl"
-                items={[
-                  {
-                    label: 'Catalog',
-                    value: blueprintList.length,
-                    sublabel: 'Indexed blueprints',
-                  },
-                  {
-                    label: 'Ready to deploy',
-                    value: readyToDeployCount,
-                    tone: readyToDeployCount > 0 ? 'success' : 'default',
-                    sublabel: 'Has operator capacity',
-                  },
-                  {
-                    label: 'Needs capacity',
-                    value: needsCapacityCount,
-                    tone: needsCapacityCount > 0 ? 'warning' : 'default',
-                    sublabel: 'Operators wanted',
-                  },
-                  {
-                    label: 'Your registrations',
-                    value: ownedBlueprints?.length ?? 0,
-                    tone: hasOwnedBlueprints ? 'accent' : 'default',
-                    sublabel: role === Role.OPERATOR ? 'Operator' : 'Deployer',
-                  },
-                ]}
-              />
-            </div>
-
-            <div className="rounded-lg border border-[color:var(--border-accent)] bg-[var(--accent-surface-soft)] p-4 shadow-[var(--shadow-card)]">
-              <p className="font-semibold text-muted-foreground text-[10px] uppercase tracking-wider">
-                {hasOwnedBlueprints ? 'Manage' : 'Get started'}
-              </p>
-              <p className="mt-2 font-display font-bold text-foreground text-base leading-snug">
-                {hasOwnedBlueprints
-                  ? 'You publish or operate blueprints on Tangle.'
-                  : 'Deploy a service or supply operator capacity.'}
-              </p>
-              <p className="mt-2 text-muted-foreground text-xs leading-relaxed">
-                {hasOwnedBlueprints
-                  ? 'Review registrations, versions, and operator capacity.'
-                  : 'Filter the catalog below for ready-to-deploy blueprints, or register capacity for ones recruiting operators.'}
-              </p>
-              <div className="mt-4 flex flex-col gap-2 sm:flex-row">
-                <Button variant="sandbox" asChild className="flex-1">
-                  <a
-                    href={
-                      hasOwnedBlueprints
-                        ? PagePath.BLUEPRINTS_MANAGE
-                        : BLUEPRINT_DOCS_LINK
-                    }
-                    target={hasOwnedBlueprints ? undefined : '_blank'}
-                    rel={hasOwnedBlueprints ? undefined : 'noreferrer'}
-                  >
-                    {hasOwnedBlueprints
-                      ? 'Manage blueprints'
-                      : 'Publish blueprint'}
-                  </a>
-                </Button>
-                <Button variant="outline" asChild className="flex-1">
-                  <Link to={PagePath.OPERATORS}>Browse operators</Link>
-                </Button>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      <MetricStrip metrics={metrics} density="compact" />
 
       <BlueprintListing
         blueprints={blueprints}

--- a/apps/tangle-cloud/src/pages/earnings/page.tsx
+++ b/apps/tangle-cloud/src/pages/earnings/page.tsx
@@ -4,7 +4,7 @@
 
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useAccount, useChainId } from 'wagmi';
-import { Card, CardContent } from '@tangle-network/sandbox-ui/primitives';
+import { PageHeader } from '../../components/chrome';
 import {
   DeveloperPaymentsQueryError,
   useDeveloperPayments,
@@ -110,21 +110,9 @@ const EarningsPage: FC = () => {
 export default EarningsPage;
 
 const EarningsHero = () => (
-  <Card
-    variant="sandbox"
-    className="cloud-hero-card cloud-compact-header overflow-hidden"
-  >
-    <CardContent className="relative p-4 md:p-5">
-      <div className="pointer-events-none absolute inset-0 opacity-70 [background:radial-gradient(circle_at_12%_8%,rgba(99,102,241,0.18),transparent_32%),radial-gradient(circle_at_86%_12%,rgba(16,185,129,0.10),transparent_28%)]" />
-      <div className="relative">
-        <h1 className="font-display font-extrabold text-3xl text-foreground leading-[1.05] tracking-[-0.035em] sm:text-4xl">
-          Publisher earnings
-        </h1>
-        <p className="mt-3 max-w-2xl text-muted-foreground text-sm leading-relaxed">
-          Track blueprint payout totals and indexed payment events for the
-          connected publisher wallet.
-        </p>
-      </div>
-    </CardContent>
-  </Card>
+  <PageHeader
+    density="compact"
+    title="Publisher earnings"
+    subtitle="Track blueprint payout totals and indexed payment events for the connected publisher wallet."
+  />
 );

--- a/apps/tangle-cloud/src/pages/instances/page.tsx
+++ b/apps/tangle-cloud/src/pages/instances/page.tsx
@@ -1,16 +1,13 @@
 import { useState } from 'react';
-import {
-  Button,
-  Card,
-  CardContent,
-} from '@tangle-network/sandbox-ui/primitives';
+import { Button } from '@tangle-network/sandbox-ui/primitives';
 import { Link } from 'react-router';
 import { useAccount } from 'wagmi';
 import { AccountStatsCard } from './AccountStatsCard';
 import { InstructionCard } from './InstructionCard';
 import { TotalValueLockedTabs } from './TotalValueLocked';
 import { BlueprintManagementSection } from './BlueprintManagementSection';
-import { StatRow } from '../../components/stats/Stat';
+import { MetricStrip, PageHeader } from '../../components/chrome';
+import type { Metric, MetricTone } from '../../components/chrome';
 import useUserStats from '../../data/operators/useUserStats';
 import useEvmOperatorInfo from '../../hooks/useEvmOperatorInfo';
 import useOperatorStats from '../../data/operators/useOperatorStats';
@@ -33,65 +30,65 @@ const Page = () => {
   // KPI strip is the prime-real-estate read on this page. The cluster shows
   // role-aware deltas — pending items first (action-required), then steady
   // counts. Disconnected wallets get the catalog/onboarding pitch instead.
-  const heroStats = isConnected
+  const heroStats: Metric[] = isConnected
     ? operatorStats && operatorStats.registeredBlueprints > 0
       ? [
           {
             label: 'Running services',
-            value: operatorStats.runningServices,
-            isLoading: isLoadingOperatorStats,
+            value: operatorStats.runningServices.toLocaleString(),
+            loading: isLoadingOperatorStats,
             tone:
               operatorStats.runningServices > 0
-                ? ('success' as const)
-                : ('default' as const),
+                ? ('success' as MetricTone)
+                : ('neutral' as MetricTone),
           },
           {
             label: 'Pending approvals',
-            value: operatorStats.pendingServices,
-            isLoading: isLoadingOperatorStats,
+            value: operatorStats.pendingServices.toLocaleString(),
+            loading: isLoadingOperatorStats,
             tone:
               operatorStats.pendingServices > 0
-                ? ('warning' as const)
-                : ('default' as const),
+                ? ('warning' as MetricTone)
+                : ('neutral' as MetricTone),
             sublabel:
               operatorStats.pendingServices > 0
-                ? 'Action required'
-                : 'No action needed',
+                ? 'action required'
+                : 'no action',
           },
           {
             label: 'Registered blueprints',
-            value: operatorStats.registeredBlueprints,
-            isLoading: isLoadingOperatorStats,
+            value: operatorStats.registeredBlueprints.toLocaleString(),
+            loading: isLoadingOperatorStats,
           },
           {
             label: 'You deployed',
-            value: userStats?.deployedServices ?? 0,
-            isLoading: isLoadingUserStats,
+            value: (userStats?.deployedServices ?? 0).toLocaleString(),
+            loading: isLoadingUserStats,
           },
         ]
       : [
           {
             label: 'Running services',
-            value: userStats?.runningServices ?? 0,
-            isLoading: isLoadingUserStats,
+            value: (userStats?.runningServices ?? 0).toLocaleString(),
+            loading: isLoadingUserStats,
             tone:
               (userStats?.runningServices ?? 0) > 0
-                ? ('success' as const)
-                : ('default' as const),
+                ? ('success' as MetricTone)
+                : ('neutral' as MetricTone),
           },
           {
             label: 'Pending requests',
-            value: userStats?.pendingServices ?? 0,
-            isLoading: isLoadingUserStats,
+            value: (userStats?.pendingServices ?? 0).toLocaleString(),
+            loading: isLoadingUserStats,
             tone:
               (userStats?.pendingServices ?? 0) > 0
-                ? ('warning' as const)
-                : ('default' as const),
+                ? ('warning' as MetricTone)
+                : ('neutral' as MetricTone),
           },
           {
             label: 'Total deployed',
-            value: userStats?.deployedServices ?? 0,
-            isLoading: isLoadingUserStats,
+            value: (userStats?.deployedServices ?? 0).toLocaleString(),
+            loading: isLoadingUserStats,
           },
           {
             label: 'Role',
@@ -102,43 +99,31 @@ const Page = () => {
 
   return (
     <div className="space-y-6">
-      <Card
-        variant="sandbox"
-        className="cloud-hero-card cloud-compact-header overflow-hidden"
-      >
-        <CardContent className="relative p-4 md:p-5">
-          <div className="pointer-events-none absolute inset-0 opacity-70 [background:radial-gradient(circle_at_12%_8%,rgba(99,102,241,0.18),transparent_32%),radial-gradient(circle_at_86%_12%,rgba(16,185,129,0.10),transparent_28%)]" />
-          <div className="relative grid gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(420px,520px)] xl:items-center">
-            <div>
-              <h1 className="font-display font-extrabold text-3xl text-foreground leading-[1.05] tracking-[-0.035em] sm:text-4xl">
-                {isConnected ? 'Instances' : 'Tangle Cloud'}
-              </h1>
-              <p className="mt-3 max-w-2xl text-muted-foreground text-sm leading-relaxed">
-                {isConnected
-                  ? 'Monitor service instances, operator approvals, job records, and account balances.'
-                  : 'Browse the blueprint catalog and operator registry. Connect a wallet to deploy services, register capacity, or approve requests.'}
-              </p>
-              {!isConnected && (
-                <div className="mt-4 flex flex-wrap gap-2">
-                  <Button variant="sandbox" asChild>
-                    <Link to={PagePath.BLUEPRINTS}>Browse blueprints</Link>
-                  </Button>
-                  <Button variant="outline" asChild>
-                    <Link to={PagePath.OPERATORS}>View operators</Link>
-                  </Button>
-                </div>
-              )}
-            </div>
+      <PageHeader
+        density="compact"
+        title={isConnected ? 'Instances' : 'Tangle Cloud'}
+        subtitle={
+          isConnected
+            ? 'Monitor service instances, operator approvals, job records, and account balances.'
+            : 'Browse the blueprint catalog and operator registry. Connect a wallet to deploy services, register capacity, or approve requests.'
+        }
+        action={
+          !isConnected ? (
+            <>
+              <Button variant="ghost" size="sm" asChild>
+                <Link to={PagePath.OPERATORS}>View operators</Link>
+              </Button>
+              <Button variant="sandbox" size="sm" asChild>
+                <Link to={PagePath.BLUEPRINTS}>Browse blueprints</Link>
+              </Button>
+            </>
+          ) : undefined
+        }
+      />
 
-            {isConnected && heroStats.length > 0 && (
-              <StatRow
-                items={heroStats}
-                className="rounded-lg border border-border bg-[var(--bg-elevated)] p-3 shadow-[var(--shadow-card)]"
-              />
-            )}
-          </div>
-        </CardContent>
-      </Card>
+      {isConnected && heroStats.length > 0 && (
+        <MetricStrip metrics={heroStats} density="compact" />
+      )}
 
       <BlueprintManagementSection
         refreshTrigger={refreshTrigger}

--- a/apps/tangle-cloud/src/pages/operators/page.tsx
+++ b/apps/tangle-cloud/src/pages/operators/page.tsx
@@ -30,7 +30,8 @@ import { formatUnits, type Address } from 'viem';
 import { useNavigate } from 'react-router';
 import { PagePath } from '../../types';
 import { useAccount } from 'wagmi';
-import { StatRow } from '../../components/stats/Stat';
+import { MetricStrip, PageHeader } from '../../components/chrome';
+import type { Metric } from '../../components/chrome';
 import createStakeDelegateUrl from './createStakeDelegateUrl';
 
 type SortKey = 'stake' | 'delegations' | 'status';
@@ -58,99 +59,78 @@ const Page: FC = () => {
     window.location.assign(createStakeDelegateUrl(operatorAddress));
   }, []);
 
+  const metrics: Metric[] = useMemo(
+    () => [
+      {
+        label: 'Total',
+        value: operatorList.length.toLocaleString(),
+        sublabel: 'registered',
+        loading: isLoading,
+      },
+      {
+        label: 'Active',
+        value: activeOperatorCount.toLocaleString(),
+        tone: activeOperatorCount > 0 ? 'success' : 'neutral',
+        sublabel:
+          operatorList.length === 0
+            ? '—'
+            : `${Math.round(
+                (activeOperatorCount / Math.max(1, operatorList.length)) * 100,
+              )}% online`,
+        loading: isLoading,
+      },
+      {
+        label: 'Open',
+        value: openOperatorCount.toLocaleString(),
+        tone: openOperatorCount > 0 ? 'accent' : 'neutral',
+        sublabel: 'accepting delegations',
+        loading: isLoading,
+      },
+      {
+        label: 'Total stake',
+        value: formatStake(totalStake),
+        sublabel: 'TNT delegated',
+        loading: isLoading,
+      },
+    ],
+    [
+      operatorList.length,
+      activeOperatorCount,
+      openOperatorCount,
+      totalStake,
+      isLoading,
+    ],
+  );
+
   return (
     <div className="space-y-6">
-      <Card
-        variant="sandbox"
-        className="cloud-hero-card cloud-compact-header overflow-hidden"
-      >
-        <CardContent className="relative p-4 md:p-5">
-          <div className="pointer-events-none absolute inset-0 opacity-70 [background:radial-gradient(circle_at_10%_8%,rgba(99,102,241,0.16),transparent_32%),radial-gradient(circle_at_86%_18%,rgba(16,185,129,0.12),transparent_28%)]" />
+      <PageHeader
+        density="compact"
+        title="Operators"
+        subtitle="Inspect registered operators, delegation mode, stake, and RPC availability."
+        action={
+          <>
+            {isConnected && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => navigate(PagePath.OPERATORS_MANAGE)}
+              >
+                Manage operator
+              </Button>
+            )}
+            <Button
+              variant="sandbox"
+              size="sm"
+              onClick={() => handleStakeClicked()}
+            >
+              Delegate
+            </Button>
+          </>
+        }
+      />
 
-          <div className="relative grid gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(380px,440px)] xl:items-center">
-            <div>
-              <h1 className="font-display font-extrabold text-3xl text-foreground leading-[1.05] tracking-[-0.035em] sm:text-4xl">
-                Operators
-              </h1>
-              <p className="mt-3 max-w-2xl text-muted-foreground text-sm leading-relaxed">
-                Inspect registered operators, delegation mode, stake, and RPC
-                availability.
-              </p>
-
-              <StatRow
-                className="mt-5 max-w-2xl"
-                items={[
-                  {
-                    label: 'Total',
-                    value: operatorList.length.toLocaleString(),
-                    sublabel: 'Registered operators',
-                    isLoading,
-                  },
-                  {
-                    label: 'Active',
-                    value: activeOperatorCount.toLocaleString(),
-                    tone: activeOperatorCount > 0 ? 'success' : 'default',
-                    sublabel: `${
-                      operatorList.length === 0
-                        ? '0%'
-                        : Math.round(
-                            (activeOperatorCount /
-                              Math.max(1, operatorList.length)) *
-                              100,
-                          ) + '%'
-                    } online`,
-                    isLoading,
-                  },
-                  {
-                    label: 'Open',
-                    value: openOperatorCount.toLocaleString(),
-                    tone: openOperatorCount > 0 ? 'accent' : 'default',
-                    sublabel: 'Accepting delegations',
-                    isLoading,
-                  },
-                  {
-                    label: 'Total stake',
-                    value: formatStake(totalStake),
-                    sublabel: 'TNT delegated',
-                    isLoading,
-                  },
-                ]}
-              />
-            </div>
-
-            <div className="rounded-lg border border-[color:var(--border-accent)] bg-[var(--accent-surface-soft)] p-4 shadow-[var(--shadow-card)]">
-              <p className="font-semibold text-muted-foreground text-[10px] uppercase tracking-wider">
-                Delegate stake
-              </p>
-              <p className="mt-2 font-display font-bold text-foreground text-base leading-snug">
-                Pick an open operator and back them with TNT.
-              </p>
-              <p className="mt-2 text-muted-foreground text-xs leading-relaxed">
-                Delegators earn a share of operator rewards proportional to
-                their stake. Switch operator any time — unbonding applies.
-              </p>
-              <div className="mt-4 flex flex-col gap-2 sm:flex-row">
-                <Button
-                  variant="sandbox"
-                  className="flex-1"
-                  onClick={() => handleStakeClicked()}
-                >
-                  Delegate
-                </Button>
-                {isConnected && (
-                  <Button
-                    variant="outline"
-                    className="flex-1"
-                    onClick={() => navigate(PagePath.OPERATORS_MANAGE)}
-                  >
-                    Manage operator
-                  </Button>
-                )}
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      <MetricStrip metrics={metrics} density="compact" />
 
       <OperatorsPanel
         operators={operatorList}

--- a/apps/tangle-cloud/src/pages/rewards/page.tsx
+++ b/apps/tangle-cloud/src/pages/rewards/page.tsx
@@ -24,6 +24,7 @@ import {
   TableHeader,
   TableRow,
 } from '@tangle-network/sandbox-ui/primitives';
+import { PageHeader } from '../../components/chrome';
 import {
   ExternalLinkLine,
   FileCopyLine,
@@ -526,23 +527,11 @@ const PendingRewardsTable: FC<PendingRewardsTableProps> = ({
 };
 
 const RewardsHero = () => (
-  <Card
-    variant="sandbox"
-    className="cloud-hero-card cloud-compact-header overflow-hidden"
-  >
-    <CardContent className="relative p-4 md:p-5">
-      <div className="pointer-events-none absolute inset-0 opacity-70 [background:radial-gradient(circle_at_12%_8%,rgba(99,102,241,0.18),transparent_32%),radial-gradient(circle_at_86%_12%,rgba(16,185,129,0.10),transparent_28%)]" />
-      <div className="relative">
-        <h1 className="font-display font-extrabold text-3xl text-foreground leading-[1.05] tracking-[-0.035em] sm:text-4xl">
-          Rewards
-        </h1>
-        <p className="mt-3 max-w-2xl text-muted-foreground text-sm leading-relaxed">
-          Pending balances come from contract state; claim history comes from
-          indexed on-chain events.
-        </p>
-      </div>
-    </CardContent>
-  </Card>
+  <PageHeader
+    density="compact"
+    title="Rewards"
+    subtitle="Pending balances come from contract state; claim history comes from indexed on-chain events."
+  />
 );
 
 const PendingAssetCell: FC<{ token: Address; addressExplorerUrl?: string }> = ({

--- a/apps/tangle-cloud/src/styles.css
+++ b/apps/tangle-cloud/src/styles.css
@@ -226,28 +226,6 @@ body {
   box-shadow: var(--shadow-card);
 }
 
-/* Page hero: dot grid + brand radial glows over elevated linear. */
-.cloud-hero-card {
-  /* prettier-ignore */
-  border-color: color-mix(in srgb, var(--brand-cool) 30%, var(--border-default));
-  /* prettier-ignore */
-  background: radial-gradient(rgba(255,255,255,0.045) 1px, transparent 1px) 0 0 / 22px 22px, radial-gradient(circle at 4% 12%, color-mix(in srgb, var(--brand-cool) 28%, transparent), transparent 32%), radial-gradient(circle at 90% 8%, color-mix(in srgb, #14b8a6 22%, transparent), transparent 28%), linear-gradient(135deg, var(--bg-elevated), var(--bg-card));
-  /* prettier-ignore */
-  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.32), inset 0 1px 0 rgba(255, 255, 255, 0.05);
-}
-.cloud-compact-header {
-  /* prettier-ignore */
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18), inset 0 1px 0 rgba(255, 255, 255, 0.04);
-}
-.cloud-compact-header h1 {
-  text-wrap: balance;
-}
-.cloud-compact-header p {
-  text-wrap: pretty;
-}
-.catalog-controls {
-  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.14);
-}
 .results-grid {
   content-visibility: auto;
   contain-intrinsic-size: 800px;

--- a/apps/tangle-cloud/src/styles/chrome.ts
+++ b/apps/tangle-cloud/src/styles/chrome.ts
@@ -1,0 +1,101 @@
+/**
+ * Tangle Cloud chrome system — single source of truth for page composition.
+ *
+ * Three rules:
+ *   1. Five type roles. No more. (display / section / body / label / mono)
+ *   2. Eight semantic colors. Bound to `@tangle-network/brand` underneath.
+ *   3. Three header heights, one toolbar height, one tray width. Apply uniformly.
+ *
+ * Decorative chrome (radial gradients on hero cards, dot-grid backdrops, ramped
+ * shadows on filter strips, tinted "sandbox" card variants outside the iframe
+ * surface) is deliberately absent. Pages compose <PageHeader>, <PageToolbar>,
+ * <FilterTray>, <MetricStrip>, <ResultGrid|ResultList>, <EmptyState>. Nothing
+ * else.
+ *
+ * Tokens are TypeScript constants (not CSS vars) so component authors can
+ * compose them in className/style without round-tripping through a custom
+ * property — but the values reference the brand CSS vars so theming still
+ * works through @tangle-network/brand.
+ */
+
+// ── Type roles ───────────────────────────────────────────────────────────────
+
+export const typeRole = {
+  /** Page H1. One per page. */
+  display:
+    'font-display font-extrabold text-3xl sm:text-4xl tracking-[-0.035em] leading-[1.05]',
+  /** Section heads, card titles. */
+  section:
+    'font-display font-semibold text-lg leading-tight tracking-[-0.012em]',
+  /** Default body copy. */
+  body: 'text-sm leading-relaxed',
+  /** Control labels, eyebrows. Always uppercase, always tracked. */
+  label:
+    'text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground',
+  /** Numerals, IDs, hashes, addresses, amounts. */
+  mono: 'font-mono text-[13px] tabular-nums',
+} as const;
+
+// ── Spacing scale ────────────────────────────────────────────────────────────
+// Stick to these. 4 / 8 / 12 / 16 / 24 / 32 / 48 / 64.
+
+export const space = {
+  pageGutter: 'px-4 md:px-8',
+  pageMaxWidth: 'max-w-[1440px]',
+  pagePadY: 'pt-6 pb-10',
+  sectionGap: 'space-y-6',
+  controlGap: 'gap-3',
+  inlineGap: 'gap-2',
+} as const;
+
+// ── Chrome heights ───────────────────────────────────────────────────────────
+// Encode the three header densities and the one toolbar height as Tailwind
+// class fragments so a component author writes <PageHeader density="compact"/>
+// and gets the right thing without remembering pixels.
+
+export const chromeHeight = {
+  headerCompact: 'min-h-[60px] py-3',
+  headerDefault: 'min-h-[80px] py-4',
+  headerHero: 'min-h-[120px] py-6',
+  toolbar: 'h-11', // 44px
+  metricStrip: 'min-h-[56px] py-3',
+  tray: 'w-[420px]',
+} as const;
+
+// ── Status palette ───────────────────────────────────────────────────────────
+// Three status tones. Outlined pills only — `border-{color} bg-{color}/8` —
+// never filled. One color per status. Used at boundaries (state of a service,
+// audit state, capacity state). Never decorative.
+
+export type StatusTone = 'neutral' | 'success' | 'warning' | 'danger' | 'info';
+
+export const statusPill: Record<StatusTone, string> = {
+  neutral: 'border border-border bg-transparent text-muted-foreground',
+  success:
+    'border border-[color:var(--md3-tertiary,#10b981)]/40 bg-[color:var(--md3-tertiary,#10b981)]/8 text-[color:var(--md3-tertiary,#10b981)]',
+  warning:
+    'border border-[color:var(--md3-warning,#f59e0b)]/40 bg-[color:var(--md3-warning,#f59e0b)]/8 text-[color:var(--md3-warning,#f59e0b)]',
+  danger:
+    'border border-[color:var(--md3-error,#ef4444)]/40 bg-[color:var(--md3-error,#ef4444)]/8 text-[color:var(--md3-error,#ef4444)]',
+  info: 'border border-[color:var(--border-accent)] bg-[var(--accent-surface-soft)] text-foreground',
+} as const;
+
+// ── Surface roles ────────────────────────────────────────────────────────────
+// Eight roles. Bound to brand tokens. Anything not in this list is a bug.
+
+export const surface = {
+  bgDefault: 'bg-background',
+  bgElevated: 'bg-[color:var(--bg-card)]',
+  bgSubtle: 'bg-[color:var(--bg-elevated)]/40',
+  fgDefault: 'text-foreground',
+  fgMuted: 'text-muted-foreground',
+  fgSubtle: 'text-foreground/60',
+  borderDefault: 'border border-border',
+  borderAccent: 'border border-[color:var(--border-accent)]',
+} as const;
+
+// ── Focus + interaction ──────────────────────────────────────────────────────
+
+export const focus = {
+  ring: 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--border-accent-hover)] focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+} as const;


### PR DESCRIPTION
## Summary

Senior-level cloud-app redesign. Replace bespoke per-page hero/filter chrome with a tokenized chrome system every page composes from the same primitives.

### What was wrong with the old chrome

Every page in tangle-cloud was inventing its own composition: gradient hero cards (~300px), filter cards (~320px), bespoke \`cloud-hero-card\` styles with dot-grid + double-radial backgrounds, custom shadow ramps. **/blueprints consumed 620px of vertical chrome on a 900px viewport before the first card rendered — only 3 cards above the fold.** Five pages shared the same anti-pattern with subtle drift. Three brands fighting in one app.

Sandbox-ui primitives (Card, Button, Input) were *used* correctly; the *composition* was the divergence.

### What this PR introduces

**\`apps/tangle-cloud/src/styles/chrome.ts\`** — single source of truth:
- 5 type roles (display / section / body / label / mono). No more.
- 8 surface tokens (fg×3, bg×3, border×2), bound to brand CSS vars.
- Status palette: outlined pills only (\`border-color bg-color/8\`), one tone per status, never filled.
- 3 chrome heights (header 60/80/120, toolbar 44, strip 56, tray 420).

**\`apps/tangle-cloud/src/components/chrome/\`** — primitive set:
- \`PageHeader\` — H1 + subtitle + action slot, 3 density modes. Replaces hero cards.
- \`PageToolbar\` — search + count + filters + trailing, 44px sticky. Replaces filter cards.
- \`FilterTray\` — popover with active-count badge. Secondary filters move off the page surface.
- \`MetricStrip\` — opt-in horizontal metrics, mono tabular numerals, dot-indicator tones.
- \`EmptyState\` — six kinds (no-data / no-match / error / loading / no-permission / no-network), hand-crafted defaults.
- \`ResultGrid\` + \`ResultList\` — grid (cards) and dense rows (table-flex).
- \`StatusPill\`, \`ViewToggle\` — supporting primitives.

**⌘K command palette + keyboard surface**:
- \`CommandPalette\` (Dialog + filtered list, no cmdk dep)
- \`useKeyboardShortcuts\` for \`⌘K\`, \`/\`, \`g b|o|r|e|i|m\`, \`?\`
- \`ShortcutsHelp\` overlay for discovery
- All mounted once in \`Layout\` so every page inherits the keyboard surface.

**URL state via \`useUrlState\`**:
Search query, filter selections, pagination — everything that matters across refresh — moves to the URL. \`string\` / \`enum<T>\` / \`int\` codecs keep clean URLs (default values omitted). Filtered views are share-links.

### Page migrations

| Page | Change |
|---|---|
| \`/blueprints\` | Full migration. **Above-the-fold 620px → ~140px.** URL state on search/category/availability/source/trust/page. |
| \`/operators\` | PageHeader + MetricStrip (4 metrics). Bespoke hero deleted. |
| \`/instances\` | PageHeader + MetricStrip (role-aware metrics). |
| \`/rewards\` | PageHeader. Hero card deleted. |
| \`/earnings\` | PageHeader. Hero card deleted. |

### Bespoke CSS deleted

\`.cloud-hero-card\` (radials + shadows), \`.cloud-compact-header\` (shadow ramp), \`.catalog-controls\` (shadow ramp). 22 lines down from styles.css.

## Test plan

- [x] \`yarn nx typecheck tangle-cloud\` — clean
- [x] \`yarn nx lint tangle-cloud\` — 2 warnings (pre-existing exhaustive-deps, not from this PR)
- [x] \`yarn nx test tangle-cloud\` — 162 / 162 passing
- [x] \`yarn nx build tangle-cloud\` — clean, bundle +8KB gzipped
- [ ] After merge: visual diff on develop.cloud.tangle.tools across /blueprints, /operators, /instances, /rewards, /earnings — confirm above-the-fold ratio and consistent header pattern
- [ ] After merge: hit \`?\` on any page; verify shortcut overlay; \`g b\` / \`g o\` etc.; \`⌘K\` palette filters across nav entries

## Why this is "9+" and not the timid v1

The 7.5 version would have been "compact toolbar, smaller hero, ship". A senior fix doesn't trim the existing layout — it picks a different page archetype (catalog, not dashboard) and builds primitives so every future page falls into the same pattern by default. The chrome system is the permanent solve; the page migrations are the proof.

## Follow-ups still owed

- \`/blueprints/[id]\` detail + \`/blueprints/manage\` + service pages — same primitives, different content.
- Hand-craft all 6 EmptyState kinds per page with context-aware copy.
- 100ms opacity+4px y page transitions.
- Density toggle in user settings.
- Audit remaining \`variant=\"sandbox\"\` Card usages across the codebase outside the iframe surface.
- Fix the regex-derived blueprint taxonomy (\`getBlueprintCategory\` matches publisher names with a regex; should move to on-chain \`blueprintUi.tags[]\` once schema supports it).