### PR TITLE
feat(blueprints): tag-driven category with regex fallback + cleanup sweep

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppLandingPage.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppLandingPage.tsx
@@ -10,7 +10,6 @@ import { resolveBlueprintAppView } from '../resolver';
 import type { BlueprintAppEntry } from '../types';
 import type { TangleBlueprintAppEntry } from '../manifest';
 import type { BlueprintIframeConfig } from '../iframe/types';
-import BlueprintAppFrameHost from './BlueprintAppFrameHost';
 import BlueprintModePicker from './BlueprintModePicker';
 import IframeBlueprintLayout from './IframeBlueprintLayout';
 import { useBlueprint } from '@tangle-network/tangle-shared-ui/data/graphql';

--- a/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
@@ -66,11 +66,45 @@ type Props = {
 const pluralize = (label: string, count: number) =>
   count === 1 ? label : `${label}s`;
 
-const getBlueprintCategory = (blueprint: Blueprint) => {
-  const explicitCategory = blueprint.category?.trim();
+/**
+ * Title-case a single tag so the catalog renders consistent chips even if
+ * the publisher's on-chain string is lowercase or mixed-case ("inference"
+ * vs "Inference" vs "INFERENCE" all render as "Inference").
+ */
+const normalizeTag = (raw: string): string => {
+  const t = raw.trim();
+  if (t.length === 0) return '';
+  // Preserve all-caps acronyms (TEE, LLM, RAG, ZK, AI, MEV).
+  if (/^[A-Z]{2,5}$/.test(t)) return t;
+  return t
+    .split(/[\s-]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(' ');
+};
 
+/**
+ * Resolve a blueprint's category in three tiers, in order:
+ *
+ *   1. `blueprintUi.tags[0]` — publisher-declared, on-chain, authoritative.
+ *      Multi-tag blueprints surface the first as the primary chip.
+ *   2. `blueprint.category` — chain-derived, present on older metadata.
+ *   3. Keyword inference from name + description — last resort.
+ *
+ * The keyword fallback is a fingerprint, not a taxonomy. It's narrow on
+ * purpose: misclassifying a blueprint into the wrong bucket is worse than
+ * dropping it into "Other" and asking the publisher to declare tags.
+ */
+const getBlueprintCategory = (blueprint: Blueprint): string => {
+  const declaredTags = blueprint.blueprintUi?.tags ?? [];
+  for (const raw of declaredTags) {
+    const normalized = normalizeTag(raw);
+    if (normalized.length > 0) return normalized;
+  }
+
+  const explicitCategory = blueprint.category?.trim();
   if (explicitCategory) {
-    return explicitCategory;
+    return normalizeTag(explicitCategory);
   }
 
   const searchable =
@@ -81,19 +115,15 @@ const getBlueprintCategory = (blueprint: Blueprint) => {
   ) {
     return 'Data';
   }
-
   if (/\b(agent|sandbox|automation|bot)\b/.test(searchable)) {
     return 'Agents';
   }
-
   if (/\b(trading|market|strategy|portfolio)\b/.test(searchable)) {
     return 'Trading';
   }
-
   if (/\b(training|train|fine[- ]?tune|checkpoint)\b/.test(searchable)) {
     return 'Training';
   }
-
   if (
     /\b(ai|llm|inference|model|image|video|voice|avatar|modal|gpu)\b/.test(
       searchable,
@@ -103,6 +133,19 @@ const getBlueprintCategory = (blueprint: Blueprint) => {
   }
 
   return 'Other';
+};
+
+/**
+ * Full tag set for a blueprint — all publisher-declared tags + the primary
+ * category (so search/filter still matches on the inferred bucket when the
+ * publisher didn't declare it explicitly).
+ */
+const getBlueprintTags = (blueprint: Blueprint): readonly string[] => {
+  const declared = (blueprint.blueprintUi?.tags ?? [])
+    .map(normalizeTag)
+    .filter((t) => t.length > 0);
+  if (declared.length > 0) return declared;
+  return [getBlueprintCategory(blueprint)];
 };
 
 const hasVerifiedManifest = (blueprint: Blueprint) =>
@@ -118,7 +161,10 @@ const matchesSearch = (blueprint: Blueprint, query: string) => {
     blueprint.description,
     blueprint.author,
     blueprint.category,
-    getBlueprintCategory(blueprint),
+    // Match against every declared tag, not just the primary category —
+    // a search for "tee" should hit a blueprint tagged ["Inference", "TEE"]
+    // even though its primary chip says Inference.
+    ...getBlueprintTags(blueprint),
     blueprint.id.toString(),
   ]
     .filter(Boolean)

--- a/libs/tangle-shared-ui/src/blueprintApps/authoring.spec.ts
+++ b/libs/tangle-shared-ui/src/blueprintApps/authoring.spec.ts
@@ -287,3 +287,57 @@ describe('parseBlueprintUiContract — modes', () => {
     expect(parsed?.modes?.[0]?.id).toBe('mode-0');
   });
 });
+
+describe('parseBlueprintUiContract — tags', () => {
+  const baseContract = {
+    displayName: 'Atlas',
+    publisher: { name: 'Northstar', namespace: 'northstar' },
+    resources: { serviceLabel: 'Service', itemLabel: 'Resource' },
+    surfaces: ['generic-overview'],
+  };
+
+  it('returns undefined when tags are absent', () => {
+    expect(parseBlueprintUiContract(baseContract)?.tags).toBeUndefined();
+  });
+
+  it('accepts a string array verbatim, preserving order', () => {
+    const parsed = parseBlueprintUiContract({
+      ...baseContract,
+      tags: ['Inference', 'TEE', 'Onchain'],
+    });
+    expect(parsed?.tags).toEqual(['Inference', 'TEE', 'Onchain']);
+  });
+
+  it('drops non-string entries, empty strings, and duplicates', () => {
+    const parsed = parseBlueprintUiContract({
+      ...baseContract,
+      tags: ['Inference', '', '  ', 'Inference', 42, null, 'TEE'],
+    });
+    expect(parsed?.tags).toEqual(['Inference', 'TEE']);
+  });
+
+  it('caps at the documented MAX_TAG_COUNT', () => {
+    const many = Array.from({ length: 20 }, (_, i) => `tag${i}`);
+    const parsed = parseBlueprintUiContract({ ...baseContract, tags: many });
+    expect(parsed?.tags?.length).toBe(8);
+    expect(parsed?.tags?.[0]).toBe('tag0');
+  });
+
+  it('drops entries longer than MAX_TAG_LENGTH (40 chars)', () => {
+    const tooLong = 'x'.repeat(50);
+    const parsed = parseBlueprintUiContract({
+      ...baseContract,
+      tags: ['Inference', tooLong, 'TEE'],
+    });
+    expect(parsed?.tags).toEqual(['Inference', 'TEE']);
+  });
+
+  it('returns undefined when every input is invalid', () => {
+    expect(
+      parseBlueprintUiContract({ ...baseContract, tags: [42, null, ''] })?.tags,
+    ).toBeUndefined();
+    expect(
+      parseBlueprintUiContract({ ...baseContract, tags: 'not-an-array' })?.tags,
+    ).toBeUndefined();
+  });
+});

--- a/libs/tangle-shared-ui/src/blueprintApps/authoring.ts
+++ b/libs/tangle-shared-ui/src/blueprintApps/authoring.ts
@@ -314,6 +314,27 @@ const normalizeExternalApp = (
   };
 };
 
+/**
+ * Tag length cap protects against publishers stuffing the field with prose;
+ * count cap prevents catalog-bombing a blueprint into every facet.
+ */
+const MAX_TAG_LENGTH = 40;
+const MAX_TAG_COUNT = 8;
+
+const parseTags = (value: unknown): readonly string[] | undefined => {
+  if (!Array.isArray(value)) return undefined;
+  const out: string[] = [];
+  for (const item of value) {
+    if (typeof item !== 'string') continue;
+    const trimmed = item.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_TAG_LENGTH) continue;
+    if (out.includes(trimmed)) continue;
+    out.push(trimmed);
+    if (out.length >= MAX_TAG_COUNT) break;
+  }
+  return out.length > 0 ? out : undefined;
+};
+
 const parseTheme = (value: unknown): BlueprintUiTheme | undefined => {
   if (!isRecord(value)) {
     return undefined;
@@ -1040,6 +1061,7 @@ export const parseBlueprintUiContract = (
   const modules = parseModules(value.modules);
   const modes = parseBlueprintModes(value.modes);
   const externalApp = normalizeExternalApp(value.externalApp);
+  const tags = parseTags(value.tags);
   const hasDeclarativeContent =
     surfaces.length > 0 ||
     overviewCards !== undefined ||
@@ -1067,6 +1089,7 @@ export const parseBlueprintUiContract = (
     },
     surfaces,
     ...(theme ? { theme } : {}),
+    ...(tags ? { tags } : {}),
     ...(overviewCards ? { overviewCards } : {}),
     ...(actions ? { actions } : {}),
     ...(resourceViews ? { resourceViews } : {}),

--- a/libs/tangle-shared-ui/src/blueprintApps/types.ts
+++ b/libs/tangle-shared-ui/src/blueprintApps/types.ts
@@ -233,6 +233,18 @@ export type BlueprintUiContract = {
   resources: BlueprintUiResources;
   surfaces: BlueprintUiSurface[];
   theme?: BlueprintUiTheme;
+  /**
+   * Optional publisher-declared category labels. The dapp catalog uses
+   * `tags[0]` as the primary category chip and surfaces the rest in
+   * filter facets. Empty / absent → fall back to `Blueprint.category`
+   * (chain-derived) and finally to keyword inference.
+   *
+   * Multi-tag is supported because a blueprint can legitimately belong
+   * to several taxonomies at once ("Inference" + "Onchain" + "TEE").
+   * Tags are normalized to title-case on consume; raw strings are
+   * accepted to keep the publisher schema lenient.
+   */
+  tags?: readonly string[];
   overviewCards?: BlueprintUiOverviewCard[];
   actions?: BlueprintUiAction[];
   resourceViews?: BlueprintUiResourceView[];


### PR DESCRIPTION
## Why

The catalog's category chip was derived from a 5-bucket regex on the blueprint's name + description — hallucinated taxonomy, drifted easily, and gave deployers no path to declare what category their blueprint belonged to.

This change adds `blueprintUi.tags?: readonly string[]` to the on-chain `BlueprintUiContract`, makes the catalog read it as the authoritative source, and demotes the regex to a last-resort fallback.

## Resolution priority

1. **`blueprintUi.tags[0]`** — publisher-declared, on-chain, authoritative. Multi-tag blueprints surface the first as the primary chip; search + filter consider every declared tag.
2. **`blueprint.category`** — chain-derived legacy field, present on older metadata. Title-cased before display.
3. **Keyword inference** — 5-bucket regex on name + description. Narrow on purpose: misclassifying into the wrong bucket is worse than dropping into "Other" and asking the publisher to declare tags.

## Tag normalization

`normalizeTag` title-cases so chips render uniformly across publisher casing variants (`inference` / `Inference` / `INFERENCE` all render as `Inference`), but preserves all-caps acronyms (TEE, LLM, ZK, MEV) which are conventional in the space.

## Schema

`parseTags` in shared-ui authoring accepts a string array verbatim, drops non-strings / empty / duplicates, caps at `MAX_TAG_COUNT` (8) and `MAX_TAG_LENGTH` (40). Tested in `authoring.spec.ts` — 6 new tests covering absent → undefined, simple array, dedup + drop-invalid, count cap, length cap, all-invalid → undefined.

## Search includes every declared tag

A search for "TEE" now matches a blueprint tagged `["Inference", "TEE"]` even though its primary chip says Inference. The haystack expanded from `[name, description, author, category, primaryCategory, id]` to `[name, description, author, category, ...allTags, id]`.

## Cleanup also dropped a dead import in BlueprintAppLandingPage

`BlueprintAppFrameHost` was unused after the iframe-first layout PR moved iframe rendering into `IframeBlueprintLayout`. Removed in this sweep.

## Test plan

- [x] `yarn nx build/typecheck tangle-cloud` — clean
- [x] `yarn nx test tangle-shared-ui --testPathPattern=authoring.spec` — 31/31 passing (was 25, added 6)
- [x] `yarn nx test tangle-cloud` — 162/162 passing
- [x] `yarn nx lint tangle-cloud` — 0 errors (2 pre-existing warnings)
- [ ] After merge: publishers can declare `blueprintUi: { tags: ["Inference", "TEE"] }` in their on-chain metadata; the catalog renders the first as the chip; search/filter matches all of them.

## Migration

Existing blueprints continue to work via the legacy fallbacks. No publisher action required; tags are opt-in.