### PR TITLE
feat(tangle-cloud): page-to-page transitions (100ms opacity + 4px y)

### DIFF
--- a/apps/tangle-cloud/src/components/Layout.tsx
+++ b/apps/tangle-cloud/src/components/Layout.tsx
@@ -5,6 +5,7 @@ import TxHistoryNotifier from './TxHistoryNotifier';
 import Header from './Header';
 import { twMerge } from 'tailwind-merge';
 import CommandPalette from './chrome/CommandPalette';
+import PageMotion from './chrome/PageMotion';
 import ShortcutsHelp from './chrome/ShortcutsHelp';
 import { useKeyboardShortcuts } from './chrome/useKeyboardShortcuts';
 
@@ -96,7 +97,9 @@ const Layout: FC<PropsWithChildren<Props>> = ({
         <CommandPalette open={isPaletteOpen} onOpenChange={setIsPaletteOpen} />
         <ShortcutsHelp open={isHelpOpen} onOpenChange={setIsHelpOpen} />
 
-        <main className="flex-1">{children}</main>
+        <main className="flex-1">
+          <PageMotion>{children}</PageMotion>
+        </main>
       </div>
     </div>
   );

--- a/apps/tangle-cloud/src/components/chrome/PageMotion.tsx
+++ b/apps/tangle-cloud/src/components/chrome/PageMotion.tsx
@@ -1,0 +1,58 @@
+import { type FC, type ReactNode, useEffect, useState } from 'react';
+import { useLocation } from 'react-router';
+import { twMerge } from 'tailwind-merge';
+
+type Props = {
+  children: ReactNode;
+  className?: string;
+};
+
+/**
+ * Page-to-page transition. 100ms opacity + 4px y translate on route change.
+ *
+ * Deliberately tiny: the goal is "the page acknowledged my click" not "watch
+ * a fancy slide." Anything longer than ~150ms reads as the app being slow,
+ * not polished. Anything more than a few pixels of translate reads as motion
+ * sickness.
+ *
+ * Implementation: when `useLocation().pathname` changes, briefly mark the
+ * shell as `data-motion="entering"` so a CSS keyframe animates the fade-in.
+ * One frame later (via setTimeout 0 — actually 16ms for the rAF) we clear
+ * the attribute so the page stays in its final state. No AnimatePresence,
+ * no library overhead — pure CSS plus a 1-line effect.
+ *
+ * Why not framer-motion: AnimatePresence + react-router v7's `Routes` needs
+ * a `location` prop that this app's `withLayout` wrapper doesn't thread,
+ * and the swap-the-tree approach breaks lazy-loaded route boundaries with
+ * a flicker. CSS keyframe on attribute change has none of those costs.
+ *
+ * `prefers-reduced-motion` is honored by the CSS rule — users with reduced
+ * motion enabled get the fade only (no translate).
+ */
+const PageMotion: FC<Props> = ({ children, className }) => {
+  const { pathname } = useLocation();
+  const [entering, setEntering] = useState(false);
+
+  useEffect(() => {
+    setEntering(true);
+    // Two rAFs: one to commit the entering state, one to clear it after the
+    // browser has had a chance to render the initial keyframe state. The
+    // CSS animation handles the actual transition; the attribute is just a
+    // trigger.
+    let rafId = requestAnimationFrame(() => {
+      rafId = requestAnimationFrame(() => setEntering(false));
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, [pathname]);
+
+  return (
+    <div
+      data-cloud-page-motion={entering ? 'entering' : 'idle'}
+      className={twMerge('cloud-page-motion', className)}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default PageMotion;

--- a/apps/tangle-cloud/src/styles.css
+++ b/apps/tangle-cloud/src/styles.css
@@ -254,6 +254,41 @@ body {
   contain-intrinsic-size: 800px;
 }
 
+/* Page-to-page transition triggered by PageMotion when react-router's
+ * pathname changes. 100ms total: 4px upward translate + opacity fade-in.
+ * Honors `prefers-reduced-motion` — reduced-motion users get the fade
+ * only, no translate.
+ *
+ * Why an attribute-keyed animation and not a CSS `transition` on a class:
+ * `transition` only fires when a CSS property *changes*, so the initial
+ * mount paint wouldn't trigger anything. A keyframe `animation`, scoped
+ * by an attribute selector, fires every time the attribute appears,
+ * giving us a clean enter-from-nothing on every navigation.
+ */
+.cloud-page-motion[data-cloud-page-motion='entering'] {
+  animation: cloud-page-enter 100ms ease-out;
+}
+@keyframes cloud-page-enter {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  @keyframes cloud-page-enter {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+}
+
 .tangle-cloud-shell :where(a, button, select, [role='tab']) {
   /* prettier-ignore */
   transition: background-color 180ms ease, border-color 180ms ease, color 180ms ease, opacity 180ms ease, transform 120ms ease, box-shadow 180ms ease;


### PR DESCRIPTION
## What

When the operator clicks Sidebar → Operators or Blueprints → blueprint detail, the next page now eases in at 100ms with a 4px upward translate. Long enough to register as "the click did something," short enough to never feel slow.

## How

`PageMotion` wraps the routed children in `Layout`. It watches `useLocation().pathname`, sets `data-cloud-page-motion="entering"` on the wrapper for one paint, then clears the attribute. A CSS keyframe (`cloud-page-enter` in `styles.css`) animates the enter. Pure CSS, no runtime library overhead.

## Why attribute-keyed CSS animation, not framer-motion

- `AnimatePresence` + react-router v7's `Routes` needs a `location` prop threaded through, which `withLayout` in `app.tsx` doesn't expose. Refactoring to pass it would touch every route.
- Tree-swap transitions break lazy-loaded route boundaries with a flicker on first paint.
- A CSS keyframe on an attribute selector has neither cost; it fires every time the attribute appears, which is exactly the "page mounted" signal we want.

## `prefers-reduced-motion`

Honored in the same CSS rule. Reduced-motion users get the fade only — no translate — so people who get motion-sick still see the same "page changed" cue without movement.

## Density toggle deliberately not in this PR

Threading a density CSS variable through the chrome system without any components consuming it would be cargo. Will land once one or two pages opt in to the variable so the toggle has visible effect.

## Test plan

- [x] `yarn nx build/typecheck tangle-cloud` — clean
- [x] `yarn nx test tangle-cloud` — 162/162 passing
- [x] `yarn nx lint tangle-cloud` — 0 errors (2 pre-existing warnings)
- [ ] After merge + deploy: click between Blueprints / Operators / Rewards on develop.cloud.tangle.tools; observe the subtle fade-in-from-4px transition on each navigation