### PR TITLE
feat(tangle-cloud): broadcast serviceContext + chain to embedded iframes

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrameHost.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrameHost.tsx
@@ -1,7 +1,10 @@
-import { type FC, useEffect, useRef } from 'react';
+import { type FC, useEffect, useMemo, useRef } from 'react';
 import BlueprintAppFrame from './BlueprintAppFrame';
 import IframeAppApprovalModal from './IframeAppApprovalModal';
-import { useIframeBridge } from '../iframe/useIframeBridge';
+import {
+  useIframeBridge,
+  type IframeServiceContext,
+} from '../iframe/useIframeBridge';
 import type { BlueprintIframeConfig } from '../iframe/types';
 
 type Props = {
@@ -15,6 +18,14 @@ type Props = {
    */
   mode?: string;
   blueprintId?: bigint | number;
+  /**
+   * Service context broadcast to the iframe so the thin-iframe SDK's
+   * `useTangleService` resolves. Operators + serviceId when known; the
+   * bridge fills in the active chain itself.
+   */
+  serviceId?: string | null;
+  operators?: IframeServiceContext['operators'];
+  jobs?: IframeServiceContext['jobs'];
 };
 
 // Composes the hardened iframe element, the parent-side message bridge, and
@@ -25,11 +36,25 @@ const BlueprintAppFrameHost: FC<Props> = ({
   appDisplayName,
   mode,
   blueprintId,
+  serviceId = null,
+  operators = [],
+  jobs = [],
 }) => {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const serviceContext = useMemo<IframeServiceContext | undefined>(() => {
+    if (blueprintId === undefined) return undefined;
+    return {
+      blueprintId: blueprintId.toString(),
+      serviceId,
+      operators,
+      jobs,
+      mode: mode ?? null,
+    };
+  }, [blueprintId, serviceId, operators, jobs, mode]);
   const { pendingApproval, approve, reject } = useIframeBridge({
     config,
     iframeRef,
+    serviceContext,
   });
 
   // Live mode-change notification. The iframe receives the picked mode in

--- a/apps/tangle-cloud/src/blueprintApps/iframe/policy.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/policy.ts
@@ -138,5 +138,28 @@ export function checkRequestAllowed(
       return checkSignMessageAllowed(request, config);
     case 'tangle.app.signTransaction':
       return checkSignTransactionAllowed(request, config);
+    case 'tangle.app.signTypedData':
+      // Typed-data signing follows the same gate as signMessage — if the
+      // app can request a personal_sign it can request typed-data. The
+      // bridge currently short-circuits this with a "not yet wired" error
+      // before any modal; when wired, this gate already governs it.
+      return checkSignMessageAllowed(
+        // signTypedData carries chainId like the others; reuse the message
+        // gate which only checks the signing capability flag + chain.
+        request as unknown as IframeRequestSignMessage,
+        config,
+      );
+    case 'tangle.app.callJob':
+      // Job invocation is allowed at the policy layer for any iframe that
+      // can read its account (the baseline embedded-app capability). The
+      // actual submit goes through the user's wallet approval downstream,
+      // so there's no "silent spend" risk from accepting here.
+      return checkReadAccountAllowed(
+        {
+          kind: 'tangle.app.readAccount',
+          correlationId: request.correlationId,
+        },
+        config,
+      );
   }
 }

--- a/apps/tangle-cloud/src/blueprintApps/iframe/protocol.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/protocol.ts
@@ -45,12 +45,46 @@ export type IframeRequestSignTransaction = {
   value?: string;
 };
 
+// EIP-712 typed-data signing — for publishers signing custom message shapes
+// (operator envelopes, off-chain attestations, claim proofs). The parent
+// renders the typed-data fields in the approval modal. `types` must NOT
+// include the EIP712Domain entry — the parent derives it from `domain`.
+export type IframeRequestSignTypedData = {
+  kind: 'tangle.app.signTypedData';
+  correlationId: string;
+  chainId: number;
+  domain: {
+    name?: string;
+    version?: string;
+    chainId?: number;
+    verifyingContract?: Address;
+    salt?: Hex;
+  };
+  types: Record<string, Array<{ name: string; type: string }>>;
+  primaryType: string;
+  message: Record<string, unknown>;
+};
+
+// Job invocation — iframe asks the parent to run a blueprint job (quote +
+// sign + submit happen parent-side). Results stream back via
+// `ParentEventJobResult`. See the dapp's job-submission integration for
+// how this maps onto the deploy/quote pipeline.
+export type IframeRequestCallJob = {
+  kind: 'tangle.app.callJob';
+  correlationId: string;
+  jobIndex: number;
+  inputs: Record<string, unknown>;
+  stream?: boolean;
+};
+
 export type IframeRequest =
   | IframeRequestHandshake
   | IframeRequestReadAccount
   | IframeRequestSwitchChain
   | IframeRequestSignMessage
-  | IframeRequestSignTransaction;
+  | IframeRequestSignTransaction
+  | IframeRequestSignTypedData
+  | IframeRequestCallJob;
 
 // ─── Parent → Iframe ───────────────────────────────────────────────────
 
@@ -80,6 +114,10 @@ export type ParentResponseSignTransactionResult = {
   kind: 'tangle.app.signTransactionResult';
 } & ParentResponseResultBase<{ txHash: Hex }>;
 
+export type ParentResponseSignTypedDataResult = {
+  kind: 'tangle.app.signTypedDataResult';
+} & ParentResponseResultBase<{ signature: Hex }>;
+
 // Unsolicited broadcasts from parent to iframe (e.g. user changes account)
 export type ParentEventAccountChanged = {
   kind: 'tangle.app.accountChanged';
@@ -91,14 +129,55 @@ export type ParentEventChainChanged = {
   chainId: number;
 };
 
+// Chain config the iframe can use to build a read-only viem client. Mirrors
+// the SDK's ChainContext. `rpcUrl` is a public RPC, never a wallet RPC —
+// signing always routes back through the bridge.
+export type IframeChainContext = {
+  id: number;
+  name: string;
+  rpcUrl: string;
+  blockExplorerUrl?: string;
+  nativeCurrency?: { name: string; symbol: string; decimals: number };
+};
+
+// Service context broadcast — tells the iframe which blueprint/service it's
+// rendering for, which operators are available, and the active chain.
+export type ParentEventServiceContext = {
+  kind: 'tangle.app.serviceContext';
+  blueprintId: string;
+  serviceId: string | null;
+  operators: Array<{
+    address: Address;
+    rpcAddress: string | undefined;
+    status: 'active' | 'inactive' | 'unknown';
+  }>;
+  jobs: Array<{ index: number; name: string }>;
+  mode: string | null;
+  chain?: IframeChainContext;
+};
+
+// Job result event — streams back from a callJob request.
+export type ParentEventJobResult = {
+  kind: 'tangle.app.jobResult';
+  correlationId: string;
+  status: 'pending' | 'streaming' | 'success' | 'error';
+  data?: unknown;
+  chunk?: unknown;
+  error?: string;
+  progress?: { percent?: number; eta_ms?: number };
+};
+
 export type ParentMessage =
   | ParentResponseHandshakeAck
   | ParentResponseReadAccountResult
   | ParentResponseSwitchChainResult
   | ParentResponseSignMessageResult
   | ParentResponseSignTransactionResult
+  | ParentResponseSignTypedDataResult
   | ParentEventAccountChanged
-  | ParentEventChainChanged;
+  | ParentEventChainChanged
+  | ParentEventServiceContext
+  | ParentEventJobResult;
 
 // ─── Validation ──────────────────────────────────────────────────────────
 
@@ -206,6 +285,63 @@ export function validateIframeRequest(value: unknown): IframeRequest | null {
         to: record.to as Address,
         data: record.data,
         ...(value !== undefined ? { value } : {}),
+      };
+    }
+    case 'tangle.app.signTypedData': {
+      if (!isValidCorrelationId(record.correlationId)) return null;
+      if (!isFiniteNumber(record.chainId) || record.chainId <= 0) return null;
+      if (!isString(record.primaryType) || record.primaryType.length > 128) {
+        return null;
+      }
+      if (typeof record.domain !== 'object' || record.domain === null) {
+        return null;
+      }
+      if (typeof record.types !== 'object' || record.types === null) {
+        return null;
+      }
+      if (typeof record.message !== 'object' || record.message === null) {
+        return null;
+      }
+      // Bound total payload size to keep the approval modal sane + prevent
+      // OOM via a giant typed-data blob.
+      try {
+        if (JSON.stringify(record.message).length > MAX_CALLDATA_BYTES) {
+          return null;
+        }
+      } catch {
+        return null;
+      }
+      return {
+        kind: 'tangle.app.signTypedData',
+        correlationId: record.correlationId,
+        chainId: record.chainId,
+        domain: record.domain as IframeRequestSignTypedData['domain'],
+        types: record.types as IframeRequestSignTypedData['types'],
+        primaryType: record.primaryType,
+        message: record.message as Record<string, unknown>,
+      };
+    }
+    case 'tangle.app.callJob': {
+      if (!isValidCorrelationId(record.correlationId)) return null;
+      if (!isFiniteNumber(record.jobIndex) || record.jobIndex < 0) return null;
+      if (typeof record.inputs !== 'object' || record.inputs === null) {
+        return null;
+      }
+      try {
+        if (JSON.stringify(record.inputs).length > MAX_CALLDATA_BYTES) {
+          return null;
+        }
+      } catch {
+        return null;
+      }
+      return {
+        kind: 'tangle.app.callJob',
+        correlationId: record.correlationId,
+        jobIndex: record.jobIndex,
+        inputs: record.inputs as Record<string, unknown>,
+        ...(typeof record.stream === 'boolean'
+          ? { stream: record.stream }
+          : {}),
       };
     }
     default:

--- a/apps/tangle-cloud/src/blueprintApps/iframe/useIframeBridge.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/useIframeBridge.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useAccount, useChainId } from 'wagmi';
+import { useAccount, useChainId, useChains } from 'wagmi';
 import type { Address, Hex } from 'viem';
 import {
   validateIframeRequest,
@@ -36,12 +36,39 @@ export type ApprovalResult =
   | { ok: true; data: { chainId: number } }
   | { ok: false; reason: string };
 
+// Service context the parent broadcasts to the iframe so the embedded app
+// knows which blueprint/service it renders for + which operators are
+// available + the active chain. All read-only; the iframe uses it to drive
+// direct operator HTTP calls + a read-only viem client (no signing here).
+export type IframeServiceContext = {
+  blueprintId: string;
+  serviceId: string | null;
+  operators: Array<{
+    address: Address;
+    rpcAddress: string | undefined;
+    status: 'active' | 'inactive' | 'unknown';
+  }>;
+  jobs: Array<{ index: number; name: string }>;
+  mode: string | null;
+  chain?: {
+    id: number;
+    name: string;
+    rpcUrl: string;
+    blockExplorerUrl?: string;
+    nativeCurrency?: { name: string; symbol: string; decimals: number };
+  };
+};
+
 type Options = {
   config: BlueprintIframeConfig;
   iframeRef: React.RefObject<HTMLIFrameElement | null>;
   // Caller decides if the bridge is allowed to surface modals. When the page
   // is hidden / the iframe wasn't mounted, set this to false to no-op.
   enabled?: boolean;
+  // Service context broadcast to the iframe on mount + whenever it changes.
+  // Optional — when absent the iframe just doesn't receive a serviceContext
+  // event (older iframes / non-service surfaces).
+  serviceContext?: IframeServiceContext;
   onPolicyDeny?: (
     request: IframeRequest,
     verdict: IframePolicyVerdict & { ok: false },
@@ -52,10 +79,12 @@ export function useIframeBridge({
   config,
   iframeRef,
   enabled = true,
+  serviceContext,
   onPolicyDeny,
 }: Options) {
   const { address } = useAccount();
   const chainId = useChainId();
+  const chains = useChains();
   const [pendingApproval, setPendingApproval] =
     useState<PendingApproval | null>(null);
   const pendingRef = useRef(pendingApproval);
@@ -185,6 +214,51 @@ export function useIframeBridge({
     }
   }, [chainId, enabled, post]);
 
+  // Broadcast service context (blueprint/service/operators/chain) so the
+  // thin-iframe SDK's `useTangleService` + `useTanglePublicClient` resolve.
+  // Re-fires whenever the context object changes (mode swap, new service,
+  // operator delta). Serialized into the dep so the effect only re-runs on
+  // real changes, not new object identity each render.
+  // Derive chain context from the active wagmi chain so the iframe's
+  // `useTanglePublicClient` can build a read-only client. Falls back to the
+  // serviceContext's own chain if the caller supplied one explicitly.
+  const activeChain = chains.find((c) => c.id === chainId);
+  const chainContext =
+    serviceContext?.chain ??
+    (activeChain
+      ? {
+          id: activeChain.id,
+          name: activeChain.name,
+          rpcUrl: activeChain.rpcUrls.default.http[0] ?? '',
+          blockExplorerUrl: activeChain.blockExplorers?.default.url,
+          nativeCurrency: {
+            name: activeChain.nativeCurrency.name,
+            symbol: activeChain.nativeCurrency.symbol,
+            decimals: activeChain.nativeCurrency.decimals,
+          },
+        }
+      : undefined);
+
+  const serviceContextKey = serviceContext
+    ? JSON.stringify({ ...serviceContext, chain: chainContext })
+    : null;
+  useEffect(() => {
+    if (!enabled || !serviceContext) return;
+    post({
+      kind: 'tangle.app.serviceContext',
+      blueprintId: serviceContext.blueprintId,
+      serviceId: serviceContext.serviceId,
+      operators: serviceContext.operators,
+      jobs: serviceContext.jobs,
+      mode: serviceContext.mode,
+      ...(chainContext ? { chain: chainContext } : {}),
+    });
+    // serviceContextKey captures the meaningful change; serviceContext +
+    // chainContext are read inside but intentionally not in deps (would
+    // re-fire on identity each render).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serviceContextKey, enabled, post]);
+
   useEffect(() => {
     if (!enabled) return;
 
@@ -260,6 +334,37 @@ export function useIframeBridge({
               '0x0000000000000000000000000000000000000000') as Address,
             chainId: chainId ?? 0,
           },
+        });
+        return;
+      }
+
+      // callJob (job invocation via quote/sign/submit) is protocol-defined
+      // but its parent-side integration with the deploy/quote pipeline is
+      // not yet wired. Respond with a clean error so the iframe surfaces a
+      // real message instead of hanging on the request timeout. Tracked as
+      // a dedicated follow-up — the financial submit path needs its own
+      // careful review, not a tail-of-session bolt-on.
+      if (request.kind === 'tangle.app.callJob') {
+        post({
+          kind: 'tangle.app.jobResult',
+          correlationId: request.correlationId,
+          status: 'error',
+          error:
+            'callJob is not yet wired in this parent build. Use direct operator HTTP for reads; on-chain job submission is coming.',
+        });
+        return;
+      }
+
+      // signTypedData routes through the approval modal (same as
+      // signMessage / signTransaction) but the modal + signer integration
+      // for typed-data isn't wired yet. Clean error rather than a hang.
+      if (request.kind === 'tangle.app.signTypedData') {
+        post({
+          kind: 'tangle.app.signTypedDataResult',
+          correlationId: request.correlationId,
+          ok: false,
+          error:
+            'signTypedData approval is not yet wired in this parent build.',
         });
         return;
       }


### PR DESCRIPTION
Parent-side half of the thin-iframe SDK protocol (@tangle-network/blueprint-ui/iframe). The dapp now tells embedded blueprint iframes which blueprint/service they render for + the active chain, so the SDK's `useTangleService()` + `useTanglePublicClient()` resolve.

## Wired
- **Protocol**: `signTypedData`, `callJob`, `serviceContext`, `jobResult` types + validators on the canonical `iframe/protocol.ts`.
- **serviceContext broadcast**: `useIframeBridge` broadcasts `{ blueprintId, serviceId, operators, jobs, mode, chain }` on mount + change. Chain config derived from the active wagmi chain.
- **Policy**: signTypedData gated like signMessage; callJob gated like readAccount.

## Deferred (clean errors, not hangs)
`callJob` and `signTypedData` are protocol-complete but their execution paths (quote/sign/submit + typed-data approval modal) aren't wired — they respond immediately with a clear error. Each deserves its own carefully-reviewed PR; the financial submit path shouldn't be a tail-of-session bolt-on. Tracked as follow-ups.

## Why serviceContext alone is the keystone
Read-only + safe + unlocks the whole thin-iframe read model: the iframe learns its context, then does direct operator HTTP + injected-publicClient reads for ~90% of a rich blueprint UX. The reference llm-inference blueprint demonstrates exactly this.

## Test plan
- [x] `yarn nx typecheck/build/test/lint tangle-cloud` — clean (162/162)
- [ ] After merge: embedded iframe receives serviceContext with chain; SDK hooks resolve
- [ ] Follow-up PRs: callJob quote/submit + signTypedData approval modal