### PR TITLE
feat(tangle-cloud): register the LLM Inference blueprint app

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/registry.ts
+++ b/apps/tangle-cloud/src/blueprintApps/registry.ts
@@ -236,6 +236,75 @@ const entries = [
       ],
     },
   },
+  {
+    slug: 'llm-inference',
+    canonicalSlug: 'llm-inference',
+    match: {
+      publisherNamespace: 'tangle',
+      requestedSlug: 'llm-inference',
+    },
+    publisher: {
+      label: 'Tangle Labs',
+      visibility: 'first-party',
+      verification: 'first-party',
+    },
+    tier: 'curated-module',
+    slugPolicy: 'reserved',
+    module: {
+      moduleId: 'llm-inference',
+      status: 'planned',
+    },
+    manifest: {
+      displayName: 'LLM Inference',
+      tagline: 'Anonymous, pay-per-use LLM inference from Tangle operators.',
+      description:
+        'Chat with vLLM-backed operator models, paying via shielded credits. Deposit once; each request is authorized off-chain by an ephemeral key, so the operator never learns who you are.',
+      surfaces: [
+        'generic-overview',
+        'service-explorer',
+        'service-console',
+        'chat',
+        'permissions',
+      ],
+      resources: {
+        serviceNoun: 'inference service',
+        resourceNoun: 'model',
+        resourceRoute: 'custom',
+      },
+      permissions: [
+        {
+          key: 'credits.fund',
+          label: 'Fund shielded credits',
+          scope: 'service',
+        },
+      ],
+      externalApp: {
+        url: 'https://llm-inference.blueprint.tangle.tools/',
+        mode: 'iframe',
+        host: 'llm-inference.blueprint.tangle.tools',
+        trust: 'trusted',
+        label: 'LLM Inference',
+      },
+    },
+    // Read surface only for now: the iframe inherits the connected wallet and
+    // self-configures from the operator's /v1/operator (model, pricing,
+    // shielded_credits, chain_id). Funding deposits (approve + fundCredits)
+    // need `sendTransaction` allowlisted against the live develop
+    // ShieldedCredits + payment-token addresses — added once the develop
+    // operator + gateway are deployed (the spending-key SpendAuths are signed
+    // inside the iframe and never touch the bridge).
+    iframe: {
+      url: 'https://llm-inference.blueprint.tangle.tools/',
+      origin: 'https://llm-inference.blueprint.tangle.tools',
+      appId: 'llm-inference',
+      allowedChainIds: [],
+      contracts: [],
+      messages: [],
+      allowReadAccount: true,
+      allowChainSwitch: false,
+      allowPopups: false,
+    },
+  },
 ] satisfies CuratedRegistryEntry[];
 
 export const blueprintAppRegistry = new Map(


### PR DESCRIPTION
## Summary
Registers the **LLM Inference** blueprint as a curated app in Tangle Cloud, embedding the hosted iframe at `https://llm-inference.blueprint.tangle.tools/` (Cloudflare Pages, deployed). Matches the `tangle / llm-inference` blueprint metadata — same pattern as AI Trading / AI Agent Sandbox.

- The iframe inherits the connected wallet and **self-configures** from the operator's `/v1/operator` (model, pricing, `shielded_credits`, `chain_id`) — no hardcoded addresses.
- **Read surface only** for now (`allowReadAccount`, no contract grants). Funding deposits (`approve` + `fundCredits`) need `sendTransaction` allowlisted against the live develop `ShieldedCredits` + payment-token addresses — a follow-up once the develop operator + gateway are deployed. Per-request SpendAuths are signed inside the iframe by an ephemeral key and never touch the bridge.

## Verified
- UI live at `https://llm-inference.pages.dev` (custom domain `llm-inference.blueprint.tangle.tools` provisioning).
- `blueprintApps` suite green: 36 tests; `tangle-cloud:typecheck` clean; full pre-push (lint/test/build) passed.
- Full inference path proven locally (SDK -> operator -> ShieldedCredits on anvil -> cli-bridge model), see tangle-network/llm-inference-blueprint#10.

## Test plan
- [x] `vitest run src/blueprintApps/*.spec.ts` — 36 passing
- [x] `tsc --noEmit -p tsconfig.app.json` clean
- [ ] Visual: app card renders + iframe embeds in develop once the custom-domain cert provisions