### PR TITLE
fix(tangle-cloud): sync wallet to iframe on handshake + iframe fills its host

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrame.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrame.tsx
@@ -102,11 +102,13 @@ const BlueprintAppFrameInner = (
       loading="lazy"
       className={className}
       style={{
-        // Default to a sensible aspect; consumer can override.
+        // Fill the host container exactly — the layout owns the height, the
+        // app inside the iframe owns its own scroll. (A hard minHeight here
+        // left dead space below the frame on tall viewports.)
         width: '100%',
-        minHeight: '720px',
+        height: '100%',
         border: '0',
-        borderRadius: '16px',
+        borderRadius: '12px',
         ...style,
       }}
       {...iframeProps}

--- a/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
@@ -85,7 +85,7 @@ const IframeBlueprintLayout: FC<Props> = ({
     : undefined;
 
   return (
-    <div className="relative -mx-4 -mt-6 md:-mx-8" style={accentStyle}>
+    <div className="relative -mx-4 -mb-10 -mt-6 md:-mx-8" style={accentStyle}>
       {/* Top strip: identity + mode picker + primary CTA + Details disclosure.
        * 52px tall. Sits flush with the viewport top under the Layout's
        * topbar — no gap, no card wrapper — so the iframe immediately follows. */}
@@ -135,9 +135,13 @@ const IframeBlueprintLayout: FC<Props> = ({
        * publisher's app is responsible for managing. */}
       <div
         className={twMerge(
-          'relative',
-          // 56 (top nav from Layout) + 52 (identity strip) = 108
-          'h-[calc(100vh-108px)] min-h-[600px]',
+          'relative overflow-hidden',
+          // 56 (top nav from Layout) + 52 (identity strip) = 108. The frame
+          // fills this box; the small padding leaves a rounded gutter around
+          // the rounded iframe so it reads as a contained surface, not an
+          // edge-to-edge takeover. The parent never scrolls — the app inside
+          // the iframe manages its own scroll.
+          'h-[calc(100vh-108px)] min-h-[480px] p-2 md:p-3',
         )}
       >
         <BlueprintAppFrameHost

--- a/apps/tangle-cloud/src/blueprintApps/iframe/useIframeBridge.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/useIframeBridge.ts
@@ -239,6 +239,17 @@ export function useIframeBridge({
         }
       : undefined);
 
+  // Latest wallet/chain/service snapshot, read by the handshake handler so a
+  // freshly-loaded iframe can be synced on connect without re-subscribing the
+  // message listener on every wallet/service change.
+  const syncRef = useRef<{
+    address?: string;
+    chainId?: number;
+    serviceContext?: IframeServiceContext;
+    chainContext?: typeof chainContext;
+  }>({});
+  syncRef.current = { address, chainId, serviceContext, chainContext };
+
   const serviceContextKey = serviceContext
     ? JSON.stringify({ ...serviceContext, chain: chainContext })
     : null;
@@ -279,6 +290,30 @@ export function useIframeBridge({
           appId: config.appId,
           protocolVersion: IFRAME_PROTOCOL_VERSION,
         });
+        // Sync current state to the freshly-handshaking iframe. The
+        // accountChanged / chainChanged / serviceContext broadcast effects
+        // fire on mount — typically before the iframe has loaded and attached
+        // its listener — so without replaying them here on handshake, a late
+        // iframe would ack but never receive the wallet (stuck "no-wallet").
+        const sync = syncRef.current;
+        post({
+          kind: 'tangle.app.accountChanged',
+          account: (sync.address ?? null) as Address | null,
+        });
+        if (typeof sync.chainId === 'number') {
+          post({ kind: 'tangle.app.chainChanged', chainId: sync.chainId });
+        }
+        if (sync.serviceContext) {
+          post({
+            kind: 'tangle.app.serviceContext',
+            blueprintId: sync.serviceContext.blueprintId,
+            serviceId: sync.serviceContext.serviceId,
+            operators: sync.serviceContext.operators,
+            jobs: sync.serviceContext.jobs,
+            mode: sync.serviceContext.mode,
+            ...(sync.chainContext ? { chain: sync.chainContext } : {}),
+          });
+        }
         return;
       }
 


### PR DESCRIPTION
Two embed bugs surfaced by the LLM Inference blueprint app.

## 1. Iframe stuck at "no-wallet" (no handoff)
The parent broadcasts `accountChanged` / `chainChanged` / `serviceContext` only from **mount effects**, which fire before the iframe has loaded and attached its `message` listener. The handshake handler acked but **didn't replay state**, so a late-handshaking iframe received the ack (and the SDK's client stops its handshake retry on ack) yet never got the account → permanent `no-wallet`.

Now the handshake handler replays the current wallet + chain + service context from a live `syncRef` right after acking. This is the parent-side mirror of the client's handshake-retry hardening.

## 2. Iframe left dead space / page scrolled
The frame had a hard `minHeight: 720px` and no `height: 100%`, so on a tall viewport it sat short inside its `calc(100vh-108px)` container (gap below), and the page's `pb-10` added more — making the **parent** scroll.

- Frame now fills its host: `height: 100%`, rounded (`12px`), no min-height floor.
- Host container gets a small padding gutter (`p-2 md:p-3`) + `overflow-hidden`, so the rounded iframe reads as a contained surface filling most of the parent.
- Layout reclaims the page's bottom padding (`-mb-10`) so the parent doesn't scroll — only the app inside the iframe scrolls.

Shared by all iframe blueprint apps (AI Trading, AI Agent Sandbox, LLM Inference).

## Test plan
- [x] `tsc --noEmit -p tsconfig.app.json` clean; full pre-push (lint/test/build) passed
- [ ] Visual: embed an iframe blueprint in Tangle Cloud — wallet shows connected; frame fills the area with a small rounded gutter; no parent scroll