### PR TITLE
fix(tangle-cloud): opaque chrome — drop glassmorphism on nav/strips/toolbar

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
@@ -89,7 +89,7 @@ const IframeBlueprintLayout: FC<Props> = ({
       {/* Top strip: identity + mode picker + primary CTA + Details disclosure.
        * 52px tall. Sits flush with the viewport top under the Layout's
        * topbar — no gap, no card wrapper — so the iframe immediately follows. */}
-      <div className="sticky top-14 z-10 flex h-[52px] items-center gap-3 border-b border-border bg-background/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/70 md:px-8">
+      <div className="sticky top-14 z-10 flex h-[52px] items-center gap-3 border-b border-border bg-background px-4 md:px-8">
         <Link
           to="/blueprints"
           className="hidden text-xs text-muted-foreground hover:text-foreground sm:inline-flex"

--- a/apps/tangle-cloud/src/components/Header.tsx
+++ b/apps/tangle-cloud/src/components/Header.tsx
@@ -53,7 +53,7 @@ export default function Header({
   return (
     <header
       className={twMerge(
-        'tangle-cloud-topbar fixed top-0 right-0 left-0 z-40 flex h-14 items-center justify-between gap-4 border-b border-border bg-[var(--bg-elevated)]/85 px-4 font-sans text-[13px] tracking-tight backdrop-blur-md lg:left-16 lg:px-8',
+        'tangle-cloud-topbar fixed top-0 right-0 left-0 z-40 flex h-14 items-center justify-between gap-4 border-b border-border bg-[var(--bg-elevated)] px-4 font-sans text-[13px] tracking-tight lg:left-16 lg:px-8',
         className,
       )}
       {...props}

--- a/apps/tangle-cloud/src/components/chrome/PageToolbar.tsx
+++ b/apps/tangle-cloud/src/components/chrome/PageToolbar.tsx
@@ -45,7 +45,7 @@ const PageToolbar: FC<Props> = ({
     <div
       className={twMerge(
         chromeHeight.toolbar,
-        'flex w-full items-center gap-3 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/70',
+        'flex w-full items-center gap-3 border-b border-border bg-background',
         sticky && 'sticky top-0 z-20',
         className,
       )}


### PR DESCRIPTION
The fixed top bar, the blueprint identity strip, and the page toolbar all used a semi-transparent background + `backdrop-blur`, so page content bled through them on scroll. Makes all three fully opaque (solid `bg-elevated` / `bg-background`, no blur).

- `Header.tsx` — top bar: `bg-[var(--bg-elevated)]/85 … backdrop-blur-md` → `bg-[var(--bg-elevated)]`.
- `IframeBlueprintLayout.tsx` — blueprint identity strip: `bg-background/95 … backdrop-blur …/70` → `bg-background`.
- `PageToolbar.tsx` — search/filter toolbar: same → `bg-background`.

The pills in the nav are untouched (you liked them).

## Test plan
- [x] full pre-push (lint/test/build) passed
- [ ] Visual: scroll any page — chrome is solid, nothing shows through