### PR TITLE
fix(tangle-cloud): kill unwanted italics on form controls + chips

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
@@ -89,7 +89,7 @@ const IframeBlueprintLayout: FC<Props> = ({
       {/* Top strip: identity + mode picker + primary CTA + Details disclosure.
        * 52px tall. Sits flush with the viewport top under the Layout's
        * topbar — no gap, no card wrapper — so the iframe immediately follows. */}
-      <div className="sticky top-14 z-10 flex h-[52px] items-center gap-3 border-b border-border bg-background/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/70 md:px-8">
+      <div className="sticky top-14 z-10 flex h-[52px] items-center gap-3 border-b border-border bg-background px-4 md:px-8">
         <Link
           to="/blueprints"
           className="hidden text-xs text-muted-foreground hover:text-foreground sm:inline-flex"

--- a/apps/tangle-cloud/src/components/Header.tsx
+++ b/apps/tangle-cloud/src/components/Header.tsx
@@ -53,7 +53,7 @@ export default function Header({
   return (
     <header
       className={twMerge(
-        'tangle-cloud-topbar fixed top-0 right-0 left-0 z-40 flex h-14 items-center justify-between gap-4 border-b border-border bg-[var(--bg-elevated)]/85 px-4 font-sans text-[13px] tracking-tight backdrop-blur-md lg:left-16 lg:px-8',
+        'tangle-cloud-topbar fixed top-0 right-0 left-0 z-40 flex h-14 items-center justify-between gap-4 border-b border-border bg-[var(--bg-elevated)] px-4 font-sans text-[13px] tracking-tight lg:left-16 lg:px-8',
         className,
       )}
       {...props}

--- a/apps/tangle-cloud/src/components/chrome/PageToolbar.tsx
+++ b/apps/tangle-cloud/src/components/chrome/PageToolbar.tsx
@@ -45,7 +45,7 @@ const PageToolbar: FC<Props> = ({
     <div
       className={twMerge(
         chromeHeight.toolbar,
-        'flex w-full items-center gap-3 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/70',
+        'flex w-full items-center gap-3 border-b border-border bg-background',
         sticky && 'sticky top-0 z-20',
         className,
       )}

--- a/apps/tangle-cloud/src/styles.css
+++ b/apps/tangle-cloud/src/styles.css
@@ -93,8 +93,15 @@ body {
 .tangle-cloud-shell :where(h1, h2, h3, h4, h5, h6, p, label, li, td, th, button, a, span) {
   color: inherit;
 }
-.tangle-cloud-shell :where(button, a, span, p, h1, h2, h3, h4, h5, h6):not(.italic) {
-  font-style: normal;
+.tangle-cloud-shell
+  :where(
+    h1, h2, h3, h4, h5, h6, p, span, a, button, label, li, td, th,
+    input, select, textarea, div
+  ):not(.italic) {
+  /* `!important` + form controls: the previous rule (no !important, no
+   * inputs/selects) let slanted fallback glyphs through on the search bar
+   * and category chips. Italics are opt-in via `.italic` only. */
+  font-style: normal !important;
 }
 
 /* Tailwind/shadcn utility classes used by the cloud — sandbox-ui's prebuilt


### PR DESCRIPTION
The existing de-italic rule (`styles.css`) only targeted `button/a/span/p/h1–h6` and had no `!important`, so slanted **fallback** glyphs leaked through on the **search bar** (`<input>`) and **category chips**. Broadens the selector to form controls (`input/select/textarea/label/li/div`) and forces `font-style: normal !important`. Italics stay opt-in via the explicit `.italic` class.

## Test plan
- [x] full pre-push (lint/test/build) passed
- [ ] Visual: search bar + category chips render upright (no slant)