### PR TITLE
feat(tangle-cloud): blueprint identity in nav pills + collapsed catalog filters

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
@@ -1,7 +1,8 @@
 import { Button } from '@tangle-network/sandbox-ui/primitives';
-import { useState, type FC, type ReactNode } from 'react';
+import { useMemo, useState, type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
 import { twMerge } from 'tailwind-merge';
+import { useTopNavSlot } from '../../components/chrome/TopNavSlot';
 import type {
   BlueprintMode,
   BlueprintUiAction,
@@ -84,23 +85,23 @@ const IframeBlueprintLayout: FC<Props> = ({
       } as React.CSSProperties)
     : undefined;
 
-  return (
-    <div className="relative -mx-4 -mb-10 -mt-6 md:-mx-8" style={accentStyle}>
-      {/* Top strip: identity + mode picker + primary CTA + Details disclosure.
-       * 52px tall. Sits flush with the viewport top under the Layout's
-       * topbar — no gap, no card wrapper — so the iframe immediately follows. */}
-      <div className="sticky top-14 z-10 flex h-[52px] items-center gap-3 border-b border-border bg-background px-4 md:px-8">
+  // Blueprint identity + primary CTA + Details disclosure live in the global
+  // top nav (as pills) rather than a second in-page bar — that bar wasted a
+  // full row and pushed the iframe down. See useTopNavSlot / Header left slot.
+  const navContent = useMemo(
+    () => (
+      <>
         <Link
           to="/blueprints"
-          className="hidden text-xs text-muted-foreground hover:text-foreground sm:inline-flex"
+          className="hidden shrink-0 text-xs text-muted-foreground hover:text-foreground sm:inline-flex"
         >
           ← Catalog
         </Link>
-        <h1 className="truncate font-display text-sm font-bold text-foreground">
+        <span className="truncate font-display text-sm font-bold text-foreground">
           {displayName}
-        </h1>
+        </span>
         {modes.length > 1 && activeMode && (
-          <div className="hidden md:block">
+          <div className="hidden shrink-0 md:block">
             <CompactModePicker
               modes={modes}
               activeId={activeMode.id}
@@ -108,8 +109,8 @@ const IframeBlueprintLayout: FC<Props> = ({
             />
           </div>
         )}
-        <div className="ml-auto flex items-center gap-2">
-          <Button asChild variant="ghost" size="sm">
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          <Button asChild variant="sandbox" size="sm">
             <Link to={provisionPath}>Create {serviceNoun}</Link>
           </Button>
           <button
@@ -127,21 +128,32 @@ const IframeBlueprintLayout: FC<Props> = ({
             Details
           </button>
         </div>
-      </div>
+      </>
+    ),
+    [
+      displayName,
+      modes,
+      activeMode,
+      onSelectMode,
+      provisionPath,
+      serviceNoun,
+      detailsOpen,
+    ],
+  );
+  useTopNavSlot(navContent);
 
-      {/* Iframe takes the remaining viewport height. The container's height
-       * is `calc(viewport - topbar - identityStrip)` so there's no scroll
-       * within the dapp shell — only inside the iframe itself, which the
-       * publisher's app is responsible for managing. */}
+  return (
+    <div className="relative -mx-4 -mb-10 -mt-6 md:-mx-8" style={accentStyle}>
+      {/* No in-page identity bar — it lives in the top nav now. The iframe
+       * fills the full height below the topbar. The small padding leaves a
+       * rounded gutter around the rounded iframe so it reads as a contained
+       * surface; the parent never scrolls — the app inside the iframe manages
+       * its own scroll. */}
       <div
         className={twMerge(
           'relative overflow-hidden',
-          // 56 (top nav from Layout) + 52 (identity strip) = 108. The frame
-          // fills this box; the small padding leaves a rounded gutter around
-          // the rounded iframe so it reads as a contained surface, not an
-          // edge-to-edge takeover. The parent never scrolls — the app inside
-          // the iframe manages its own scroll.
-          'h-[calc(100vh-108px)] min-h-[480px] p-2 md:p-3',
+          // 56 = top nav (Layout). No identity strip anymore.
+          'h-[calc(100vh-56px)] min-h-[480px] p-2 md:p-3',
         )}
       >
         <BlueprintAppFrameHost

--- a/apps/tangle-cloud/src/components/Header.tsx
+++ b/apps/tangle-cloud/src/components/Header.tsx
@@ -28,6 +28,7 @@ import { useLocation } from 'react-router';
 import { twMerge } from 'tailwind-merge';
 import { useAccount, useChainId, useSwitchChain } from 'wagmi';
 import TxHistoryDrawer from './TxHistoryDrawer';
+import { useTopNavSlotContent } from './chrome/TopNavSlot';
 import {
   Network,
   NetworkId,
@@ -45,6 +46,7 @@ export default function Header({
 }) {
   const pathname = useLocation().pathname;
   const breadcrumbs = useMemo(() => getHeaderBreadcrumbs(pathname), [pathname]);
+  const topNavContent = useTopNavSlotContent();
   const hasContextualConnect =
     pathname.startsWith('/rewards') ||
     pathname.startsWith('/earnings') ||
@@ -58,13 +60,12 @@ export default function Header({
       )}
       {...props}
     >
-      {/* Topbar left slot reserved for future global controls (search, branch
-       * selector, etc.). Breadcrumbs were removed: the sidebar already shows
-       * the active section, and the page H1 (PageHeader) names the leaf —
-       * the `Cloud / Blueprints / Details`-style breadcrumb was double
-       * labeling without conveying new information, and reading the leaf
-       * "Details" wasn't actually useful navigation. */}
-      <div className="ml-12 flex min-w-0 flex-1 items-center gap-2 sm:ml-0" />
+      {/* Topbar left slot: pages inject contextual pills/actions here via
+       * useTopNavSlot (e.g. a blueprint's catalog-back + name + create action),
+       * so per-page context lives in the nav instead of an extra in-page bar. */}
+      <div className="ml-12 flex min-w-0 flex-1 items-center gap-2 sm:ml-0">
+        {topNavContent}
+      </div>
       {/* Kept for potential future use; intentionally unread so the lint
        * doesn't yell about the unused memo. */}
       <span hidden aria-hidden>

--- a/apps/tangle-cloud/src/components/Layout.tsx
+++ b/apps/tangle-cloud/src/components/Layout.tsx
@@ -96,7 +96,10 @@ const Layout: FC<PropsWithChildren<Props>> = ({
         >
           <TxHistoryNotifier />
           <TxConfirmationModal />
-          <CommandPalette open={isPaletteOpen} onOpenChange={setIsPaletteOpen} />
+          <CommandPalette
+            open={isPaletteOpen}
+            onOpenChange={setIsPaletteOpen}
+          />
           <ShortcutsHelp open={isHelpOpen} onOpenChange={setIsHelpOpen} />
 
           <main className="flex-1">

--- a/apps/tangle-cloud/src/components/Layout.tsx
+++ b/apps/tangle-cloud/src/components/Layout.tsx
@@ -8,6 +8,7 @@ import CommandPalette from './chrome/CommandPalette';
 import PageMotion from './chrome/PageMotion';
 import ShortcutsHelp from './chrome/ShortcutsHelp';
 import { useKeyboardShortcuts } from './chrome/useKeyboardShortcuts';
+import { TopNavSlotProvider } from './chrome/TopNavSlot';
 
 type Props = {
   isSidebarInitiallyExpanded?: boolean;
@@ -71,37 +72,39 @@ const Layout: FC<PropsWithChildren<Props>> = ({
   });
 
   return (
-    <div
-      data-sandbox-ui
-      data-sandbox-theme={theme === 'dark' ? 'tangle' : 'vault'}
-      className="tangle-cloud-shell min-h-screen bg-tangle text-foreground"
-    >
-      <Sidebar
-        isExpandedByDefault={isSidebarExpanded}
-        onExpandedChange={setIsSidebarExpanded}
-      />
-      <Header
-        theme={theme}
-        onThemeChange={setTheme}
-        className={isSidebarExpanded ? 'lg:left-64' : 'lg:left-16'}
-      />
-
+    <TopNavSlotProvider>
       <div
-        className={twMerge(
-          'min-h-screen pt-14 transition-[padding-left] duration-200',
-          isSidebarExpanded ? 'lg:pl-64' : 'lg:pl-16',
-        )}
+        data-sandbox-ui
+        data-sandbox-theme={theme === 'dark' ? 'tangle' : 'vault'}
+        className="tangle-cloud-shell min-h-screen bg-tangle text-foreground"
       >
-        <TxHistoryNotifier />
-        <TxConfirmationModal />
-        <CommandPalette open={isPaletteOpen} onOpenChange={setIsPaletteOpen} />
-        <ShortcutsHelp open={isHelpOpen} onOpenChange={setIsHelpOpen} />
+        <Sidebar
+          isExpandedByDefault={isSidebarExpanded}
+          onExpandedChange={setIsSidebarExpanded}
+        />
+        <Header
+          theme={theme}
+          onThemeChange={setTheme}
+          className={isSidebarExpanded ? 'lg:left-64' : 'lg:left-16'}
+        />
 
-        <main className="flex-1">
-          <PageMotion>{children}</PageMotion>
-        </main>
+        <div
+          className={twMerge(
+            'min-h-screen pt-14 transition-[padding-left] duration-200',
+            isSidebarExpanded ? 'lg:pl-64' : 'lg:pl-16',
+          )}
+        >
+          <TxHistoryNotifier />
+          <TxConfirmationModal />
+          <CommandPalette open={isPaletteOpen} onOpenChange={setIsPaletteOpen} />
+          <ShortcutsHelp open={isHelpOpen} onOpenChange={setIsHelpOpen} />
+
+          <main className="flex-1">
+            <PageMotion>{children}</PageMotion>
+          </main>
+        </div>
       </div>
-    </div>
+    </TopNavSlotProvider>
   );
 };
 

--- a/apps/tangle-cloud/src/components/chrome/TopNavSlot.tsx
+++ b/apps/tangle-cloud/src/components/chrome/TopNavSlot.tsx
@@ -1,0 +1,46 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+
+/**
+ * Lets a page inject content (pills, contextual actions) into the global top
+ * nav's left slot. The Header and the page live in different subtrees under
+ * Layout, so this bridges them: pages call `useTopNavSlot(node)` to publish,
+ * the Header renders `useTopNavSlotContent()`.
+ *
+ * Pass a memoized node to `useTopNavSlot` (e.g. `useMemo`) so the publish
+ * effect doesn't re-fire every render.
+ */
+type TopNavSlotCtx = {
+  content: ReactNode;
+  setContent: (node: ReactNode) => void;
+};
+
+const TopNavSlotContext = createContext<TopNavSlotCtx | null>(null);
+
+export function TopNavSlotProvider({ children }: { children: ReactNode }) {
+  const [content, setContent] = useState<ReactNode>(null);
+  return (
+    <TopNavSlotContext.Provider value={{ content, setContent }}>
+      {children}
+    </TopNavSlotContext.Provider>
+  );
+}
+
+export function useTopNavSlotContent(): ReactNode {
+  return useContext(TopNavSlotContext)?.content ?? null;
+}
+
+/** Publish `node` into the top-nav left slot while this component is mounted. */
+export function useTopNavSlot(node: ReactNode): void {
+  const ctx = useContext(TopNavSlotContext);
+  useEffect(() => {
+    if (!ctx) return;
+    ctx.setContent(node);
+    return () => ctx.setContent(null);
+  }, [ctx, node]);
+}

--- a/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
@@ -5,10 +5,6 @@ import {
   CardContent,
   Skeleton,
 } from '../../components/sandbox/SandboxUi';
-import {
-  SegmentedControl,
-  type SegmentedControlOption,
-} from '@tangle-network/sandbox-ui/primitives';
 import { formatBlueprintName } from '../../components/blueprints/blueprintVisualUtils';
 import { EmptyState, FilterTray, PageToolbar } from '../../components/chrome';
 import {
@@ -17,17 +13,19 @@ import {
   stringCodec,
   useUrlState,
 } from '../../components/chrome/useUrlState';
-import { typeRole } from '../../styles/chrome';
+import { focus, typeRole } from '../../styles/chrome';
 import type { UseAllBlueprintsReturn } from '@tangle-network/tangle-shared-ui/data/graphql';
 import type { Blueprint } from '@tangle-network/tangle-shared-ui/types/blueprint';
 import {
   Dispatch,
   FC,
   SetStateAction,
+  useCallback,
   useDeferredValue,
   useEffect,
   useMemo,
 } from 'react';
+import * as Popover from '@radix-ui/react-popover';
 import { useQueries } from '@tanstack/react-query';
 import { useChainId, usePublicClient } from 'wagmi';
 import type { Address } from 'viem';
@@ -51,7 +49,6 @@ import {
 } from '../../blueprintApps/dedupe';
 
 const PAGE_SIZE = 12;
-const ALL_CATEGORIES = 'All categories';
 
 type AudienceFilter = 'all' | 'customers' | 'operators';
 type ManifestFilter = 'all' | 'verified' | 'fallback';
@@ -174,6 +171,104 @@ const matchesSearch = (blueprint: Blueprint, query: string) => {
   return haystack.includes(query);
 };
 
+/**
+ * Multi-select category dropdown for the toolbar. Replaces the old
+ * full-width segmented row — categories collapse into one pill with a
+ * checkbox list, so search + categories + filters fit a single toolbar row.
+ */
+const CategoryFilterMenu: FC<{
+  categories: { category: string; count: number }[];
+  selected: string[];
+  onToggle: (category: string) => void;
+  onClear: () => void;
+}> = ({ categories, selected, onToggle, onClear }) => {
+  const count = selected.length;
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          className={twMerge(
+            'inline-flex h-9 items-center gap-2 rounded-md border border-border bg-transparent px-3 text-sm font-medium text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
+            focus.ring,
+          )}
+        >
+          <span>Categories</span>
+          {count > 0 && (
+            <span
+              className={twMerge(
+                typeRole.mono,
+                'flex h-5 min-w-[20px] items-center justify-center rounded-full bg-[color:var(--border-accent)] px-1.5 text-[11px] text-foreground',
+              )}
+            >
+              {count}
+            </span>
+          )}
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="end"
+          sideOffset={8}
+          className={twMerge(
+            'z-50 max-h-[60vh] w-64 overflow-y-auto rounded-lg border border-border bg-[color:var(--bg-card)] p-2 shadow-[var(--shadow-dropdown)]',
+            'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+          )}
+        >
+          <div className="mb-1 flex items-center justify-between px-2 py-1">
+            <span className={typeRole.label}>Categories</span>
+            {count > 0 && (
+              <button
+                type="button"
+                onClick={onClear}
+                className="text-xs text-muted-foreground hover:text-foreground"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+          {categories.length === 0 ? (
+            <p className="px-2 py-3 text-sm text-muted-foreground">
+              No categories
+            </p>
+          ) : (
+            categories.map(({ category, count: c }) => {
+              const checked = selected.includes(category);
+              return (
+                <button
+                  key={category}
+                  type="button"
+                  onClick={() => onToggle(category)}
+                  className={twMerge(
+                    'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
+                    focus.ring,
+                  )}
+                >
+                  <span className="flex items-center gap-2">
+                    <span
+                      className={twMerge(
+                        'flex h-4 w-4 items-center justify-center rounded border border-border text-[10px] leading-none',
+                        checked &&
+                          'border-[color:var(--border-accent-hover)] bg-[color:var(--border-accent)]',
+                      )}
+                    >
+                      {checked ? '✓' : ''}
+                    </span>
+                    {category}
+                  </span>
+                  <span className="font-mono text-[10px] text-muted-foreground">
+                    {c}
+                  </span>
+                </button>
+              );
+            })
+          )}
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+};
+
 const BlueprintListing: FC<Props> = ({
   rowSelection,
   onRowSelectionChange,
@@ -188,9 +283,24 @@ const BlueprintListing: FC<Props> = ({
   // every keystroke doesn't pollute the history stack.
   const [page, setPage] = useUrlState('page', intCodec(0));
   const [searchQuery, setSearchQuery] = useUrlState('q', stringCodec(''));
-  const [selectedCategory, setSelectedCategory] = useUrlState(
+  // Multi-select categories, comma-joined in the URL (empty = all). Single
+  // dropdown in the toolbar replaces the old full-width category row.
+  const [categoryParam, setCategoryParam] = useUrlState(
     'category',
-    stringCodec(ALL_CATEGORIES),
+    stringCodec(''),
+  );
+  const selectedCategories = useMemo(
+    () => (categoryParam ? categoryParam.split(',').filter(Boolean) : []),
+    [categoryParam],
+  );
+  const toggleCategory = useCallback(
+    (category: string) => {
+      const next = selectedCategories.includes(category)
+        ? selectedCategories.filter((c) => c !== category)
+        : [...selectedCategories, category];
+      setCategoryParam(next.join(','));
+    },
+    [selectedCategories, setCategoryParam],
   );
   const [audienceFilter, setAudienceFilter] = useUrlState<AudienceFilter>(
     'avail',
@@ -241,8 +351,8 @@ const BlueprintListing: FC<Props> = ({
       }
 
       if (
-        selectedCategory !== ALL_CATEGORIES &&
-        getBlueprintCategory(blueprint) !== selectedCategory
+        selectedCategories.length > 0 &&
+        !selectedCategories.includes(getBlueprintCategory(blueprint))
       ) {
         return false;
       }
@@ -285,7 +395,7 @@ const BlueprintListing: FC<Props> = ({
     blueprintItems,
     deferredSearchQuery,
     manifestFilter,
-    selectedCategory,
+    categoryParam,
   ]);
 
   useEffect(() => {
@@ -295,7 +405,7 @@ const BlueprintListing: FC<Props> = ({
     auditFilter,
     deferredSearchQuery,
     manifestFilter,
-    selectedCategory,
+    categoryParam,
   ]);
 
   // Collapse the catalog by metadata identity (publisher.namespace,
@@ -316,7 +426,7 @@ const BlueprintListing: FC<Props> = ({
   );
   const hasActiveFilters =
     searchQuery.trim() !== '' ||
-    selectedCategory !== ALL_CATEGORIES ||
+    selectedCategories.length > 0 ||
     audienceFilter !== 'all' ||
     manifestFilter !== 'all' ||
     auditFilter !== 'all';
@@ -366,7 +476,7 @@ const BlueprintListing: FC<Props> = ({
 
   const resetAllFilters = () => {
     setSearchQuery('');
-    setSelectedCategory(ALL_CATEGORIES);
+    setCategoryParam('');
     setAudienceFilter('all');
     setManifestFilter('all');
     setAuditFilter('all');
@@ -386,92 +496,69 @@ const BlueprintListing: FC<Props> = ({
           noun: 'matches',
         }}
         trailing={
-          <FilterTray
-            activeCount={activeFilterCount}
-            onClear={resetAllFilters}
-            trayTitle="Catalog filters"
-          >
-            <label className="block space-y-1.5">
-              <span className={typeRole.label}>Availability</span>
-              <select
-                value={audienceFilter}
-                onChange={(event) =>
-                  setAudienceFilter(event.currentTarget.value as AudienceFilter)
-                }
-                className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none hover:bg-[color:var(--bg-hover)] focus:border-[color:var(--border-accent-hover)]"
-              >
-                <option value="all">All availability</option>
-                <option value="customers">Has operators</option>
-                <option value="operators">Needs capacity</option>
-              </select>
-            </label>
+          <div className="flex items-center gap-2">
+            <CategoryFilterMenu
+              categories={categories}
+              selected={selectedCategories}
+              onToggle={toggleCategory}
+              onClear={() => setCategoryParam('')}
+            />
+            <FilterTray
+              activeCount={activeFilterCount}
+              onClear={resetAllFilters}
+              trayTitle="Catalog filters"
+            >
+              <label className="block space-y-1.5">
+                <span className={typeRole.label}>Availability</span>
+                <select
+                  value={audienceFilter}
+                  onChange={(event) =>
+                    setAudienceFilter(
+                      event.currentTarget.value as AudienceFilter,
+                    )
+                  }
+                  className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none hover:bg-[color:var(--bg-hover)] focus:border-[color:var(--border-accent-hover)]"
+                >
+                  <option value="all">All availability</option>
+                  <option value="customers">Has operators</option>
+                  <option value="operators">Needs capacity</option>
+                </select>
+              </label>
 
-            <label className="block space-y-1.5">
-              <span className={typeRole.label}>Source</span>
-              <select
-                value={manifestFilter}
-                onChange={(event) =>
-                  setManifestFilter(event.currentTarget.value as ManifestFilter)
-                }
-                className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none hover:bg-[color:var(--bg-hover)] focus:border-[color:var(--border-accent-hover)]"
-              >
-                <option value="all">All sources</option>
-                <option value="verified">Pinned source</option>
-                <option value="fallback">Chain-only</option>
-              </select>
-            </label>
+              <label className="block space-y-1.5">
+                <span className={typeRole.label}>Source</span>
+                <select
+                  value={manifestFilter}
+                  onChange={(event) =>
+                    setManifestFilter(
+                      event.currentTarget.value as ManifestFilter,
+                    )
+                  }
+                  className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none hover:bg-[color:var(--bg-hover)] focus:border-[color:var(--border-accent-hover)]"
+                >
+                  <option value="all">All sources</option>
+                  <option value="verified">Pinned source</option>
+                  <option value="fallback">Chain-only</option>
+                </select>
+              </label>
 
-            <label className="block space-y-1.5">
-              <span className={typeRole.label}>Trust</span>
-              <select
-                value={auditFilter}
-                onChange={(event) =>
-                  setAuditFilter(event.currentTarget.value as AuditFilter)
-                }
-                className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none hover:bg-[color:var(--bg-hover)] focus:border-[color:var(--border-accent-hover)]"
-              >
-                <option value="all">All blueprints</option>
-                <option value="audited">Audited only</option>
-              </select>
-            </label>
-          </FilterTray>
+              <label className="block space-y-1.5">
+                <span className={typeRole.label}>Trust</span>
+                <select
+                  value={auditFilter}
+                  onChange={(event) =>
+                    setAuditFilter(event.currentTarget.value as AuditFilter)
+                  }
+                  className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none hover:bg-[color:var(--bg-hover)] focus:border-[color:var(--border-accent-hover)]"
+                >
+                  <option value="all">All blueprints</option>
+                  <option value="audited">Audited only</option>
+                </select>
+              </label>
+            </FilterTray>
+          </div>
         }
       />
-
-      {/* Category strip — a thin row above the grid. Not wrapped in a card,
-       * not bordered. Categories live on-chain when present; otherwise they
-       * fall back to the regex-derived buckets in getBlueprintCategory until
-       * the metadata schema grows `blueprintUi.tags[]`. */}
-      <div className="overflow-x-auto pb-0.5">
-        <SegmentedControl<string>
-          aria-label="Filter blueprints by category"
-          value={selectedCategory}
-          onValueChange={setSelectedCategory}
-          options={[
-            {
-              value: ALL_CATEGORIES,
-              label: 'All',
-              adornment: (
-                <span className="rounded-full bg-background/70 px-2 py-0.5 font-mono text-[10px] text-foreground">
-                  {blueprintItems.length}
-                </span>
-              ),
-            } satisfies SegmentedControlOption<string>,
-            ...categories.map(
-              ({ category, count }) =>
-                ({
-                  value: category,
-                  label: category.replace(/^AI /, ''),
-                  adornment: (
-                    <span className="rounded-full bg-background/70 px-2 py-0.5 font-mono text-[10px] text-foreground">
-                      {count}
-                    </span>
-                  ),
-                }) satisfies SegmentedControlOption<string>,
-            ),
-          ]}
-        />
-      </div>
 
       {dedupedRows.length === 0 ? (
         <EmptyState


### PR DESCRIPTION
Addresses the catalog/detail chrome feedback.

## 1. Blueprint identity bar → top-nav pills
The blueprint detail page had a separate 52px identity strip (← Catalog + name + Create + Details) that wasted a row and pushed the iframe down. Adds a **top-nav slot** (`useTopNavSlot` + the Header's previously-empty left slot) and moves that content into the global nav as pills. The iframe now fills the full height below the topbar (`calc(100vh-56px)`).

## 2. Collapsed catalog filters
The catalog spent ~3 rows: title + search + a full-width category segmented strip. The category strip is replaced by a compact **multi-select "Categories" dropdown** in the toolbar (Radix popover + checkbox list), so search + categories + filters fit one row. Category selection is now multi-select (comma-joined in the URL); the filter predicate matches any selected category.

## Notes
- Pills in the nav (which you liked) are untouched.
- Builds on the merged opaque-chrome + de-italic + iframe-fill fixes.

## Test plan
- [x] `tsc --noEmit -p tsconfig.app.json` clean
- [x] full pre-push (lint/prettier/test/build) passed
- [ ] Visual: detail page shows identity in the nav, iframe fills; catalog is one toolbar row with a working multi-select Categories dropdown