### PR TITLE
fix(tangle-cloud): readable Create-service nav button

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
@@ -120,16 +120,27 @@ const IframeBlueprintLayout: FC<Props> = ({
           </div>
         )}
         <div className="ml-auto flex shrink-0 items-center gap-2">
-          <Button asChild variant="sandbox" size="sm">
-            <Link to={provisionPath}>Create {serviceNoun}</Link>
-          </Button>
+          {/* Explicit styling rather than the sandbox Button variant: the
+           * vendored variant left dark, italic text on the purple fill
+           * (unreadable). White text on a solid accent, non-italic, sized to
+           * match the Details button. */}
+          <Link
+            to={provisionPath}
+            className={twMerge(
+              'inline-flex h-8 shrink-0 items-center rounded-md px-3 text-xs font-semibold not-italic transition-opacity',
+              'bg-[color:var(--primary)] text-white hover:opacity-90',
+              focus.ring,
+            )}
+          >
+            Create {serviceNoun}
+          </Link>
           <button
             type="button"
             onClick={() => setDetailsOpen((v) => !v)}
             aria-expanded={detailsOpen}
             aria-controls="blueprint-details-panel"
             className={twMerge(
-              'inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-transparent px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
+              'inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-transparent px-2.5 text-xs font-medium not-italic text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
               detailsOpen && 'border-[color:var(--border-accent-hover)]',
               focus.ring,
             )}

--- a/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
@@ -91,15 +91,25 @@ const IframeBlueprintLayout: FC<Props> = ({
   const navContent = useMemo(
     () => (
       <>
-        <Link
-          to="/blueprints"
-          className="hidden shrink-0 text-xs text-muted-foreground hover:text-foreground sm:inline-flex"
+        {/* Breadcrumb trail: Blueprints / <name> — matches the route trail
+         * style used across the app; the section root links to the catalog. */}
+        <nav
+          aria-label="Breadcrumb"
+          className="flex min-w-0 items-center gap-1.5 text-[13px]"
         >
-          ← Catalog
-        </Link>
-        <span className="truncate font-display text-sm font-bold text-foreground">
-          {displayName}
-        </span>
+          <Link
+            to="/blueprints"
+            className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Blueprints
+          </Link>
+          <span aria-hidden className="text-muted-foreground/40">
+            /
+          </span>
+          <span className="truncate font-semibold text-foreground">
+            {displayName}
+          </span>
+        </nav>
         {modes.length > 1 && activeMode && (
           <div className="hidden shrink-0 md:block">
             <CompactModePicker

--- a/apps/tangle-cloud/src/components/Header.tsx
+++ b/apps/tangle-cloud/src/components/Header.tsx
@@ -24,7 +24,7 @@ import {
   DropdownMenuTrigger,
 } from '@tangle-network/sandbox-ui/primitives';
 import { ComponentProps, useCallback, useMemo, useState } from 'react';
-import { useLocation } from 'react-router';
+import { Link, useLocation } from 'react-router';
 import { twMerge } from 'tailwind-merge';
 import { useAccount, useChainId, useSwitchChain } from 'wagmi';
 import TxHistoryDrawer from './TxHistoryDrawer';
@@ -45,7 +45,7 @@ export default function Header({
   onThemeChange: (theme: 'dark' | 'light') => void;
 }) {
   const pathname = useLocation().pathname;
-  const breadcrumbs = useMemo(() => getHeaderBreadcrumbs(pathname), [pathname]);
+  const trail = useMemo(() => getHeaderTrail(pathname), [pathname]);
   const topNavContent = useTopNavSlotContent();
   const hasContextualConnect =
     pathname.startsWith('/rewards') ||
@@ -60,17 +60,12 @@ export default function Header({
       )}
       {...props}
     >
-      {/* Topbar left slot: pages inject contextual pills/actions here via
-       * useTopNavSlot (e.g. a blueprint's catalog-back + name + create action),
-       * so per-page context lives in the nav instead of an extra in-page bar. */}
+      {/* Topbar left slot: the route breadcrumb trail by default
+       * ("Blueprints / Trading"); pages can override it with contextual
+       * content (name + actions) via useTopNavSlot. */}
       <div className="ml-12 flex min-w-0 flex-1 items-center gap-2 sm:ml-0">
-        {topNavContent}
+        {topNavContent ?? <HeaderTrail items={trail} />}
       </div>
-      {/* Kept for potential future use; intentionally unread so the lint
-       * doesn't yell about the unused memo. */}
-      <span hidden aria-hidden>
-        {breadcrumbs.length}
-      </span>
 
       <div className="flex shrink-0 items-center justify-end gap-2">
         <div className="hidden sm:block">
@@ -91,38 +86,86 @@ export default function Header({
   );
 }
 
-const getHeaderBreadcrumbs = (pathname: string): string[] => {
+type TrailItem = { label: string; href?: string };
+
+/**
+ * Breadcrumb trail for the top nav ("Blueprints / Trading"). The leading
+ * "Cloud" is dropped — the whole app is Cloud and the sidebar already names
+ * the section. Non-leaf section roots link back (e.g. Blueprints → catalog).
+ * Blueprint *detail* pages override this via useTopNavSlot with the real name.
+ */
+const getHeaderTrail = (pathname: string): TrailItem[] => {
+  const blueprints: TrailItem = { label: 'Blueprints', href: '/blueprints' };
+  const operators: TrailItem = { label: 'Operators', href: '/operators' };
+  const instances: TrailItem = { label: 'Instances', href: '/instances' };
+
   if (pathname === '/blueprints/create')
-    return ['Cloud', 'Blueprints', 'Create'];
+    return [blueprints, { label: 'Create' }];
   if (pathname === '/blueprints/manage')
-    return ['Cloud', 'Blueprints', 'Manage'];
+    return [blueprints, { label: 'Manage' }];
+  if (pathname.startsWith('/blueprints/') && pathname.endsWith('/deploy'))
+    return [blueprints, { label: 'Instance checkout' }];
+  if (pathname.startsWith('/blueprints/') && pathname.includes('/services/'))
+    return [blueprints, { label: 'Service' }];
+  if (pathname.startsWith('/blueprints/') && pathname !== '/blueprints')
+    return [blueprints, { label: 'Details' }];
+  if (pathname.startsWith('/blueprints')) return [blueprints];
 
-  if (pathname.startsWith('/blueprints/') && pathname.endsWith('/deploy')) {
-    return ['Cloud', 'Blueprints', 'Instance checkout'];
-  }
-
-  if (pathname.startsWith('/blueprints/') && pathname.includes('/services/')) {
-    return ['Cloud', 'Blueprints', 'Service'];
-  }
-
-  if (pathname.startsWith('/blueprints/') && pathname !== '/blueprints') {
-    return ['Cloud', 'Blueprints', 'Details'];
-  }
-
-  if (pathname.startsWith('/blueprints')) return ['Cloud', 'Blueprints'];
-  if (pathname === '/operators/manage') return ['Cloud', 'Operators', 'Manage'];
-  if (pathname.startsWith('/operators')) return ['Cloud', 'Operators'];
-  if (pathname === '/payments/credits') return ['Cloud', 'Payments', 'Credits'];
+  if (pathname === '/operators/manage') return [operators, { label: 'Manage' }];
+  if (pathname.startsWith('/operators')) return [operators];
+  if (pathname === '/payments/credits')
+    return [{ label: 'Payments' }, { label: 'Credits' }];
   if (pathname === '/payments/pool')
-    return ['Cloud', 'Payments', 'Shielded pool'];
-  if (pathname.startsWith('/rewards')) return ['Cloud', 'Rewards'];
-  if (pathname.startsWith('/earnings')) return ['Cloud', 'Earnings'];
+    return [{ label: 'Payments' }, { label: 'Shielded pool' }];
+  if (pathname.startsWith('/rewards')) return [{ label: 'Rewards' }];
+  if (pathname.startsWith('/earnings')) return [{ label: 'Earnings' }];
   if (pathname.startsWith('/services/'))
-    return ['Cloud', 'Instances', 'Service'];
-  if (pathname.startsWith('/instances')) return ['Cloud', 'Instances'];
+    return [instances, { label: 'Service' }];
+  if (pathname.startsWith('/instances')) return [instances];
 
-  return ['Tangle Cloud'];
+  return [{ label: 'Tangle Cloud' }];
 };
+
+/** Renders a breadcrumb trail; non-leaf items with an href are links. */
+function HeaderTrail({ items }: { items: TrailItem[] }) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="flex min-w-0 items-center gap-1.5 text-[13px]"
+    >
+      {items.map((item, i) => {
+        const isLeaf = i === items.length - 1;
+        return (
+          <span key={i} className="flex min-w-0 items-center gap-1.5">
+            {i > 0 && (
+              <span aria-hidden className="text-muted-foreground/40">
+                /
+              </span>
+            )}
+            {item.href && !isLeaf ? (
+              <Link
+                to={item.href}
+                className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+              >
+                {item.label}
+              </Link>
+            ) : (
+              <span
+                className={twMerge(
+                  isLeaf
+                    ? 'truncate font-semibold text-foreground'
+                    : 'shrink-0 text-muted-foreground',
+                )}
+              >
+                {item.label}
+              </span>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}
 
 function ThemeToggle({
   theme,

--- a/apps/tangle-cloud/src/components/chrome/TopNavSlot.tsx
+++ b/apps/tangle-cloud/src/components/chrome/TopNavSlot.tsx
@@ -31,11 +31,14 @@ export function TopNavSlotProvider({ children }: { children: ReactNode }) {
   );
 }
 
+// Context module: the Provider component lives alongside its hooks by design.
+// eslint-disable-next-line react-refresh/only-export-components
 export function useTopNavSlotContent(): ReactNode {
   return useContext(TopNavSlotContext)?.content ?? null;
 }
 
 /** Publish `node` into the top-nav left slot while this component is mounted. */
+// eslint-disable-next-line react-refresh/only-export-components
 export function useTopNavSlot(node: ReactNode): void {
   const ctx = useContext(TopNavSlotContext);
   useEffect(() => {


### PR DESCRIPTION
The 'Create {service}' button in the blueprint nav used the sandbox Button variant, which left dark, italic text on its purple fill — unreadable. Render it as an explicit styled link (white text on a solid accent, non-italic, sized to match the Details button). Also silences the react-refresh lint rule on the TopNavSlot context module so the project lints clean.