### PR TITLE
feat(tangle-cloud): honor iframe requestConnect — open the parent wallet modal

### DIFF
--- a/apps/tangle-cloud/src/app/PaymentProviders.tsx
+++ b/apps/tangle-cloud/src/app/PaymentProviders.tsx
@@ -1,10 +1,13 @@
 import { type FC, type PropsWithChildren } from 'react';
 import { CreditsProvider } from './CreditsProvider';
 import { ShieldedProvider } from './ShieldedProvider';
+import { WalletConnectModalProvider } from '../blueprintApps/iframe/WalletConnectModalContext';
 
 const PaymentProviders: FC<PropsWithChildren> = ({ children }) => (
   <ShieldedProvider>
-    <CreditsProvider>{children}</CreditsProvider>
+    <CreditsProvider>
+      <WalletConnectModalProvider>{children}</WalletConnectModalProvider>
+    </CreditsProvider>
   </ShieldedProvider>
 );
 

--- a/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
@@ -120,16 +120,27 @@ const IframeBlueprintLayout: FC<Props> = ({
           </div>
         )}
         <div className="ml-auto flex shrink-0 items-center gap-2">
-          <Button asChild variant="sandbox" size="sm">
-            <Link to={provisionPath}>Create {serviceNoun}</Link>
-          </Button>
+          {/* Explicit styling rather than the sandbox Button variant: the
+           * vendored variant left dark, italic text on the purple fill
+           * (unreadable). White text on a solid accent, non-italic, sized to
+           * match the Details button. */}
+          <Link
+            to={provisionPath}
+            className={twMerge(
+              'inline-flex h-8 shrink-0 items-center rounded-md px-3 text-xs font-semibold not-italic transition-opacity',
+              'bg-[color:var(--primary)] text-white hover:opacity-90',
+              focus.ring,
+            )}
+          >
+            Create {serviceNoun}
+          </Link>
           <button
             type="button"
             onClick={() => setDetailsOpen((v) => !v)}
             aria-expanded={detailsOpen}
             aria-controls="blueprint-details-panel"
             className={twMerge(
-              'inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-transparent px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
+              'inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-transparent px-2.5 text-xs font-medium not-italic text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
               detailsOpen && 'border-[color:var(--border-accent-hover)]',
               focus.ring,
             )}

--- a/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
@@ -91,15 +91,25 @@ const IframeBlueprintLayout: FC<Props> = ({
   const navContent = useMemo(
     () => (
       <>
-        <Link
-          to="/blueprints"
-          className="hidden shrink-0 text-xs text-muted-foreground hover:text-foreground sm:inline-flex"
+        {/* Breadcrumb trail: Blueprints / <name> — matches the route trail
+         * style used across the app; the section root links to the catalog. */}
+        <nav
+          aria-label="Breadcrumb"
+          className="flex min-w-0 items-center gap-1.5 text-[13px]"
         >
-          ← Catalog
-        </Link>
-        <span className="truncate font-display text-sm font-bold text-foreground">
-          {displayName}
-        </span>
+          <Link
+            to="/blueprints"
+            className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Blueprints
+          </Link>
+          <span aria-hidden className="text-muted-foreground/40">
+            /
+          </span>
+          <span className="truncate font-semibold text-foreground">
+            {displayName}
+          </span>
+        </nav>
         {modes.length > 1 && activeMode && (
           <div className="hidden shrink-0 md:block">
             <CompactModePicker

--- a/apps/tangle-cloud/src/blueprintApps/iframe/WalletConnectModalContext.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/WalletConnectModalContext.tsx
@@ -1,0 +1,54 @@
+import { EvmWalletModal } from '@tangle-network/tangle-shared-ui/components/EvmWalletModal';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+/**
+ * App-level owner of a single wallet-connect modal that can be opened
+ * imperatively — specifically so the iframe bridge can honour a
+ * `tangle.app.requestConnect` from an embedded blueprint (the iframe is
+ * sandboxed and can't reach a wallet itself; it delegates to the parent).
+ *
+ * This is the same `EvmWalletModal` the nav's ConnectWalletButton uses; here
+ * it's mounted once at the app root and driven by context so any consumer —
+ * including the bridge hook, which lives in a different subtree — can open it.
+ */
+type WalletConnectModalCtx = {
+  /** Open the wallet-connect modal. */
+  open: () => void;
+  /** Whether the modal is currently open (lets the bridge detect dismissal). */
+  isOpen: boolean;
+};
+
+const Context = createContext<WalletConnectModalCtx | null>(null);
+
+export function WalletConnectModalProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const open = useCallback(() => setIsOpen(true), []);
+  const value = useMemo<WalletConnectModalCtx>(
+    () => ({ open, isOpen }),
+    [open, isOpen],
+  );
+
+  return (
+    <Context.Provider value={value}>
+      {children}
+      <EvmWalletModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </Context.Provider>
+  );
+}
+
+/** Imperative wallet-connect modal control. Safe no-op outside the provider. */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useWalletConnectModal(): WalletConnectModalCtx {
+  return useContext(Context) ?? { open: () => undefined, isOpen: false };
+}

--- a/apps/tangle-cloud/src/blueprintApps/iframe/policy.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/policy.ts
@@ -132,6 +132,17 @@ export function checkRequestAllowed(
       return accept();
     case 'tangle.app.readAccount':
       return checkReadAccountAllowed(request, config);
+    case 'tangle.app.requestConnect':
+      // Initiating a connect is read-tier: an app allowed to read the account
+      // may prompt the user to connect one. The user still confirms in the
+      // parent's own wallet modal — no silent connection.
+      return checkReadAccountAllowed(
+        {
+          kind: 'tangle.app.readAccount',
+          correlationId: request.correlationId,
+        },
+        config,
+      );
     case 'tangle.app.switchChain':
       return checkSwitchChainAllowed(request, config);
     case 'tangle.app.signMessage':

--- a/apps/tangle-cloud/src/blueprintApps/iframe/protocol.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/protocol.ts
@@ -23,6 +23,11 @@ export type IframeRequestReadAccount = {
   correlationId: string;
 };
 
+export type IframeRequestRequestConnect = {
+  kind: 'tangle.app.requestConnect';
+  correlationId: string;
+};
+
 export type IframeRequestSwitchChain = {
   kind: 'tangle.app.switchChain';
   correlationId: string;
@@ -80,6 +85,7 @@ export type IframeRequestCallJob = {
 export type IframeRequest =
   | IframeRequestHandshake
   | IframeRequestReadAccount
+  | IframeRequestRequestConnect
   | IframeRequestSwitchChain
   | IframeRequestSignMessage
   | IframeRequestSignTransaction
@@ -100,6 +106,10 @@ export type ParentResponseResultBase<T> = {
 
 export type ParentResponseReadAccountResult = {
   kind: 'tangle.app.readAccountResult';
+} & ParentResponseResultBase<{ account: Address; chainId: number }>;
+
+export type ParentResponseConnectResult = {
+  kind: 'tangle.app.connectResult';
 } & ParentResponseResultBase<{ account: Address; chainId: number }>;
 
 export type ParentResponseSwitchChainResult = {
@@ -170,6 +180,7 @@ export type ParentEventJobResult = {
 export type ParentMessage =
   | ParentResponseHandshakeAck
   | ParentResponseReadAccountResult
+  | ParentResponseConnectResult
   | ParentResponseSwitchChainResult
   | ParentResponseSignMessageResult
   | ParentResponseSignTransactionResult
@@ -237,6 +248,13 @@ export function validateIframeRequest(value: unknown): IframeRequest | null {
       if (!isValidCorrelationId(record.correlationId)) return null;
       return {
         kind: 'tangle.app.readAccount',
+        correlationId: record.correlationId,
+      };
+    }
+    case 'tangle.app.requestConnect': {
+      if (!isValidCorrelationId(record.correlationId)) return null;
+      return {
+        kind: 'tangle.app.requestConnect',
         correlationId: record.correlationId,
       };
     }

--- a/apps/tangle-cloud/src/blueprintApps/iframe/useIframeBridge.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/useIframeBridge.ts
@@ -10,6 +10,7 @@ import {
 import { isMessageFromIframe, buildIframeMessageContext } from './origin';
 import { checkRequestAllowed, type IframePolicyVerdict } from './policy';
 import type { BlueprintIframeConfig } from './types';
+import { useWalletConnectModal } from './WalletConnectModalContext';
 
 // Pending operator-approved request that the bridge is waiting on the user
 // to confirm via the dapp's approval modal. Surfaced through the hook's
@@ -85,10 +86,16 @@ export function useIframeBridge({
   const { address } = useAccount();
   const chainId = useChainId();
   const chains = useChains();
+  const { open: openWalletModal, isOpen: walletModalOpen } =
+    useWalletConnectModal();
   const [pendingApproval, setPendingApproval] =
     useState<PendingApproval | null>(null);
   const pendingRef = useRef(pendingApproval);
   pendingRef.current = pendingApproval;
+  // correlationId of an in-flight tangle.app.requestConnect (the iframe asked
+  // us to connect a wallet). Resolved when an account appears, or rejected if
+  // the user dismisses the modal without connecting.
+  const pendingConnectRef = useRef<string | null>(null);
 
   const post = useCallback(
     (message: ParentMessage) => {
@@ -373,6 +380,24 @@ export function useIframeBridge({
         return;
       }
 
+      // The iframe asked us to connect a wallet. If one is already connected,
+      // answer immediately; otherwise open the parent's connect modal and
+      // resolve later (see the address / modal-close effects below).
+      if (request.kind === 'tangle.app.requestConnect') {
+        if (address) {
+          post({
+            kind: 'tangle.app.connectResult',
+            correlationId: request.correlationId,
+            ok: true,
+            data: { account: address as Address, chainId: chainId ?? 0 },
+          });
+          return;
+        }
+        pendingConnectRef.current = request.correlationId;
+        openWalletModal();
+        return;
+      }
+
       // callJob (job invocation via quote/sign/submit) is protocol-defined
       // but its parent-side integration with the deploy/quote pipeline is
       // not yet wired. Respond with a clean error so the iframe surfaces a
@@ -432,9 +457,36 @@ export function useIframeBridge({
     enabled,
     iframeRef,
     onPolicyDeny,
+    openWalletModal,
     post,
     respond,
   ]);
+
+  // Resolve an in-flight requestConnect once a wallet connects.
+  useEffect(() => {
+    if (!enabled || !address || !pendingConnectRef.current) return;
+    post({
+      kind: 'tangle.app.connectResult',
+      correlationId: pendingConnectRef.current,
+      ok: true,
+      data: { account: address as Address, chainId: chainId ?? 0 },
+    });
+    pendingConnectRef.current = null;
+  }, [address, chainId, enabled, post]);
+
+  // If the user dismissed the connect modal without connecting, reject the
+  // in-flight requestConnect so the iframe gets a clean error rather than
+  // hanging until its timeout.
+  useEffect(() => {
+    if (walletModalOpen || !pendingConnectRef.current || address) return;
+    post({
+      kind: 'tangle.app.connectResult',
+      correlationId: pendingConnectRef.current,
+      ok: false,
+      error: 'User dismissed the connect modal.',
+    });
+    pendingConnectRef.current = null;
+  }, [walletModalOpen, address, post]);
 
   return {
     pendingApproval,

--- a/apps/tangle-cloud/src/components/Header.tsx
+++ b/apps/tangle-cloud/src/components/Header.tsx
@@ -24,7 +24,7 @@ import {
   DropdownMenuTrigger,
 } from '@tangle-network/sandbox-ui/primitives';
 import { ComponentProps, useCallback, useMemo, useState } from 'react';
-import { useLocation } from 'react-router';
+import { Link, useLocation } from 'react-router';
 import { twMerge } from 'tailwind-merge';
 import { useAccount, useChainId, useSwitchChain } from 'wagmi';
 import TxHistoryDrawer from './TxHistoryDrawer';
@@ -45,7 +45,7 @@ export default function Header({
   onThemeChange: (theme: 'dark' | 'light') => void;
 }) {
   const pathname = useLocation().pathname;
-  const breadcrumbs = useMemo(() => getHeaderBreadcrumbs(pathname), [pathname]);
+  const trail = useMemo(() => getHeaderTrail(pathname), [pathname]);
   const topNavContent = useTopNavSlotContent();
   const hasContextualConnect =
     pathname.startsWith('/rewards') ||
@@ -60,17 +60,12 @@ export default function Header({
       )}
       {...props}
     >
-      {/* Topbar left slot: pages inject contextual pills/actions here via
-       * useTopNavSlot (e.g. a blueprint's catalog-back + name + create action),
-       * so per-page context lives in the nav instead of an extra in-page bar. */}
+      {/* Topbar left slot: the route breadcrumb trail by default
+       * ("Blueprints / Trading"); pages can override it with contextual
+       * content (name + actions) via useTopNavSlot. */}
       <div className="ml-12 flex min-w-0 flex-1 items-center gap-2 sm:ml-0">
-        {topNavContent}
+        {topNavContent ?? <HeaderTrail items={trail} />}
       </div>
-      {/* Kept for potential future use; intentionally unread so the lint
-       * doesn't yell about the unused memo. */}
-      <span hidden aria-hidden>
-        {breadcrumbs.length}
-      </span>
 
       <div className="flex shrink-0 items-center justify-end gap-2">
         <div className="hidden sm:block">
@@ -91,38 +86,86 @@ export default function Header({
   );
 }
 
-const getHeaderBreadcrumbs = (pathname: string): string[] => {
+type TrailItem = { label: string; href?: string };
+
+/**
+ * Breadcrumb trail for the top nav ("Blueprints / Trading"). The leading
+ * "Cloud" is dropped — the whole app is Cloud and the sidebar already names
+ * the section. Non-leaf section roots link back (e.g. Blueprints → catalog).
+ * Blueprint *detail* pages override this via useTopNavSlot with the real name.
+ */
+const getHeaderTrail = (pathname: string): TrailItem[] => {
+  const blueprints: TrailItem = { label: 'Blueprints', href: '/blueprints' };
+  const operators: TrailItem = { label: 'Operators', href: '/operators' };
+  const instances: TrailItem = { label: 'Instances', href: '/instances' };
+
   if (pathname === '/blueprints/create')
-    return ['Cloud', 'Blueprints', 'Create'];
+    return [blueprints, { label: 'Create' }];
   if (pathname === '/blueprints/manage')
-    return ['Cloud', 'Blueprints', 'Manage'];
+    return [blueprints, { label: 'Manage' }];
+  if (pathname.startsWith('/blueprints/') && pathname.endsWith('/deploy'))
+    return [blueprints, { label: 'Instance checkout' }];
+  if (pathname.startsWith('/blueprints/') && pathname.includes('/services/'))
+    return [blueprints, { label: 'Service' }];
+  if (pathname.startsWith('/blueprints/') && pathname !== '/blueprints')
+    return [blueprints, { label: 'Details' }];
+  if (pathname.startsWith('/blueprints')) return [blueprints];
 
-  if (pathname.startsWith('/blueprints/') && pathname.endsWith('/deploy')) {
-    return ['Cloud', 'Blueprints', 'Instance checkout'];
-  }
-
-  if (pathname.startsWith('/blueprints/') && pathname.includes('/services/')) {
-    return ['Cloud', 'Blueprints', 'Service'];
-  }
-
-  if (pathname.startsWith('/blueprints/') && pathname !== '/blueprints') {
-    return ['Cloud', 'Blueprints', 'Details'];
-  }
-
-  if (pathname.startsWith('/blueprints')) return ['Cloud', 'Blueprints'];
-  if (pathname === '/operators/manage') return ['Cloud', 'Operators', 'Manage'];
-  if (pathname.startsWith('/operators')) return ['Cloud', 'Operators'];
-  if (pathname === '/payments/credits') return ['Cloud', 'Payments', 'Credits'];
+  if (pathname === '/operators/manage') return [operators, { label: 'Manage' }];
+  if (pathname.startsWith('/operators')) return [operators];
+  if (pathname === '/payments/credits')
+    return [{ label: 'Payments' }, { label: 'Credits' }];
   if (pathname === '/payments/pool')
-    return ['Cloud', 'Payments', 'Shielded pool'];
-  if (pathname.startsWith('/rewards')) return ['Cloud', 'Rewards'];
-  if (pathname.startsWith('/earnings')) return ['Cloud', 'Earnings'];
+    return [{ label: 'Payments' }, { label: 'Shielded pool' }];
+  if (pathname.startsWith('/rewards')) return [{ label: 'Rewards' }];
+  if (pathname.startsWith('/earnings')) return [{ label: 'Earnings' }];
   if (pathname.startsWith('/services/'))
-    return ['Cloud', 'Instances', 'Service'];
-  if (pathname.startsWith('/instances')) return ['Cloud', 'Instances'];
+    return [instances, { label: 'Service' }];
+  if (pathname.startsWith('/instances')) return [instances];
 
-  return ['Tangle Cloud'];
+  return [{ label: 'Tangle Cloud' }];
 };
+
+/** Renders a breadcrumb trail; non-leaf items with an href are links. */
+function HeaderTrail({ items }: { items: TrailItem[] }) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="flex min-w-0 items-center gap-1.5 text-[13px]"
+    >
+      {items.map((item, i) => {
+        const isLeaf = i === items.length - 1;
+        return (
+          <span key={i} className="flex min-w-0 items-center gap-1.5">
+            {i > 0 && (
+              <span aria-hidden className="text-muted-foreground/40">
+                /
+              </span>
+            )}
+            {item.href && !isLeaf ? (
+              <Link
+                to={item.href}
+                className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+              >
+                {item.label}
+              </Link>
+            ) : (
+              <span
+                className={twMerge(
+                  isLeaf
+                    ? 'truncate font-semibold text-foreground'
+                    : 'shrink-0 text-muted-foreground',
+                )}
+              >
+                {item.label}
+              </span>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}
 
 function ThemeToggle({
   theme,

--- a/apps/tangle-cloud/src/components/chrome/TopNavSlot.tsx
+++ b/apps/tangle-cloud/src/components/chrome/TopNavSlot.tsx
@@ -31,11 +31,14 @@ export function TopNavSlotProvider({ children }: { children: ReactNode }) {
   );
 }
 
+// Context module: the Provider component lives alongside its hooks by design.
+// eslint-disable-next-line react-refresh/only-export-components
 export function useTopNavSlotContent(): ReactNode {
   return useContext(TopNavSlotContext)?.content ?? null;
 }
 
 /** Publish `node` into the top-nav left slot while this component is mounted. */
+// eslint-disable-next-line react-refresh/only-export-components
 export function useTopNavSlot(node: ReactNode): void {
   const ctx = useContext(TopNavSlotContext);
   useEffect(() => {


### PR DESCRIPTION
Lets an embedded blueprint **initiate** a wallet connection without breaking the sandbox model — the missing piece behind "connect inside the iframe doesn't do anything."

A sandboxed iframe can't reach a wallet extension, so it delegates to the parent via the new `tangle.app.requestConnect` (SDK side merged in blueprint-ui #22, published 0.5.2). The bridge:
- answers immediately if a wallet is already connected;
- otherwise opens the parent's wallet-connect modal (new app-level `WalletConnectModalContext` mounting one `EvmWalletModal`) and resolves the request when an account appears — or rejects it if the user dismisses the modal, so the iframe never hangs on its timeout.

Gated **read-tier** in policy (`allowReadAccount`). Protocol + validator mirror the SDK.

This is what makes **both** tiers connect from inside the iframe:
- **thin-iframe** (e.g. llm-inference): `useTangleWallet().connect()`;
- **full-iframe** wagmi apps (ai-trading, ai-agent-sandbox): their own "Connect" → `eth_requestAccounts` on the parent-bridge connector now drives this.

## Test plan
- [x] `tsc --noEmit` clean; protocol + policy specs green (16); full pre-push (lint/test/build) passed
- [ ] Visual: embed a blueprint while disconnected → its connect opens the cloud wallet modal → connecting flows the account into the iframe