### PR TITLE
[RELEASE] chore(tangle-cloud): v0.0.4 — iframe wallet connect

### DIFF
--- a/apps/tangle-cloud/CHANGELOG.md
+++ b/apps/tangle-cloud/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.4 (2026-05-30)
+
+### 🚀 Features
+
+- **tangle-cloud:** iframe wallet connect — pass `?parent=` to embedded apps so they can detect Tangle Cloud and install the parent-bridge connector (referrer is empty under `no-referrer` + the opaque sandbox origin), plus the `tangle.app.requestConnect` bridge that opens the parent wallet modal ([#3252](https://github.com/tangle-network/dapp/pull/3252))
+- **tangle-cloud:** allow embedded trading-arena to switch to Base Sepolia (84532) — read-only, no signing surface ([#3252](https://github.com/tangle-network/dapp/pull/3252))
+
 ## 0.0.3 (2025-08-06)
 
 ### 🩹 Fixes

--- a/apps/tangle-cloud/package.json
+++ b/apps/tangle-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/tangle-cloud",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "Apache-2.0",
   "type": "module"
 }

--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrame.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrame.tsx
@@ -102,7 +102,8 @@ const BlueprintAppFrameInner = (
         // Deterministic parent-origin signal for the embedded app's bridge
         // detection — `document.referrer` is empty (no-referrer + opaque
         // sandbox origin), so `?parent=` is how the iframe learns it's us.
-        parent: typeof window !== 'undefined' ? window.location.origin : undefined,
+        parent:
+          typeof window !== 'undefined' ? window.location.origin : undefined,
       })}
       sandbox={buildSandbox(config)}
       allow={PERMISSIONS_POLICY_DENY_ALL}

--- a/apps/tangle-cloud/src/blueprintApps/iframe/url.spec.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/url.spec.ts
@@ -6,7 +6,11 @@ describe('buildBlueprintIframeUrl', () => {
 
   it('sets the reserved params', () => {
     const url = new URL(
-      buildBlueprintIframeUrl(base, { mode: 'instance', blueprintId: 13, theme: 'dark' }),
+      buildBlueprintIframeUrl(base, {
+        mode: 'instance',
+        blueprintId: 13,
+        theme: 'dark',
+      }),
     );
     expect(url.searchParams.get('mode')).toBe('instance');
     expect(url.searchParams.get('blueprintId')).toBe('13');
@@ -38,8 +42,10 @@ describe('buildBlueprintIframeUrl', () => {
   });
 
   it('returns the raw string for a malformed URL', () => {
-    expect(buildBlueprintIframeUrl('not a url', { parent: 'https://cloud.tangle.tools' })).toBe(
-      'not a url',
-    );
+    expect(
+      buildBlueprintIframeUrl('not a url', {
+        parent: 'https://cloud.tangle.tools',
+      }),
+    ).toBe('not a url');
   });
 });


### PR DESCRIPTION
## Release: tangle-cloud v0.0.4

Ships the iframe wallet-connect fix (#3252) to production `cloud.tangle.tools`.

**Mechanism:** this `[RELEASE]`-tagged commit, on merge to `develop`, triggers `auto-sync-master-with-develop` → fast-forwards `develop` into `master` → `release-dapps.yml` sees `apps/tangle-cloud/CHANGELOG.md` changed → deploys tangle-cloud.

**What goes live (tangle-cloud):**
- `?parent=` passed to embedded blueprint iframes so they can detect Tangle Cloud and install the parent-bridge wallet connector (`document.referrer` is empty under `no-referrer` + the opaque sandbox origin) — fixes "the embedded arena can't connect at all."
- `tangle.app.requestConnect` bridge (opens the parent wallet modal from inside the iframe).
- trading-arena iframe policy: `allowChainSwitch` to Base Sepolia (84532), read-only (no signing).

**Bump:** `0.0.3 → 0.0.4`, CHANGELOG entry added.

**Note:** per the repo's release model, the auto-sync fast-forwards *all* of `develop` into `master`, so everything currently ahead on `develop` ships in this release — not only the tangle-cloud change.

Pairs with the already-live arena-side fixes (Base Sepolia wallet chain, operator backend URL, operator CORS) so both the direct site and the embedded iframe connect + load the live leaderboard.
