### PR TITLE
[RELEASE] Promote develop → master: tangle-cloud v0.0.4 (iframe wallet connect)

### DIFF
--- a/apps/tangle-cloud/CHANGELOG.md
+++ b/apps/tangle-cloud/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.4 (2026-05-30)
+
+### 🚀 Features
+
+- **tangle-cloud:** iframe wallet connect — pass `?parent=` to embedded apps so they can detect Tangle Cloud and install the parent-bridge connector (referrer is empty under `no-referrer` + the opaque sandbox origin), plus the `tangle.app.requestConnect` bridge that opens the parent wallet modal ([#3252](https://github.com/tangle-network/dapp/pull/3252))
+- **tangle-cloud:** allow embedded trading-arena to switch to Base Sepolia (84532) — read-only, no signing surface ([#3252](https://github.com/tangle-network/dapp/pull/3252))
+
 ## 0.0.3 (2025-08-06)
 
 ### 🩹 Fixes

--- a/apps/tangle-cloud/package.json
+++ b/apps/tangle-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/tangle-cloud",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "Apache-2.0",
   "type": "module"
 }

--- a/apps/tangle-cloud/src/app/PaymentProviders.tsx
+++ b/apps/tangle-cloud/src/app/PaymentProviders.tsx
@@ -1,10 +1,13 @@
 import { type FC, type PropsWithChildren } from 'react';
 import { CreditsProvider } from './CreditsProvider';
 import { ShieldedProvider } from './ShieldedProvider';
+import { WalletConnectModalProvider } from '../blueprintApps/iframe/WalletConnectModalContext';
 
 const PaymentProviders: FC<PropsWithChildren> = ({ children }) => (
   <ShieldedProvider>
-    <CreditsProvider>{children}</CreditsProvider>
+    <CreditsProvider>
+      <WalletConnectModalProvider>{children}</WalletConnectModalProvider>
+    </CreditsProvider>
   </ShieldedProvider>
 );
 

--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrame.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrame.tsx
@@ -95,7 +95,15 @@ const BlueprintAppFrameInner = (
     <iframe
       ref={ref}
       title={title}
-      src={buildBlueprintIframeUrl(config.url, { mode, blueprintId, theme })}
+      src={buildBlueprintIframeUrl(config.url, {
+        mode,
+        blueprintId,
+        theme,
+        // Deterministic parent-origin signal for the embedded app's bridge
+        // detection — `document.referrer` is empty (no-referrer + opaque
+        // sandbox origin), so `?parent=` is how the iframe learns it's us.
+        parent: typeof window !== 'undefined' ? window.location.origin : undefined,
+      })}
       sandbox={buildSandbox(config)}
       allow={PERMISSIONS_POLICY_DENY_ALL}
       referrerPolicy="no-referrer"

--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrame.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrame.tsx
@@ -102,7 +102,8 @@ const BlueprintAppFrameInner = (
         // Deterministic parent-origin signal for the embedded app's bridge
         // detection — `document.referrer` is empty (no-referrer + opaque
         // sandbox origin), so `?parent=` is how the iframe learns it's us.
-        parent: typeof window !== 'undefined' ? window.location.origin : undefined,
+        parent:
+          typeof window !== 'undefined' ? window.location.origin : undefined,
       })}
       sandbox={buildSandbox(config)}
       allow={PERMISSIONS_POLICY_DENY_ALL}

--- a/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
@@ -120,16 +120,27 @@ const IframeBlueprintLayout: FC<Props> = ({
           </div>
         )}
         <div className="ml-auto flex shrink-0 items-center gap-2">
-          <Button asChild variant="sandbox" size="sm">
-            <Link to={provisionPath}>Create {serviceNoun}</Link>
-          </Button>
+          {/* Explicit styling rather than the sandbox Button variant: the
+           * vendored variant left dark, italic text on the purple fill
+           * (unreadable). White text on a solid accent, non-italic, sized to
+           * match the Details button. */}
+          <Link
+            to={provisionPath}
+            className={twMerge(
+              'inline-flex h-8 shrink-0 items-center rounded-md px-3 text-xs font-semibold not-italic transition-opacity',
+              'bg-[color:var(--primary)] text-white hover:opacity-90',
+              focus.ring,
+            )}
+          >
+            Create {serviceNoun}
+          </Link>
           <button
             type="button"
             onClick={() => setDetailsOpen((v) => !v)}
             aria-expanded={detailsOpen}
             aria-controls="blueprint-details-panel"
             className={twMerge(
-              'inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-transparent px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
+              'inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-transparent px-2.5 text-xs font-medium not-italic text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
               detailsOpen && 'border-[color:var(--border-accent-hover)]',
               focus.ring,
             )}

--- a/apps/tangle-cloud/src/blueprintApps/iframe/WalletConnectModalContext.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/WalletConnectModalContext.tsx
@@ -1,0 +1,54 @@
+import { EvmWalletModal } from '@tangle-network/tangle-shared-ui/components/EvmWalletModal';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+/**
+ * App-level owner of a single wallet-connect modal that can be opened
+ * imperatively — specifically so the iframe bridge can honour a
+ * `tangle.app.requestConnect` from an embedded blueprint (the iframe is
+ * sandboxed and can't reach a wallet itself; it delegates to the parent).
+ *
+ * This is the same `EvmWalletModal` the nav's ConnectWalletButton uses; here
+ * it's mounted once at the app root and driven by context so any consumer —
+ * including the bridge hook, which lives in a different subtree — can open it.
+ */
+type WalletConnectModalCtx = {
+  /** Open the wallet-connect modal. */
+  open: () => void;
+  /** Whether the modal is currently open (lets the bridge detect dismissal). */
+  isOpen: boolean;
+};
+
+const Context = createContext<WalletConnectModalCtx | null>(null);
+
+export function WalletConnectModalProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const open = useCallback(() => setIsOpen(true), []);
+  const value = useMemo<WalletConnectModalCtx>(
+    () => ({ open, isOpen }),
+    [open, isOpen],
+  );
+
+  return (
+    <Context.Provider value={value}>
+      {children}
+      <EvmWalletModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </Context.Provider>
+  );
+}
+
+/** Imperative wallet-connect modal control. Safe no-op outside the provider. */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useWalletConnectModal(): WalletConnectModalCtx {
+  return useContext(Context) ?? { open: () => undefined, isOpen: false };
+}

--- a/apps/tangle-cloud/src/blueprintApps/iframe/policy.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/policy.ts
@@ -132,6 +132,17 @@ export function checkRequestAllowed(
       return accept();
     case 'tangle.app.readAccount':
       return checkReadAccountAllowed(request, config);
+    case 'tangle.app.requestConnect':
+      // Initiating a connect is read-tier: an app allowed to read the account
+      // may prompt the user to connect one. The user still confirms in the
+      // parent's own wallet modal — no silent connection.
+      return checkReadAccountAllowed(
+        {
+          kind: 'tangle.app.readAccount',
+          correlationId: request.correlationId,
+        },
+        config,
+      );
     case 'tangle.app.switchChain':
       return checkSwitchChainAllowed(request, config);
     case 'tangle.app.signMessage':

--- a/apps/tangle-cloud/src/blueprintApps/iframe/protocol.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/protocol.ts
@@ -23,6 +23,11 @@ export type IframeRequestReadAccount = {
   correlationId: string;
 };
 
+export type IframeRequestRequestConnect = {
+  kind: 'tangle.app.requestConnect';
+  correlationId: string;
+};
+
 export type IframeRequestSwitchChain = {
   kind: 'tangle.app.switchChain';
   correlationId: string;
@@ -80,6 +85,7 @@ export type IframeRequestCallJob = {
 export type IframeRequest =
   | IframeRequestHandshake
   | IframeRequestReadAccount
+  | IframeRequestRequestConnect
   | IframeRequestSwitchChain
   | IframeRequestSignMessage
   | IframeRequestSignTransaction
@@ -100,6 +106,10 @@ export type ParentResponseResultBase<T> = {
 
 export type ParentResponseReadAccountResult = {
   kind: 'tangle.app.readAccountResult';
+} & ParentResponseResultBase<{ account: Address; chainId: number }>;
+
+export type ParentResponseConnectResult = {
+  kind: 'tangle.app.connectResult';
 } & ParentResponseResultBase<{ account: Address; chainId: number }>;
 
 export type ParentResponseSwitchChainResult = {
@@ -170,6 +180,7 @@ export type ParentEventJobResult = {
 export type ParentMessage =
   | ParentResponseHandshakeAck
   | ParentResponseReadAccountResult
+  | ParentResponseConnectResult
   | ParentResponseSwitchChainResult
   | ParentResponseSignMessageResult
   | ParentResponseSignTransactionResult
@@ -237,6 +248,13 @@ export function validateIframeRequest(value: unknown): IframeRequest | null {
       if (!isValidCorrelationId(record.correlationId)) return null;
       return {
         kind: 'tangle.app.readAccount',
+        correlationId: record.correlationId,
+      };
+    }
+    case 'tangle.app.requestConnect': {
+      if (!isValidCorrelationId(record.correlationId)) return null;
+      return {
+        kind: 'tangle.app.requestConnect',
         correlationId: record.correlationId,
       };
     }

--- a/apps/tangle-cloud/src/blueprintApps/iframe/url.spec.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/url.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { buildBlueprintIframeUrl } from './url';
+
+describe('buildBlueprintIframeUrl', () => {
+  const base = 'https://trading-arena.blueprint.tangle.tools/';
+
+  it('sets the reserved params', () => {
+    const url = new URL(
+      buildBlueprintIframeUrl(base, { mode: 'instance', blueprintId: 13, theme: 'dark' }),
+    );
+    expect(url.searchParams.get('mode')).toBe('instance');
+    expect(url.searchParams.get('blueprintId')).toBe('13');
+    expect(url.searchParams.get('theme')).toBe('dark');
+  });
+
+  it('defaults mode to "default" and omits unset optionals', () => {
+    const url = new URL(buildBlueprintIframeUrl(base, {}));
+    expect(url.searchParams.get('mode')).toBe('default');
+    expect(url.searchParams.has('blueprintId')).toBe(false);
+    expect(url.searchParams.has('theme')).toBe(false);
+    expect(url.searchParams.has('parent')).toBe(false);
+  });
+
+  // The embedded app's bridge detection reads `?parent=` (document.referrer is
+  // empty under no-referrer + the opaque sandbox origin). Without this the
+  // iframe can't tell it's inside Tangle Cloud and never installs the
+  // parent-bridge wallet connector.
+  it('appends the parent origin when provided', () => {
+    const url = new URL(
+      buildBlueprintIframeUrl(base, { parent: 'https://cloud.tangle.tools' }),
+    );
+    expect(url.searchParams.get('parent')).toBe('https://cloud.tangle.tools');
+  });
+
+  it('omits parent when not provided', () => {
+    const url = new URL(buildBlueprintIframeUrl(base, { mode: 'default' }));
+    expect(url.searchParams.has('parent')).toBe(false);
+  });
+
+  it('returns the raw string for a malformed URL', () => {
+    expect(buildBlueprintIframeUrl('not a url', { parent: 'https://cloud.tangle.tools' })).toBe(
+      'not a url',
+    );
+  });
+});

--- a/apps/tangle-cloud/src/blueprintApps/iframe/url.spec.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/url.spec.ts
@@ -6,7 +6,11 @@ describe('buildBlueprintIframeUrl', () => {
 
   it('sets the reserved params', () => {
     const url = new URL(
-      buildBlueprintIframeUrl(base, { mode: 'instance', blueprintId: 13, theme: 'dark' }),
+      buildBlueprintIframeUrl(base, {
+        mode: 'instance',
+        blueprintId: 13,
+        theme: 'dark',
+      }),
     );
     expect(url.searchParams.get('mode')).toBe('instance');
     expect(url.searchParams.get('blueprintId')).toBe('13');
@@ -38,8 +42,10 @@ describe('buildBlueprintIframeUrl', () => {
   });
 
   it('returns the raw string for a malformed URL', () => {
-    expect(buildBlueprintIframeUrl('not a url', { parent: 'https://cloud.tangle.tools' })).toBe(
-      'not a url',
-    );
+    expect(
+      buildBlueprintIframeUrl('not a url', {
+        parent: 'https://cloud.tangle.tools',
+      }),
+    ).toBe('not a url');
   });
 });

--- a/apps/tangle-cloud/src/blueprintApps/iframe/url.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/url.ts
@@ -9,6 +9,12 @@
  *                      `data-sandbox-theme` can match the parent shell
  *                      instead of rendering a dark void on a light dapp
  *                      (or vice versa)
+ *   - `parent`       — the parent (this dapp's) origin, so the embedded app
+ *                      can deterministically detect that it's running inside
+ *                      Tangle Cloud and install the parent-bridge wallet
+ *                      connector. The sandbox runs at an opaque origin and we
+ *                      send `referrerpolicy="no-referrer"`, so `document.referrer`
+ *                      is unavailable — `?parent=` is the only reliable signal.
  *
  * Other (non-reserved) params on the manifest URL are preserved verbatim —
  * publishers may sign intent into them and we shouldn't drop that.
@@ -24,6 +30,7 @@ export const buildBlueprintIframeUrl = (
     mode?: string;
     blueprintId?: bigint | number;
     theme?: 'light' | 'dark';
+    parent?: string;
   },
 ): string => {
   let url: URL;
@@ -42,6 +49,9 @@ export const buildBlueprintIframeUrl = (
   }
   if (options.theme === 'light' || options.theme === 'dark') {
     url.searchParams.set('theme', options.theme);
+  }
+  if (options.parent) {
+    url.searchParams.set('parent', options.parent);
   }
   return url.toString();
 };

--- a/apps/tangle-cloud/src/blueprintApps/iframe/useIframeBridge.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/useIframeBridge.ts
@@ -10,6 +10,7 @@ import {
 import { isMessageFromIframe, buildIframeMessageContext } from './origin';
 import { checkRequestAllowed, type IframePolicyVerdict } from './policy';
 import type { BlueprintIframeConfig } from './types';
+import { useWalletConnectModal } from './WalletConnectModalContext';
 
 // Pending operator-approved request that the bridge is waiting on the user
 // to confirm via the dapp's approval modal. Surfaced through the hook's
@@ -85,10 +86,16 @@ export function useIframeBridge({
   const { address } = useAccount();
   const chainId = useChainId();
   const chains = useChains();
+  const { open: openWalletModal, isOpen: walletModalOpen } =
+    useWalletConnectModal();
   const [pendingApproval, setPendingApproval] =
     useState<PendingApproval | null>(null);
   const pendingRef = useRef(pendingApproval);
   pendingRef.current = pendingApproval;
+  // correlationId of an in-flight tangle.app.requestConnect (the iframe asked
+  // us to connect a wallet). Resolved when an account appears, or rejected if
+  // the user dismisses the modal without connecting.
+  const pendingConnectRef = useRef<string | null>(null);
 
   const post = useCallback(
     (message: ParentMessage) => {
@@ -373,6 +380,24 @@ export function useIframeBridge({
         return;
       }
 
+      // The iframe asked us to connect a wallet. If one is already connected,
+      // answer immediately; otherwise open the parent's connect modal and
+      // resolve later (see the address / modal-close effects below).
+      if (request.kind === 'tangle.app.requestConnect') {
+        if (address) {
+          post({
+            kind: 'tangle.app.connectResult',
+            correlationId: request.correlationId,
+            ok: true,
+            data: { account: address as Address, chainId: chainId ?? 0 },
+          });
+          return;
+        }
+        pendingConnectRef.current = request.correlationId;
+        openWalletModal();
+        return;
+      }
+
       // callJob (job invocation via quote/sign/submit) is protocol-defined
       // but its parent-side integration with the deploy/quote pipeline is
       // not yet wired. Respond with a clean error so the iframe surfaces a
@@ -432,9 +457,36 @@ export function useIframeBridge({
     enabled,
     iframeRef,
     onPolicyDeny,
+    openWalletModal,
     post,
     respond,
   ]);
+
+  // Resolve an in-flight requestConnect once a wallet connects.
+  useEffect(() => {
+    if (!enabled || !address || !pendingConnectRef.current) return;
+    post({
+      kind: 'tangle.app.connectResult',
+      correlationId: pendingConnectRef.current,
+      ok: true,
+      data: { account: address as Address, chainId: chainId ?? 0 },
+    });
+    pendingConnectRef.current = null;
+  }, [address, chainId, enabled, post]);
+
+  // If the user dismissed the connect modal without connecting, reject the
+  // in-flight requestConnect so the iframe gets a clean error rather than
+  // hanging until its timeout.
+  useEffect(() => {
+    if (walletModalOpen || !pendingConnectRef.current || address) return;
+    post({
+      kind: 'tangle.app.connectResult',
+      correlationId: pendingConnectRef.current,
+      ok: false,
+      error: 'User dismissed the connect modal.',
+    });
+    pendingConnectRef.current = null;
+  }, [walletModalOpen, address, post]);
 
   return {
     pendingApproval,

--- a/apps/tangle-cloud/src/blueprintApps/registry.ts
+++ b/apps/tangle-cloud/src/blueprintApps/registry.ts
@@ -99,20 +99,22 @@ const entries = [
         label: 'AI Trading',
       },
     },
-    // Iframe runtime policy. Empty allowedChainIds / contracts on purpose:
-    // the trading-arena UI doesn't issue tangle.app.signTransaction yet, so
-    // we don't grant transaction surface. allowReadAccount surfaces the
-    // connected wallet to the iframe for read-only views (positions,
-    // balances) without unlocking signing.
+    // Iframe runtime policy. No contracts/messages: the trading-arena UI
+    // doesn't issue tangle.app.signTransaction yet, so we don't grant a
+    // transaction surface. allowReadAccount surfaces the connected wallet for
+    // read-only views (positions, balances). Chain switching IS allowed but
+    // restricted to Base Sepolia (84532) — the chain the trading bots run on —
+    // so the embedded arena can move a wrong-network wallet onto the right
+    // chain without unlocking signing.
     iframe: {
       url: 'https://trading-arena.blueprint.tangle.tools/',
       origin: 'https://trading-arena.blueprint.tangle.tools',
       appId: 'trading-arena',
-      allowedChainIds: [],
+      allowedChainIds: [84532],
       contracts: [],
       messages: [],
       allowReadAccount: true,
-      allowChainSwitch: false,
+      allowChainSwitch: true,
       allowPopups: false,
     },
   },

--- a/apps/tangle-cloud/src/components/chrome/TopNavSlot.tsx
+++ b/apps/tangle-cloud/src/components/chrome/TopNavSlot.tsx
@@ -31,11 +31,14 @@ export function TopNavSlotProvider({ children }: { children: ReactNode }) {
   );
 }
 
+// Context module: the Provider component lives alongside its hooks by design.
+// eslint-disable-next-line react-refresh/only-export-components
 export function useTopNavSlotContent(): ReactNode {
   return useContext(TopNavSlotContext)?.content ?? null;
 }
 
 /** Publish `node` into the top-nav left slot while this component is mounted. */
+// eslint-disable-next-line react-refresh/only-export-components
 export function useTopNavSlot(node: ReactNode): void {
   const ctx = useContext(TopNavSlotContext);
   useEffect(() => {

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.4.19",
     "eslint-plugin-storybook": "^0.12.0",
     "framer-motion": "^12.7.2",

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "@typescript-eslint/parser": "^8.30.1",
     "@vitejs/plugin-react-swc": "^3.8.1",
     "@vitest/coverage-v8": "^3.1.1",
-    "@vitest/ui": "^3.1.1",
+    "@vitest/ui": "^4.1.7",
     "autoprefixer": "^10.4.21",
     "classnames": "^2.5.1",
     "copy-to-clipboard": "^3.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,6 +156,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/code-frame@npm:7.29.7"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.1.1"
+  checksum: 10c0/169fc2080169a40c1760155eaaaf739bcb882df0bec76a83adbda5493645bc17270a3434b8848c494b1933e96fe1d147370001e3cda09a39f43ae30f08ef2069
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.26.8":
   version: 7.26.8
   resolution: "@babel/compat-data@npm:7.26.8"
@@ -167,6 +178,13 @@ __metadata:
   version: 7.29.0
   resolution: "@babel/compat-data@npm:7.29.0"
   checksum: 10c0/08f348554989d23aa801bf1405aa34b15e841c0d52d79da7e524285c77a5f9d298e70e11d91cc578d8e2c9542efc586d50c5f5cf8e1915b254a9dcf786913a94
+  languageName: node
+  linkType: hard
+
+"@babel/compat-data@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/compat-data@npm:7.29.7"
+  checksum: 10c0/47913f05e08a45a1c9df38c02b4b49e391005085b489432647a1abe112e5d9c75e3be8ea5972b7f6da4ec5d1339922ceb9ea02b8a25d4ed1cb8636e5261f344e
   languageName: node
   linkType: hard
 
@@ -190,6 +208,29 @@ __metadata:
     json5: "npm:^2.2.3"
     semver: "npm:^6.3.1"
   checksum: 10c0/e046e0e988ab53841b512ee9d263ca409f6c46e2a999fe53024688b92db394346fa3aeae5ea0866331f62133982eee05a675d22922a4603c3f603aa09a581d62
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:^7.24.4":
+  version: 7.29.7
+  resolution: "@babel/core@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.7"
+    "@babel/helper-compilation-targets": "npm:^7.29.7"
+    "@babel/helper-module-transforms": "npm:^7.29.7"
+    "@babel/helpers": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    "@jridgewell/remapping": "npm:^2.3.5"
+    convert-source-map: "npm:^2.0.0"
+    debug: "npm:^4.1.0"
+    gensync: "npm:^1.0.0-beta.2"
+    json5: "npm:^2.2.3"
+    semver: "npm:^6.3.1"
+  checksum: 10c0/112fb09c24de7a1de64d1de2c31fe65c4e6af4cb2fb6e6d99ea5373e6fc51e75b88581c0efae4c4c68f119a02a988c7106e95011a41530a2fb8ed793c7eaa07b
   languageName: node
   linkType: hard
 
@@ -255,6 +296,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/generator@npm:7.29.7"
+  dependencies:
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    jsesc: "npm:^3.0.2"
+  checksum: 10c0/9bf72b01b5bd0ea5b1288a0e37dbd360bff2f2b1ce73342c0d40fb3db2ec3dc004ada5ffa925c5e12939a416eed59e600d562b8ecd938ce0d27dfd0eb6c6c2b7
+  languageName: node
+  linkType: hard
+
 "@babel/helper-annotate-as-pure@npm:^7.22.5":
   version: 7.27.3
   resolution: "@babel/helper-annotate-as-pure@npm:7.27.3"
@@ -296,6 +350,19 @@ __metadata:
     lru-cache: "npm:^5.1.1"
     semver: "npm:^6.3.1"
   checksum: 10c0/3fcdf3b1b857a1578e99d20508859dbd3f22f3c87b8a0f3dc540627b4be539bae7f6e61e49d931542fe5b557545347272bbdacd7f58a5c77025a18b745593a50
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-compilation-targets@npm:7.29.7"
+  dependencies:
+    "@babel/compat-data": "npm:^7.29.7"
+    "@babel/helper-validator-option": "npm:^7.29.7"
+    browserslist: "npm:^4.24.0"
+    lru-cache: "npm:^5.1.1"
+    semver: "npm:^6.3.1"
+  checksum: 10c0/4c15fd4c69a0a7047799a28a88460c19cede0a0ee8af994ea169114986f4af48b92c7393a4a3fee0456c11a656eece3448a6ed06354453d6c27cccf17195453b
   languageName: node
   linkType: hard
 
@@ -351,6 +418,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-globals@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-globals@npm:7.29.7"
+  checksum: 10c0/f38417c40b1129a1b2b519ca961b9040c8827d1444fd74068702286b91b77089431dc76b6b9d5c1496e5da2a4f3ad329c6946e688ba3fa0d1d0b3d2b4f34f36a
+  languageName: node
+  linkType: hard
+
 "@babel/helper-member-expression-to-functions@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-member-expression-to-functions@npm:7.25.9"
@@ -391,6 +465,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-imports@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-imports@npm:7.29.7"
+  dependencies:
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/6adf60d97356027413342a092f818d9678c4f5caff716a33e3284b5ae14e47a9e88059d421dde4ee4894691260039a12602c0e7becadc175602194b40dfa345d
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-transforms@npm:^7.25.9, @babel/helper-module-transforms@npm:^7.26.0":
   version: 7.26.0
   resolution: "@babel/helper-module-transforms@npm:7.26.0"
@@ -414,6 +498,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 10c0/6f03e14fc30b287ce0b839474b5f271e72837d0cafe6b172d759184d998fbee3903a035e81e07c2c596449e504f453463d58baa65b6f40a37ded5bec74620b2b
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-transforms@npm:7.29.7"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 10c0/ee5a2172c24a42be696836f4b0d947489c9729d8adf5821885cf77d1ad5333e3c447368e9a71f67df1099570490553dccf9f888ef0a92a48aa63cb086bd8c7e1
   languageName: node
   linkType: hard
 
@@ -497,6 +594,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-string-parser@npm:7.29.7"
+  checksum: 10c0/194bc0f1716e396d5ffde56ad6119745fb9557662c98611590e5e454906783a4ccb21ce93056b8eb69a4909044834e45d96e50ac695bbe9e3221648fe033c06c
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-validator-identifier@npm:7.25.9"
@@ -511,6 +615,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
+  checksum: 10c0/4795354e7ae0dcafa72de1cd04ec51252dc1498517170beaf019e03effc5b7bf13c6b21a3949a77e07b8125be7f106ed1131350d8ebd4566ae874094a726d62b
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-validator-option@npm:7.25.9"
@@ -522,6 +633,13 @@ __metadata:
   version: 7.27.1
   resolution: "@babel/helper-validator-option@npm:7.27.1"
   checksum: 10c0/6fec5f006eba40001a20f26b1ef5dbbda377b7b68c8ad518c05baa9af3f396e780bdfded24c4eef95d14bb7b8fd56192a6ed38d5d439b97d10efc5f1a191d148
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-option@npm:7.29.7"
+  checksum: 10c0/d2a06c6d0ac40ba4a2f219fc2cab249c7a94bacdb2686273b7f9598571c908809b48468ff588915a346e6cc7296f60b581023d1d498b747fed06f779d335c2cc
   languageName: node
   linkType: hard
 
@@ -556,6 +674,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helpers@npm:7.29.7"
+  dependencies:
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/218e8d10953647c9f44775f5a022b227a182674853b5ea8631889deb7e1a3e4bc870388aaecf59bb8bd92a87f9a96220ed3f70a35bffec6bcf9169ecb67891ac
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.25.3, @babel/parser@npm:^7.25.4, @babel/parser@npm:^7.26.10, @babel/parser@npm:^7.27.0":
   version: 7.27.0
   resolution: "@babel/parser@npm:7.27.0"
@@ -564,6 +692,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10c0/ba2ed3f41735826546a3ef2a7634a8d10351df221891906e59b29b0a0cd748f9b0e7a6f07576858a9de8e77785aad925c8389ddef146de04ea2842047c9d2859
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.24.4, @babel/parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/parser@npm:7.29.7"
+  dependencies:
+    "@babel/types": "npm:^7.29.7"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/65133038f80b54a714d6027cb77cee3f9a6b5c4c6842ce674301e13947cbcbfa8055e63acaf1b84c085d34226a14425b2c2b97b829e0e226d2e8f1299942a51d
   languageName: node
   linkType: hard
 
@@ -1774,6 +1913,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/template@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/8bb7f900dcab0e9e1c5ffbc33ca10e0d26b7b2e2ca804becb73ee771b9c4ed6e2908a4ae4a14c08560febb45d2b6b9a173955e42ad404d05f8b04840a14d9c58
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.16.0, @babel/traverse@npm:^7.18.9, @babel/traverse@npm:^7.25.9, @babel/traverse@npm:^7.26.10, @babel/traverse@npm:^7.26.5, @babel/traverse@npm:^7.26.8, @babel/traverse@npm:^7.27.0":
   version: 7.27.0
   resolution: "@babel/traverse@npm:7.27.0"
@@ -1819,6 +1969,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/traverse@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.7"
+    "@babel/helper-globals": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    debug: "npm:^4.3.1"
+  checksum: 10c0/e256a1fbdb956555b76f3c285b1e453f6bedec8b3afb61751d99d933efd11c7d79caf5ddf2493570058a9f7deaa1b48324380d7c1aa1443fd9508becbf56331a
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.13, @babel/types@npm:^7.18.9, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.25.4, @babel/types@npm:^7.25.9, @babel/types@npm:^7.26.0, @babel/types@npm:^7.26.10, @babel/types@npm:^7.27.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.27.0
   resolution: "@babel/types@npm:7.27.0"
@@ -1846,6 +2011,16 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
   checksum: 10c0/23cc3466e83bcbfab8b9bd0edaafdb5d4efdb88b82b3be6728bbade5ba2f0996f84f63b1c5f7a8c0d67efded28300898a5f930b171bb40b311bca2029c4e9b4f
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/types@npm:7.29.7"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+  checksum: 10c0/b6623994c69717fa27294f5fa46d59140338e2d86c6c1c13085c84ef7d53086ee357fbf4fe9abe3dd3da75734dc77c4c0df2f90fb29e667558bb3b3fb705e88f
   languageName: node
   linkType: hard
 
@@ -21030,12 +21205,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "eslint-plugin-react-hooks@npm:5.2.0"
+"eslint-plugin-react-hooks@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "eslint-plugin-react-hooks@npm:7.1.1"
+  dependencies:
+    "@babel/core": "npm:^7.24.4"
+    "@babel/parser": "npm:^7.24.4"
+    hermes-parser: "npm:^0.25.1"
+    zod: "npm:^3.25.0 || ^4.0.0"
+    zod-validation-error: "npm:^3.5.0 || ^4.0.0"
   peerDependencies:
-    eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
-  checksum: 10c0/1c8d50fa5984c6dea32470651807d2922cc3934cf3425e78f84a24c2dfd972e7f019bee84aefb27e0cf2c13fea0ac1d4473267727408feeb1c56333ca1489385
+    eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+  checksum: 10c0/cee8454915d71ac5d70a0d8f4f260e76eaf45fcd4162747dd4282b792ee5616d187351dabe6cdcff9040c79d0cec625635c4fd0777276be119efa88ebe058525
   languageName: node
   linkType: hard
 
@@ -22946,6 +23127,22 @@ __metadata:
     capital-case: "npm:^1.0.4"
     tslib: "npm:^2.0.3"
   checksum: 10c0/c9f295d9d8e38fa50679281fd70d80726962256e888a76c8e72e526453da7a1832dcb427caa716c1ad5d79841d4537301b90156fa30298fefd3d68f4ea2181bb
+  languageName: node
+  linkType: hard
+
+"hermes-estree@npm:0.25.1":
+  version: 0.25.1
+  resolution: "hermes-estree@npm:0.25.1"
+  checksum: 10c0/48be3b2fa37a0cbc77a112a89096fa212f25d06de92781b163d67853d210a8a5c3784fac23d7d48335058f7ed283115c87b4332c2a2abaaccc76d0ead1a282ac
+  languageName: node
+  linkType: hard
+
+"hermes-parser@npm:^0.25.1":
+  version: 0.25.1
+  resolution: "hermes-parser@npm:0.25.1"
+  dependencies:
+    hermes-estree: "npm:0.25.1"
+  checksum: 10c0/3abaa4c6f1bcc25273f267297a89a4904963ea29af19b8e4f6eabe04f1c2c7e9abd7bfc4730ddb1d58f2ea04b6fee74053d8bddb5656ec6ebf6c79cc8d14202c
   languageName: node
   linkType: hard
 
@@ -32435,7 +32632,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.31.0"
     eslint-plugin-jsx-a11y: "npm:^6.10.2"
     eslint-plugin-react: "npm:^7.37.5"
-    eslint-plugin-react-hooks: "npm:^5.2.0"
+    eslint-plugin-react-hooks: "npm:^7.1.1"
     eslint-plugin-react-refresh: "npm:^0.4.19"
     eslint-plugin-storybook: "npm:^0.12.0"
     framer-motion: "npm:^12.7.2"
@@ -35211,6 +35408,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"zod-validation-error@npm:^3.5.0 || ^4.0.0":
+  version: 4.0.2
+  resolution: "zod-validation-error@npm:4.0.2"
+  peerDependencies:
+    zod: ^3.25.0 || ^4.0.0
+  checksum: 10c0/0ccfec48c46de1be440b719cd02044d4abb89ed0e14c13e637cd55bf29102f67ccdba373f25def0fc7130e5f15025be4d557a7edcc95d5a3811599aade689e1b
+  languageName: node
+  linkType: hard
+
 "zod@npm:3.22.4":
   version: 3.22.4
   resolution: "zod@npm:3.22.4"
@@ -35229,6 +35435,13 @@ __metadata:
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25.0 || ^4.0.0":
+  version: 4.4.3
+  resolution: "zod@npm:4.4.3"
+  checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15381,12 +15381,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:3.1.2":
-  version: 3.1.2
-  resolution: "@vitest/pretty-format@npm:3.1.2"
+"@vitest/pretty-format@npm:4.1.7":
+  version: 4.1.7
+  resolution: "@vitest/pretty-format@npm:4.1.7"
   dependencies:
-    tinyrainbow: "npm:^2.0.0"
-  checksum: 10c0/f4a79be6d5a1a0b3215ba66b3cc62b2e0fc3a81b4eee07b2644600450b796a8630ee86180691391a5597c9a792f3d213d54f2043f4a0809a9386473bfcca85fb
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/49ef801171708e3a92214e8720efbedbd6e0e6baf17971aaf4feb7422e5c9eba82262c24a9e6dd4d41a31fae77bd31d5b37cf140d13e0ac4ce29a7457bdc692f
   languageName: node
   linkType: hard
 
@@ -15429,20 +15429,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/ui@npm:^3.1.1":
-  version: 3.1.2
-  resolution: "@vitest/ui@npm:3.1.2"
+"@vitest/ui@npm:^4.1.7":
+  version: 4.1.7
+  resolution: "@vitest/ui@npm:4.1.7"
   dependencies:
-    "@vitest/utils": "npm:3.1.2"
+    "@vitest/utils": "npm:4.1.7"
     fflate: "npm:^0.8.2"
-    flatted: "npm:^3.3.3"
+    flatted: "npm:^3.4.2"
     pathe: "npm:^2.0.3"
-    sirv: "npm:^3.0.1"
-    tinyglobby: "npm:^0.2.13"
-    tinyrainbow: "npm:^2.0.0"
+    sirv: "npm:^3.0.2"
+    tinyglobby: "npm:^0.2.15"
+    tinyrainbow: "npm:^3.1.0"
   peerDependencies:
-    vitest: 3.1.2
-  checksum: 10c0/ab8c927726196e2477411f19055e9082f94574c9c8c55bf6965aad71cfbe8311d7af10b320c4498ecdbaae4145c7baed436ffc6768f3fc232ec97312e8b9884a
+    vitest: 4.1.7
+  checksum: 10c0/7688c7dd1673d1de533417e8872e388f2c7bee3c9935bff7873fe6d8b7cfdf6ae3cce5b6c8f1a1e7a017d204db3970c9e73449af351721d5361dcade9b0753f3
   languageName: node
   linkType: hard
 
@@ -15469,14 +15469,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/utils@npm:3.1.2":
-  version: 3.1.2
-  resolution: "@vitest/utils@npm:3.1.2"
+"@vitest/utils@npm:4.1.7":
+  version: 4.1.7
+  resolution: "@vitest/utils@npm:4.1.7"
   dependencies:
-    "@vitest/pretty-format": "npm:3.1.2"
-    loupe: "npm:^3.1.3"
-    tinyrainbow: "npm:^2.0.0"
-  checksum: 10c0/9e778ab7cf483396d650ddd079e702af6b9f087443a99045707865bf433cfa3c4f468d94d17a44173e6adcc5cce218a1b0073d1b94bbd84a03262033e427336d
+    "@vitest/pretty-format": "npm:4.1.7"
+    convert-source-map: "npm:^2.0.0"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/aa0079d8923506300527dc23ff68cf090ffcb2c6a9549e598ae22ba0eb8a6bb4448b10724b38bc6b077f9957333302a857d791ad2f7abd807bb6263c9a218833
   languageName: node
   linkType: hard
 
@@ -21971,15 +21971,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fdir@npm:^6.4.4":
-  version: 6.4.4
-  resolution: "fdir@npm:6.4.4"
+"fdir@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "fdir@npm:6.5.0"
   peerDependencies:
     picomatch: ^3 || ^4
   peerDependenciesMeta:
     picomatch:
       optional: true
-  checksum: 10c0/6ccc33be16945ee7bc841e1b4178c0b4cf18d3804894cb482aa514651c962a162f96da7ffc6ebfaf0df311689fb70091b04dd6caffe28d56b9ebdc0e7ccadfdd
+  checksum: 10c0/e345083c4306b3aed6cb8ec551e26c36bab5c511e99ea4576a16750ddc8d3240e63826cc624f5ae17ad4dc82e68a253213b60d556c11bfad064b7607847ed07f
   languageName: node
   linkType: hard
 
@@ -22198,10 +22198,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatted@npm:^3.2.7, flatted@npm:^3.2.9, flatted@npm:^3.3.3":
+"flatted@npm:^3.2.7, flatted@npm:^3.2.9":
   version: 3.3.3
   resolution: "flatted@npm:3.3.3"
   checksum: 10c0/e957a1c6b0254aa15b8cce8533e24165abd98fadc98575db082b786b5da1b7d72062b81bfdcd1da2f4d46b6ed93bec2434e62333e9b4261d79ef2e75a10dd538
+  languageName: node
+  linkType: hard
+
+"flatted@npm:^3.4.2":
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 10c0/a65b67aae7172d6cdf63691be7de6c5cd5adbdfdfe2e9da1a09b617c9512ed794037741ee53d93114276bff3f93cd3b0d97d54f9b316e1e4885dde6e9ffdf7ed
   languageName: node
   linkType: hard
 
@@ -28723,7 +28730,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.3":
+"picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
@@ -31567,14 +31574,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sirv@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "sirv@npm:3.0.1"
+"sirv@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "sirv@npm:3.0.2"
   dependencies:
     "@polka/url": "npm:^1.0.0-next.24"
     mrmime: "npm:^2.0.0"
     totalist: "npm:^3.0.0"
-  checksum: 10c0/7cf64b28daa69b15f77b38b0efdd02c007b72bb3ec5f107b208ebf59f01b174ef63a1db3aca16d2df925501831f4c209be6ece3302b98765919ef5088b45bf80
+  checksum: 10c0/5930e4397afdb14fbae13751c3be983af4bda5c9aadec832607dc2af15a7162f7d518c71b30e83ae3644b9a24cea041543cc969e5fe2b80af6ce8ea3174b2d04
   languageName: node
   linkType: hard
 
@@ -32611,7 +32618,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.30.1"
     "@vitejs/plugin-react-swc": "npm:^3.8.1"
     "@vitest/coverage-v8": "npm:^3.1.1"
-    "@vitest/ui": "npm:^3.1.1"
+    "@vitest/ui": "npm:^4.1.7"
     "@walletconnect/ethereum-provider": "npm:^2.19.2"
     autoprefixer: "npm:^10.4.21"
     blo: "npm:^2.0.0"
@@ -32916,13 +32923,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.13":
-  version: 0.2.13
-  resolution: "tinyglobby@npm:0.2.13"
+"tinyglobby@npm:^0.2.15":
+  version: 0.2.16
+  resolution: "tinyglobby@npm:0.2.16"
   dependencies:
-    fdir: "npm:^6.4.4"
-    picomatch: "npm:^4.0.2"
-  checksum: 10c0/ef07dfaa7b26936601d3f6d999f7928a4d1c6234c5eb36896bb88681947c0d459b7ebe797022400e555fe4b894db06e922b95d0ce60cb05fd827a0a66326b18c
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/f2e09fd93dd95c41e522113b686ff6f7c13020962f8698a864a257f3d7737599afc47722b7ab726e12f8a813f779906187911ff8ee6701ede65072671a7e934b
   languageName: node
   linkType: hard
 
@@ -32944,6 +32951,13 @@ __metadata:
   version: 2.0.0
   resolution: "tinyrainbow@npm:2.0.0"
   checksum: 10c0/c83c52bef4e0ae7fb8ec6a722f70b5b6fa8d8be1c85792e829f56c0e1be94ab70b293c032dc5048d4d37cfe678f1f5babb04bdc65fd123098800148ca989184f
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "tinyrainbow@npm:3.1.0"
+  checksum: 10c0/f11cf387a26c5c9255bec141a90ac511b26172981b10c3e50053bc6700ea7d2336edcc4a3a21dbb8412fe7c013477d2ba4d7e4877800f3f8107be5105aad6511
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Release develop → master (tangle-cloud v0.0.4)

Promotes `develop` to `master` to ship **tangle-cloud v0.0.4** (iframe wallet connect — `?parent=` parent-origin detection + `requestConnect` bridge + Base Sepolia switch) to production `cloud.tangle.tools`.

**Why a PR instead of auto-sync:** the `[RELEASE]` commit (#3253) landed on `develop`, but `auto-sync-master-with-develop` failed — `master` has diverged (it carries merge commit `0d9c71a3` from a prior develop→master PR #3249 that isn't on develop), so its `git merge --ff-only` can't fast-forward. This PR is the same promotion pattern that produced master's current HEAD.

On merge: push to `master` + the `apps/tangle-cloud/CHANGELOG.md` bump → `release-dapps.yml` deploys tangle-cloud to prod.

**Scope:** promotes everything currently on `develop` ahead of `master` (standard for this release model).

**Note on the `Clean 🧹 / lint` check:** it fails on a pre-existing, monorepo-wide `react-hooks/preserve-manual-memoization` (React Compiler) rule across 5 projects in files unrelated to this release — same failure already present on `develop`. Not introduced here.
