### PR TITLE
fix(ci): auto-sync master uses --no-ff so releases don't break on branch divergence

### DIFF
--- a/.github/workflows/auto-sync-master-with-develop.yml
+++ b/.github/workflows/auto-sync-master-with-develop.yml
@@ -39,9 +39,16 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Merge Release Commit to Master
+        # Use a real merge (not --ff-only). master legitimately diverges from
+        # develop whenever a develop→master promotion is merged as a PR (which
+        # adds a merge/squash commit to master that isn't on develop), and
+        # --ff-only then fails permanently on every subsequent release. A no-ff
+        # merge always succeeds (non-destructive — master keeps its own commits,
+        # develop's release commits come in) and still changes CHANGELOG.md so
+        # release-dapps deploys.
         run: |
           git fetch origin develop
-          git merge --ff-only ${{ github.sha }}
+          git merge --no-ff -m "chore(release): sync develop into master (${{ github.sha }})" ${{ github.sha }}
 
       - name: Push Changes to Master
         run: git push origin master


### PR DESCRIPTION
## Problem

The `auto-sync-master-with-develop` workflow ran `git merge --ff-only <develop>` onto master. That fails permanently once `master` diverges from `develop` — which happens whenever a develop→master promotion lands as a PR (a merge/squash commit on master that isn't on develop). This is exactly what stalled the **tangle-cloud v0.0.4** release: the `[RELEASE]` commit landed on develop, auto-sync failed on `--ff-only`, and the promotion had to be done by hand (PR #3254).

## Fix

Use `git merge --no-ff` (with a message). It always succeeds, is non-destructive (master keeps its own commits; develop's release commits merge in), and still changes `CHANGELOG.md` so `release-dapps.yml` deploys. Future `[RELEASE]` pushes to develop will auto-sync to master without manual promotion.

## Note
Surfaced alongside a second pre-existing infra issue (separate fix, needs a secret rotation): `create-dapp-release`'s `secrets.REPO_TOKEN` is expired — the release-tag step fails with "Bad credentials." That only tags a GitHub release (the CF Pages deploy is git-integration-driven), but it should be rotated.

YAML-only change (outside the prettier/nx-lint globs); pushed through the pre-push hook.