### PR TITLE
feat(tangle-cloud): adopt chrome status and money contracts

### DIFF
--- a/.evolve/tangle-cloud-design-audit-2026-06-07.md
+++ b/.evolve/tangle-cloud-design-audit-2026-06-07.md
@@ -1,0 +1,126 @@
+# Product Design Audit
+
+Status: implemented and verified locally
+Product: Tangle Cloud blueprint catalog / registration / deploy flow
+Primary users: deployers browsing service blueprints; operators registering capacity
+Reference surfaces: existing Tangle Cloud chrome, Arena readability critique, `apps/tangle-cloud/PRODUCT_BRIEF.md`
+Product brief: `apps/tangle-cloud/PRODUCT_BRIEF.md`
+
+## Inventory
+- Route/page: `/blueprints`, `/blueprints?view=grid`, `/blueprints?register=0`, `/blueprints/:id/deploy`
+- Components: `BlueprintListing`, `ResultList`, `PageToolbar`, `StatusPill`, `BlueprintVisual`, `RegistrationDrawer`, `Header`, shared blueprint GraphQL hooks, shared wallet dropdown
+- States: loading, cached/degraded, list, grid, mobile, disconnected register drawer, disconnected deploy gate
+- Data dependencies: Envio indexer, direct chain fallback, selected Cloud network, wallet chain, React Query cache
+- Known complaints: glass-on-glass catalog, duplicate page title, missing blueprint logo/image, button dots, no caching on revisit, localhost RPC failure after wallet connect, hidden wallet address, italic network text, hard-to-read colors/fonts, tiny status labels, AI Agent deploy/register blank screen
+
+## Page Evaluations
+### Blueprints Catalog
+Purpose: choose a blueprint, compare capacity/trust, deploy or register.
+Primary user decision: deploy available blueprint or register operator capacity.
+Current score: 6/10 before; 8/10 after.
+Target score: 9/10.
+Findings:
+- Page header duplicated the topbar breadcrumb and consumed vertical space without adding a decision.
+- List rows used the same background family as the page and had no blueprint identity art.
+- Mobile list forced desktop columns into 390px, hiding titles under action buttons.
+- Grid cards hid actions until hover and could intermittently render blank under `content-visibility`.
+Complaint ledger:
+- Fixed: duplicate title removed; actions moved into toolbar.
+- Fixed: list/card surfaces use elevated card background, stronger borders, and generated/default visuals.
+- Fixed: mobile list has dedicated compact cards with identity, description, status, and actions.
+- Fixed: deploy/register action links have explicit action classes and no pseudo-dot affordances.
+- Fixed: status pills are larger and catalog capacity/audit pills omit decorative dots.
+- Fixed: grid actions are visible without hover.
+- Fixed: removed `content-visibility` from the result grid.
+Alternatives:
+- Keep dense desktop list only: 6/10; fails mobile and visual identity.
+- Default to card wall everywhere: 7/10; better identity, worse operator comparison.
+- Hybrid: desktop list/grid toggle with mobile-specific cards: 9/10; keeps density and mobile readability.
+Decision: hybrid.
+Changes shipped: `BlueprintListing`, `ResultList`, `PageToolbar`, `StatusPill`, `BlueprintVisual`, `styles.css`.
+Verification: screenshots `desktop-blueprints-list.png`, `desktop-blueprints-grid-v3.png`, `mobile-blueprints-list-v3.png`; no page errors; no horizontal overflow.
+Remaining risk: topbar breadcrumb still says `Blueprints`; acceptable after removing page title, but a future app-shell pass could move route context fully into page-local controls.
+
+### Register Drawer
+Purpose: register/preregister an active operator for selected blueprints.
+Primary user decision: connect operator wallet or continue registration.
+Current score: 7/10 before; 8/10 after.
+Target score: 9/10.
+Findings:
+- `/blueprints?register=0` opened a nonblank drawer, but the drawer had two close controls.
+Complaint ledger:
+- Fixed: duplicate custom close button removed; Radix dialog close remains.
+- Verified: mobile register screenshot shows connected-wallet gate, not a blank screen.
+Alternatives:
+- Keep drawer as-is: 6/10; looks broken.
+- Replace with route page: 7/10; more work, less continuity from catalog.
+- Keep drawer, remove duplicate close, preserve catalog context: 8/10.
+Decision: keep drawer and remove duplicate control.
+Verification: `mobile-blueprints-register-v3.png`; no page errors; no horizontal overflow.
+Remaining risk: disconnected drawer still visually overlays a full-page screenshot while background content appears below in full-page captures; viewport behavior is correct.
+
+### Deploy Gate
+Purpose: prepare and submit a service request transaction.
+Primary user decision: connect wallet, then configure instance.
+Current score: 6/10 before; 8/10 after.
+Target score: 9/10.
+Findings:
+- Disconnected deploy gate was generic, so a direct route such as `/blueprints/10/deploy` did not confirm the selected blueprint.
+Complaint ledger:
+- Fixed: disconnected deploy gate title includes the loaded blueprint name.
+- Verified: `/blueprints/10/deploy` contains `AI Agent Sandbox` and `Connect`.
+Alternatives:
+- Generic connect gate: 6/10; route context lost.
+- Full blueprint preview before wallet: 9/10; best UX but broader deploy-page composition.
+- Contextual connect gate with blueprint name: 8/10; low-risk fix now.
+Decision: contextual connect gate.
+Verification: `desktop-ai-agent-deploy-v2.png`; no page errors; no horizontal overflow.
+Remaining risk: richer disconnected preview belongs in a deeper deploy-flow pass.
+
+## Cross-Cutting System Findings
+- Navigation: removed catalog page header; topbar/sidebar remain the route shell.
+- Theme: dark palette is less purple and less bright; card/list surfaces now separate from page background.
+- Tables/charts: desktop list remains row-based; mobile list is not a squeezed table.
+- Density: toolbar wraps on mobile instead of cramming into one 44px row.
+- Copy/labels: no extra explanatory page title; statuses use larger text.
+- Interactions: card actions always visible; register drawer no longer double-closes; deploy gate carries blueprint context.
+- Responsiveness: 390px mobile has no horizontal overflow.
+- Data truth: browse data follows selected Cloud network rather than connected wallet chain; connected wallet no longer forces read-only catalog to dead localhost RPC.
+- Production/deploy: not deployed in this pass.
+
+## Product Innovation Audit
+- High-value innovation shipped: generated/default blueprint visual identity from deterministic category/name diagrams. This gives every blueprint a scannable artifact without trusting missing metadata images.
+- Reliability innovation shipped: read-only blueprint queries use Cloud network selection, keep previous data, and retain cache for 30 minutes. Wallet chain is reserved for transaction context instead of browse context.
+- Interaction innovation shipped: hybrid responsive catalog: desktop comparison list plus mobile action cards.
+- Rejected: app-store hero/gallery treatment. It would improve screenshots but weaken operator comparison and contradict the infrastructure-console brief.
+- Rejected: hiding register/deploy behind hover. It looks cleaner but makes primary actions feel missing and hurts touch devices.
+
+## Verification
+- Commands:
+  - `npx nx run tangle-cloud:typecheck`
+  - `npx nx build tangle-cloud`
+  - `npx nx test tangle-cloud` — 26 files, 167 tests passed
+  - `npx nx lint tangle-cloud` — passed with existing warnings
+  - `npx nx run ui-components:typecheck`
+  - `npx nx run tangle-shared-ui:test` — 5 suites, 74 tests passed
+  - `npx nx lint tangle-shared-ui` — passed with existing warnings
+  - `git diff --check`
+- Browser checks:
+  - `/blueprints`
+  - `/blueprints?view=grid`
+  - `/blueprints?register=0`
+  - `/blueprints/0/deploy`
+  - `/blueprints/10/deploy`
+- Screenshots:
+  - `.evolve/tangle-cloud-design-audit-2026-06-07/desktop-blueprints-list.png`
+  - `.evolve/tangle-cloud-design-audit-2026-06-07/desktop-blueprints-grid-v3.png`
+  - `.evolve/tangle-cloud-design-audit-2026-06-07/mobile-blueprints-list-v3.png`
+  - `.evolve/tangle-cloud-design-audit-2026-06-07/mobile-blueprints-register-v3.png`
+  - `.evolve/tangle-cloud-design-audit-2026-06-07/desktop-ai-agent-deploy-v2.png`
+- Deployment: not requested.
+- Live proof: local dev server at `http://127.0.0.1:4210` with polling due system watcher limit.
+
+## Next Pass
+- Add a richer disconnected deploy preview that shows blueprint identity, operators, and trust before wallet connect.
+- Consider moving route context out of the fixed topbar in a broader app-shell pass.
+- Add a configured testnet Envio endpoint to avoid expected fallback warnings during local browsing.

--- a/apps/tangle-cloud/src/app/CreditsProvider.tsx
+++ b/apps/tangle-cloud/src/app/CreditsProvider.tsx
@@ -48,12 +48,15 @@ export const CreditsProvider: FC<PropsWithChildren> = ({ children }) => {
     : undefined;
 
   useEffect(() => {
-    setCreditAccounts([]);
-    setIsLoading(true);
     const gen = ++genRef.current;
+    queueMicrotask(() => {
+      if (genRef.current === gen) {
+        setCreditAccounts([]);
+        setIsLoading(Boolean(address));
+      }
+    });
 
     if (!address) {
-      setIsLoading(false);
       return;
     }
 

--- a/apps/tangle-cloud/src/app/ShieldedProvider.tsx
+++ b/apps/tangle-cloud/src/app/ShieldedProvider.tsx
@@ -61,14 +61,19 @@ export const ShieldedProvider: FC<PropsWithChildren> = ({ children }) => {
   const [isReady, setIsReady] = useState(false);
   const storageRef = useRef<IndexedDbNoteStorage | null>(null);
   const notesRef = useRef(notes);
-  notesRef.current = notes;
   // Sequential write queue to prevent concurrent persist() from losing notes
   const writeQueueRef = useRef<Promise<void>>(Promise.resolve());
 
   useEffect(() => {
+    notesRef.current = notes;
+  }, [notes]);
+
+  useEffect(() => {
     // Reset synchronously to prevent stale data flash
-    setNotes([]);
-    setIsReady(false);
+    queueMicrotask(() => {
+      setNotes([]);
+      setIsReady(false);
+    });
     // Flush the write queue so no pending writes leak to the new address
     writeQueueRef.current = Promise.resolve();
 

--- a/apps/tangle-cloud/src/app/providers.tsx
+++ b/apps/tangle-cloud/src/app/providers.tsx
@@ -3,11 +3,13 @@ import { ToastProvider } from '@tangle-network/sandbox-ui/primitives';
 import useLocalChainGuard from '@tangle-network/tangle-shared-ui/hooks/useLocalChainGuard';
 import useNetworkSync from '@tangle-network/tangle-shared-ui/hooks/useNetworkSync';
 import { IndexerStatusProvider } from '@tangle-network/tangle-shared-ui/context/IndexerStatusContext';
+import useNetworkStore from '@tangle-network/tangle-shared-ui/context/useNetworkStore';
 import { isLocalPreviewHost } from '@tangle-network/tangle-shared-ui/utils/localPreview';
 import { FC, type PropsWithChildren, useEffect, useState } from 'react';
 import { WagmiProvider } from 'wagmi';
 import {
   ANVIL_LOCAL_NETWORK,
+  BASE_SEPOLIA_NETWORK,
   TANGLE_CLOUD_NETWORKS,
 } from '../constants/networks';
 import { cloudWagmiConfig } from './cloudWagmiConfig';
@@ -15,9 +17,23 @@ import PaymentProviders from './PaymentProviders';
 
 // Component to sync network store with wagmi chain
 const NetworkSync: FC<PropsWithChildren> = ({ children }) => {
+  const forceLocalChain = import.meta.env.VITE_FORCE_LOCAL_CHAIN === 'true';
+  const selectedNetwork = useNetworkStore((store) => store.network2);
+  const setNetwork = useNetworkStore((store) => store.setNetwork);
+
+  useEffect(() => {
+    if (forceLocalChain) {
+      return;
+    }
+
+    if (selectedNetwork?.evmChainId === ANVIL_LOCAL_NETWORK.evmChainId) {
+      setNetwork(BASE_SEPOLIA_NETWORK);
+    }
+  }, [forceLocalChain, selectedNetwork?.evmChainId, setNetwork]);
+
   useNetworkSync(TANGLE_CLOUD_NETWORKS);
   useLocalChainGuard({
-    enabled: isLocalPreviewHost(),
+    enabled: forceLocalChain && isLocalPreviewHost(),
     targetChainId: ANVIL_LOCAL_NETWORK.evmChainId ?? 31337,
   });
   return children;

--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrameOverlay.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrameOverlay.tsx
@@ -1,0 +1,167 @@
+import { type FC, type ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { Button } from '@tangle-network/sandbox-ui/primitives';
+import { focus, typeRole } from '../../styles/chrome';
+import StatusPill from '../../components/chrome/StatusPill';
+
+/**
+ * Designed load states for the embedded publisher app. The iframe is a dead
+ * rectangle until the origin responds; without these overlays a slow or
+ * unreachable origin shows a silent blank surface (audit EMBED-2). Each phase
+ * gets a real label, a tone pill, and — for the failure phases — a retry.
+ *
+ * Phases:
+ *   loading  — handshake hasn't completed; show a shape-matched skeleton so the
+ *              user sees the surface is alive, not frozen.
+ *   timeout  — `onLoad` never fired inside the budget; the origin is slow or the
+ *              network is degraded. Retry reloads the frame.
+ *   error    — the iframe element raised `error`, or the origin refused to frame
+ *              (X-Frame-Options / CSP). Retry + open-in-new-tab escape hatch.
+ *   blocked  — the parent couldn't build a valid iframe URL/origin (malformed
+ *              manifest). Not retryable here; the publisher must fix the manifest.
+ */
+export type FramePhase = 'loading' | 'ready' | 'timeout' | 'error' | 'blocked';
+
+type Props = {
+  phase: FramePhase;
+  appDisplayName: string;
+  /** Origin the app loads from — shown so the user can audit where it came from. */
+  origin: string;
+  /** Reload the iframe (bumps the key in the host). */
+  onRetry?: () => void;
+  /** Standalone URL for the open-in-new-tab escape hatch on failure phases. */
+  externalUrl?: string;
+  /** Rounded corners match the frame's 12px radius; focus-mode passes 0. */
+  rounded?: boolean;
+};
+
+const PHASE_COPY: Record<
+  Exclude<FramePhase, 'ready'>,
+  { tone: 'pending' | 'warning' | 'danger' | 'neutral'; label: string }
+> = {
+  loading: { tone: 'pending', label: 'Connecting' },
+  timeout: { tone: 'warning', label: 'Slow to respond' },
+  error: { tone: 'danger', label: 'Unavailable' },
+  blocked: { tone: 'danger', label: 'Blocked' },
+};
+
+const PHASE_TITLE: Record<Exclude<FramePhase, 'ready'>, string> = {
+  loading: 'Loading the app',
+  timeout: 'The app is taking too long',
+  error: 'The app could not be loaded',
+  blocked: 'This app cannot be embedded',
+};
+
+const phaseBody = (
+  phase: Exclude<FramePhase, 'ready'>,
+  appDisplayName: string,
+): ReactNode => {
+  switch (phase) {
+    case 'loading':
+      return `Waiting for ${appDisplayName} to respond.`;
+    case 'timeout':
+      return `${appDisplayName} did not finish loading. The origin may be slow or temporarily down — retry, or open it in a new tab.`;
+    case 'error':
+      return `${appDisplayName} refused to load in this frame. The origin may be offline or may not allow embedding.`;
+    case 'blocked':
+      return `The blueprint manifest does not point at a valid app origin, so it can't be embedded safely. The publisher must fix the manifest.`;
+  }
+};
+
+/**
+ * Skeleton that mirrors a typical embedded app's chrome (top bar + content
+ * blocks) so the loading state reads as the app's shape, not a spinner over a
+ * void. Pure decoration — aria-hidden — the live region lives in the overlay.
+ */
+const FrameSkeleton: FC = () => (
+  <div aria-hidden className="absolute inset-0 flex flex-col gap-3 p-4">
+    <div className="flex items-center gap-3">
+      <div className="h-7 w-7 animate-pulse rounded-md bg-[color:var(--bg-elevated)]" />
+      <div className="h-4 w-40 animate-pulse rounded bg-[color:var(--bg-elevated)]" />
+      <div className="ml-auto h-7 w-24 animate-pulse rounded-md bg-[color:var(--bg-elevated)]" />
+    </div>
+    <div className="grid flex-1 gap-3 md:grid-cols-3">
+      <div className="hidden animate-pulse rounded-lg bg-[color:var(--bg-elevated)] md:block" />
+      <div className="col-span-2 flex flex-col gap-3">
+        <div className="h-24 animate-pulse rounded-lg bg-[color:var(--bg-elevated)]" />
+        <div className="flex-1 animate-pulse rounded-lg bg-[color:var(--bg-elevated)]" />
+      </div>
+    </div>
+  </div>
+);
+
+/**
+ * Overlay rendered above the iframe for every non-ready phase. On `loading` it
+ * is a translucent veil over the skeleton (so a fast app flashes minimally); on
+ * failure phases it is an opaque panel with the recovery actions.
+ */
+const BlueprintAppFrameOverlay: FC<Props> = ({
+  phase,
+  appDisplayName,
+  origin,
+  onRetry,
+  externalUrl,
+  rounded = true,
+}) => {
+  if (phase === 'ready') return null;
+  const meta = PHASE_COPY[phase];
+  const isFailure = phase !== 'loading';
+
+  return (
+    <div
+      role={phase === 'error' || phase === 'blocked' ? 'alert' : 'status'}
+      aria-live="polite"
+      className={twMerge(
+        'absolute inset-0 z-10 flex items-center justify-center bg-background',
+        rounded && 'rounded-[12px]',
+        phase === 'loading' && 'bg-background/85 backdrop-blur-[1px]',
+      )}
+    >
+      {phase === 'loading' && <FrameSkeleton />}
+      <div
+        className={twMerge(
+          'relative flex max-w-md flex-col items-center gap-3 px-6 text-center',
+          isFailure &&
+            'rounded-lg border border-border bg-[color:var(--bg-card)] py-6 shadow-[var(--shadow-card)]',
+        )}
+      >
+        <StatusPill tone={meta.tone}>{meta.label}</StatusPill>
+        <div className="space-y-1.5">
+          <h2 className={twMerge(typeRole.section, 'text-foreground')}>
+            {PHASE_TITLE[phase]}
+          </h2>
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            {phaseBody(phase, appDisplayName)}
+          </p>
+          <p className="pt-1 font-mono text-[11px] text-muted-foreground/70">
+            {origin}
+          </p>
+        </div>
+        {isFailure && (
+          <div className="flex flex-wrap items-center justify-center gap-2 pt-1">
+            {onRetry && phase !== 'blocked' && (
+              <Button size="sm" onClick={onRetry}>
+                Retry
+              </Button>
+            )}
+            {externalUrl && (
+              <a
+                href={externalUrl}
+                target="_blank"
+                rel="noreferrer"
+                className={twMerge(
+                  'inline-flex h-8 items-center rounded-md border border-border bg-transparent px-3 text-xs font-medium text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
+                  focus.ring,
+                )}
+              >
+                Open in new tab ↗
+              </a>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BlueprintAppFrameOverlay;

--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppLandingPage.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppLandingPage.tsx
@@ -83,8 +83,14 @@ const BlueprintAppLandingPage: FC<Props> = ({ entry }) => {
   // directly. Each renderer falls back to a sensible default when its field
   // is absent so blueprints with no opinion still get a polished landing.
   const blueprintUi = canonicalBlueprint?.blueprintUi ?? null;
-  const overviewCards = blueprintUi?.overviewCards ?? [];
-  const actions = blueprintUi?.actions ?? [];
+  const overviewCards = useMemo(
+    () => blueprintUi?.overviewCards ?? [],
+    [blueprintUi?.overviewCards],
+  );
+  const actions = useMemo(
+    () => blueprintUi?.actions ?? [],
+    [blueprintUi?.actions],
+  );
   const theme = blueprintUi?.theme;
 
   // Right-hand "checkout path" panel — defaults to a three-step affordance
@@ -92,19 +98,16 @@ const BlueprintAppLandingPage: FC<Props> = ({ entry }) => {
   // each action becomes a step (label → optional description). Cap at 5 to
   // keep the column scannable; overflow lives on the deploy page.
   const checkoutSteps: { title: string; description?: string }[] =
-    useMemo(() => {
-      if (actions.length > 0) {
-        return actions.slice(0, 5).map((a: BlueprintUiAction) => ({
+    actions.length > 0
+      ? actions.slice(0, 5).map((a: BlueprintUiAction) => ({
           title: a.label,
           description: a.description,
-        }));
-      }
-      return [
-        { title: `Configure the ${serviceNoun}` },
-        { title: 'Choose registered operators' },
-        { title: `Track ${resourceNoun} output` },
-      ];
-    }, [actions, serviceNoun, resourceNoun]);
+        }))
+      : [
+          { title: `Configure the ${serviceNoun}` },
+          { title: 'Choose registered operators' },
+          { title: `Track ${resourceNoun} output` },
+        ];
 
   // Iframe-mode blueprints get the iframe-first layout — the publisher's
   // hosted app fills the viewport, our chrome is a 52px strip with the

--- a/apps/tangle-cloud/src/blueprintApps/iframe/useIframeBridge.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/useIframeBridge.ts
@@ -91,7 +91,9 @@ export function useIframeBridge({
   const [pendingApproval, setPendingApproval] =
     useState<PendingApproval | null>(null);
   const pendingRef = useRef(pendingApproval);
-  pendingRef.current = pendingApproval;
+  useEffect(() => {
+    pendingRef.current = pendingApproval;
+  }, [pendingApproval]);
   // correlationId of an in-flight tangle.app.requestConnect (the iframe asked
   // us to connect a wallet). Resolved when an account appears, or rejected if
   // the user dismisses the modal without connecting.
@@ -255,7 +257,9 @@ export function useIframeBridge({
     serviceContext?: IframeServiceContext;
     chainContext?: typeof chainContext;
   }>({});
-  syncRef.current = { address, chainId, serviceContext, chainContext };
+  useEffect(() => {
+    syncRef.current = { address, chainId, serviceContext, chainContext };
+  }, [address, chainContext, chainId, serviceContext]);
 
   const serviceContextKey = serviceContext
     ? JSON.stringify({ ...serviceContext, chain: chainContext })

--- a/apps/tangle-cloud/src/components/Header.tsx
+++ b/apps/tangle-cloud/src/components/Header.tsx
@@ -47,10 +47,6 @@ export default function Header({
   const pathname = useLocation().pathname;
   const trail = useMemo(() => getHeaderTrail(pathname), [pathname]);
   const topNavContent = useTopNavSlotContent();
-  const hasContextualConnect =
-    pathname.startsWith('/rewards') ||
-    pathname.startsWith('/earnings') ||
-    pathname.startsWith('/instances');
 
   return (
     <header
@@ -76,9 +72,10 @@ export default function Header({
 
         <ThemeToggle theme={theme} onThemeChange={onThemeChange} />
 
-        {!hasContextualConnect && (
-          <ConnectWalletButton className="tangle-cloud-wallet-action" />
-        )}
+        {/* Connection state lives in the chrome on every route — the header is
+         * the single owner of Connect Wallet. Pages never duplicate this; a
+         * disconnected page body renders a designed empty state instead. */}
+        <ConnectWalletButton className="tangle-cloud-wallet-action" />
       </div>
     </header>
   );
@@ -255,14 +252,15 @@ function CloudNetworkSelector({ networks }: { networks: Network[] }) {
     NetworkId | null | 'custom'
   >(null);
   const [customRpcEndpoint, setCustomRpcEndpoint] = useState('');
+  const evmChainId = network?.evmChainId;
 
   const isWrongEvmNetwork = useMemo(() => {
-    if (!isConnected || !network?.evmChainId) {
+    if (!isConnected || !evmChainId) {
       return false;
     }
 
-    return network.evmChainId !== chainId;
-  }, [chainId, isConnected, network?.evmChainId]);
+    return evmChainId !== chainId;
+  }, [chainId, evmChainId, isConnected]);
 
   const isLoading = isWalletConnecting || isSwitchingChain;
   const networkName = isLoading ? 'Connecting' : (network?.name ?? 'Network');
@@ -296,12 +294,12 @@ function CloudNetworkSelector({ networks }: { networks: Network[] }) {
   }, [customRpcEndpoint, setNetwork]);
 
   const switchToCorrectEvmChain = useCallback(() => {
-    if (!network?.evmChainId || !switchChain) {
+    if (!evmChainId || !switchChain) {
       return;
     }
 
-    switchChain({ chainId: network.evmChainId });
-  }, [network?.evmChainId, switchChain]);
+    switchChain({ chainId: evmChainId });
+  }, [evmChainId, switchChain]);
 
   return (
     <div className="flex items-center gap-2">

--- a/apps/tangle-cloud/src/components/Header.tsx
+++ b/apps/tangle-cloud/src/components/Header.tsx
@@ -60,7 +60,8 @@ export default function Header({
        * ("Blueprints / Trading"); pages can override it with contextual
        * content (name + actions) via useTopNavSlot. */}
       <div className="ml-12 flex min-w-0 flex-1 items-center gap-2 sm:ml-0">
-        {topNavContent ?? <HeaderTrail items={trail} />}
+        {topNavContent ??
+          (trail.length > 0 ? <HeaderTrail items={trail} /> : null)}
       </div>
 
       <div className="flex shrink-0 items-center justify-end gap-2">
@@ -104,6 +105,7 @@ const getHeaderTrail = (pathname: string): TrailItem[] => {
     return [blueprints, { label: 'Service' }];
   if (pathname.startsWith('/blueprints/') && pathname !== '/blueprints')
     return [blueprints, { label: 'Details' }];
+  if (pathname === '/blueprints') return [];
   if (pathname.startsWith('/blueprints')) return [blueprints];
 
   if (pathname === '/operators/manage') return [operators, { label: 'Manage' }];

--- a/apps/tangle-cloud/src/components/Header.tsx
+++ b/apps/tangle-cloud/src/components/Header.tsx
@@ -323,14 +323,16 @@ function CloudNetworkSelector({ networks }: { networks: Network[] }) {
             type="button"
             variant="outline"
             disabled={isLoading}
-            className="h-11 gap-2 border-border bg-muted/30 px-3 font-bold text-foreground hover:bg-muted"
+            className="h-11 gap-2 border-border bg-muted/30 px-3 font-sans font-medium not-italic text-foreground hover:bg-muted"
           >
             {isLoading ? (
               <Spinner size="lg" />
             ) : (
               <ChainIcon size="lg" className="shrink-0" name={networkName} />
             )}
-            <span className="hidden sm:inline">{networkName}</span>
+            <span className="hidden font-sans not-italic sm:inline">
+              {networkName}
+            </span>
           </Button>
         </DropdownMenuTrigger>
 
@@ -353,7 +355,9 @@ function CloudNetworkSelector({ networks }: { networks: Network[] }) {
                   ) : (
                     <ChainIcon size="lg" name={item.name} />
                   )}
-                  <span className="truncate font-semibold">{item.name}</span>
+                  <span className="truncate font-sans font-medium not-italic">
+                    {item.name}
+                  </span>
                 </span>
                 {isSelected && (
                   <StatusIndicator

--- a/apps/tangle-cloud/src/components/binaryUpgrade/PublishVersionDialog.tsx
+++ b/apps/tangle-cloud/src/components/binaryUpgrade/PublishVersionDialog.tsx
@@ -153,7 +153,9 @@ const WizardPublishDialog: FC<{
   // notify step.
   useEffect(() => {
     if (publishSuccess && furthestStep < 5) {
-      setFurthestStep(5);
+      queueMicrotask(() => {
+        setFurthestStep(5);
+      });
     }
   }, [publishSuccess, furthestStep]);
 

--- a/apps/tangle-cloud/src/components/blueprints/BlueprintVisual.tsx
+++ b/apps/tangle-cloud/src/components/blueprints/BlueprintVisual.tsx
@@ -1,5 +1,6 @@
 import type { Blueprint } from '@tangle-network/tangle-shared-ui/types/blueprint';
 import { useState, type CSSProperties } from 'react';
+import { twMerge } from 'tailwind-merge';
 import {
   formatBlueprintName,
   getGithubPreviewUrl,
@@ -30,13 +31,11 @@ export const BlueprintVisual = ({
 
   return (
     <div
-      className={[
+      className={twMerge(
         'relative isolate overflow-hidden rounded-xl border border-border bg-muted/40 shadow-[var(--shadow-card)]',
         compact ? 'h-24' : 'h-44',
         className,
-      ]
-        .filter(Boolean)
-        .join(' ')}
+      )}
       style={style}
     >
       {resolvedImageUrl ? (

--- a/apps/tangle-cloud/src/components/blueprints/BlueprintVisual.tsx
+++ b/apps/tangle-cloud/src/components/blueprints/BlueprintVisual.tsx
@@ -1,5 +1,5 @@
 import type { Blueprint } from '@tangle-network/tangle-shared-ui/types/blueprint';
-import { useEffect, useState, type CSSProperties } from 'react';
+import { useState, type CSSProperties } from 'react';
 import {
   formatBlueprintName,
   getGithubPreviewUrl,
@@ -22,14 +22,11 @@ export const BlueprintVisual = ({
   const imageUrl =
     getUsableMetadataImageUrl(blueprint.imgUrl) ??
     getGithubPreviewUrl(blueprint.githubUrl);
-  const [hasImageError, setHasImageError] = useState(false);
+  const [imageErrorUrl, setImageErrorUrl] = useState<string | null>(null);
   const displayName = formatBlueprintName(blueprint.name);
   const style = getBlueprintVisualStyle(`${displayName}:${category}`);
+  const hasImageError = imageErrorUrl === imageUrl;
   const resolvedImageUrl = imageUrl && !hasImageError ? imageUrl : null;
-
-  useEffect(() => {
-    setHasImageError(false);
-  }, [imageUrl]);
 
   return (
     <div
@@ -49,7 +46,7 @@ export const BlueprintVisual = ({
             alt=""
             className="absolute inset-0 h-full w-full object-cover opacity-80"
             loading="lazy"
-            onError={() => setHasImageError(true)}
+            onError={() => setImageErrorUrl(imageUrl)}
           />
           <div className="absolute inset-0 bg-gradient-to-br from-black/50 via-black/25 to-black/60" />
         </>

--- a/apps/tangle-cloud/src/components/chrome/CommandPalette.tsx
+++ b/apps/tangle-cloud/src/components/chrome/CommandPalette.tsx
@@ -153,8 +153,10 @@ const CommandPalette: FC<Props> = ({ open, onOpenChange, extra = [] }) => {
   // Reset on open / collapse on close so the next invocation starts fresh.
   useEffect(() => {
     if (open) {
-      setQuery('');
-      setActiveIndex(0);
+      queueMicrotask(() => {
+        setQuery('');
+        setActiveIndex(0);
+      });
       // Focus on next tick so the Dialog's autofocus doesn't steal it.
       const id = window.setTimeout(() => inputRef.current?.focus(), 10);
       return () => window.clearTimeout(id);
@@ -163,7 +165,9 @@ const CommandPalette: FC<Props> = ({ open, onOpenChange, extra = [] }) => {
   }, [open]);
 
   useEffect(() => {
-    setActiveIndex((i) => Math.min(i, Math.max(0, filtered.length - 1)));
+    queueMicrotask(() => {
+      setActiveIndex((i) => Math.min(i, Math.max(0, filtered.length - 1)));
+    });
   }, [filtered.length]);
 
   const onKeyDown = (e: React.KeyboardEvent) => {

--- a/apps/tangle-cloud/src/components/chrome/CopyableId.tsx
+++ b/apps/tangle-cloud/src/components/chrome/CopyableId.tsx
@@ -1,0 +1,103 @@
+import { useCallback, useState, type FC } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+type Props = {
+  /** The full value copied to the clipboard (id, hash, address). */
+  value: string | null | undefined;
+  /**
+   * Display text. Defaults to a middle-truncated form of `value` when it looks
+   * like a hash/address (long + hex), otherwise the raw value.
+   */
+  display?: string;
+  /** Middle-truncate hex-looking values to `head…tail`. Default true. */
+  truncate?: boolean;
+  className?: string;
+};
+
+function middleTruncate(value: string, head = 6, tail = 4): string {
+  if (value.length <= head + tail + 1) return value;
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
+/**
+ * Copyable identifier cell — mono, theme-aware, click-to-copy. The canonical
+ * way to render an id / tx hash / address inside a table or detail row so the
+ * operator can audit and copy the exact value (principle 2: copyable IDs). Long
+ * hex values are middle-truncated for scan density; the full value is always in
+ * `title` and on the clipboard.
+ */
+const CopyableId: FC<Props> = ({
+  value,
+  display,
+  truncate = true,
+  className,
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = useCallback(() => {
+    if (!value) return;
+    void navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    });
+  }, [value]);
+
+  if (!value) {
+    return <span className="text-muted-foreground">—</span>;
+  }
+
+  const looksHex = /^0x[0-9a-fA-F]{8,}$/.test(value);
+  const shown =
+    display ?? (truncate && looksHex ? middleTruncate(value) : value);
+
+  return (
+    <button
+      type="button"
+      onClick={onCopy}
+      title={copied ? 'Copied' : `Copy: ${value}`}
+      aria-label={`Copy ${value}`}
+      className={twMerge(
+        'group inline-flex max-w-full items-center gap-1 font-mono text-[13px] tabular-nums text-foreground transition-colors hover:text-[color:var(--border-accent-hover)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--border-accent-hover)]',
+        className,
+      )}
+    >
+      <span className="truncate">{shown}</span>
+      <span
+        aria-hidden
+        className="shrink-0 text-muted-foreground/60 transition-colors group-hover:text-[color:var(--border-accent-hover)]"
+      >
+        {copied ? (
+          <svg viewBox="0 0 16 16" fill="none" className="h-3 w-3" aria-hidden>
+            <path
+              d="M3.5 8.5l3 3 6-6.5"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        ) : (
+          <svg viewBox="0 0 16 16" fill="none" className="h-3 w-3" aria-hidden>
+            <rect
+              x="5.5"
+              y="5.5"
+              width="7"
+              height="7"
+              rx="1.2"
+              stroke="currentColor"
+              strokeWidth="1.2"
+            />
+            <path
+              d="M10.5 3.5H4.7c-.66 0-1.2.54-1.2 1.2v5.8"
+              stroke="currentColor"
+              strokeWidth="1.2"
+              strokeLinecap="round"
+            />
+          </svg>
+        )}
+      </span>
+    </button>
+  );
+};
+
+export default CopyableId;

--- a/apps/tangle-cloud/src/components/chrome/DataTable.tsx
+++ b/apps/tangle-cloud/src/components/chrome/DataTable.tsx
@@ -1,0 +1,177 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tangle-network/sandbox-ui/primitives';
+import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { focus, typeRole } from '../../styles/chrome';
+
+export type DataColumn<T> = {
+  /** Column header. */
+  header: ReactNode;
+  /** Cell renderer for a row. */
+  render: (item: T, index: number) => ReactNode;
+  /**
+   * Alignment. Use `right` for amounts/numerics so columns line up on the
+   * decimal — the senior move for a ledger.
+   */
+  align?: 'left' | 'right' | 'center';
+  /** Render this column's cells as mono tabular numerics (IDs, hashes, amounts). */
+  mono?: boolean;
+  /** Width / sizing class for the `<th>`/`<td>` (e.g. `w-24`, `w-[1%]`). */
+  className?: string;
+  /** Header-cell class override. */
+  headerClassName?: string;
+  /** Fold this column on narrow viewports. */
+  hideBelow?: 'sm' | 'md' | 'lg' | 'xl';
+};
+
+type Props<T> = {
+  items: T[];
+  columns: DataColumn<T>[];
+  rowKey: (item: T, index: number) => string;
+  /** Make rows clickable (entire row is the target). */
+  onRowClick?: (item: T, index: number) => void;
+  /** Caption for screen readers. */
+  caption?: string;
+  /** Empty slot — pass an <EmptyState/> for the zero-row case. */
+  empty?: ReactNode;
+  className?: string;
+};
+
+const HIDE_CLASS: Record<
+  NonNullable<DataColumn<unknown>['hideBelow']>,
+  string
+> = {
+  sm: 'hidden sm:table-cell',
+  md: 'hidden md:table-cell',
+  lg: 'hidden lg:table-cell',
+  xl: 'hidden xl:table-cell',
+};
+
+const ALIGN_CLASS: Record<NonNullable<DataColumn<unknown>['align']>, string> = {
+  left: 'text-left',
+  right: 'text-right',
+  center: 'text-center',
+};
+
+/**
+ * Dense console table — the design-system instrument for in-page ledgers,
+ * job history, payout events, and any N-row homogeneous data inside a detail
+ * surface. Wraps the design-system `Table` family with the console defaults the
+ * brief mandates: mono tabular numerics, right-aligned amounts, copyable IDs
+ * (via the `mono` + `<CopyableId>` helpers), thin borders, row-as-target.
+ *
+ * Use this — NOT a hand-rolled `<table>` (the F4-svc bug) — whenever the data
+ * is tabular and lives inside a page. For top-level catalog/directory pages
+ * that need search + view-toggle, use `ResultList` instead.
+ *
+ *   <DataTable
+ *     items={jobs}
+ *     rowKey={(j) => j.id}
+ *     columns={[
+ *       { header: 'Job', render: (j) => <CopyableId value={j.id} />, mono: true },
+ *       { header: 'Amount', align: 'right', mono: true,
+ *         render: (j) => <Money value={j.amount} options={{ decimals, symbol }} /> },
+ *       { header: 'Status', render: (j) =>
+ *         <StatusPill tone={statusToneFor('job', j.status)}>{j.status}</StatusPill> },
+ *     ]}
+ *   />
+ */
+function DataTable<T>({
+  items,
+  columns,
+  rowKey,
+  onRowClick,
+  caption,
+  empty,
+  className,
+}: Props<T>) {
+  if (items.length === 0 && empty !== undefined) {
+    return empty;
+  }
+
+  return (
+    <div
+      className={twMerge(
+        'overflow-x-auto rounded-lg border border-border',
+        className,
+      )}
+    >
+      <Table>
+        {caption && <caption className="sr-only">{caption}</caption>}
+        <TableHeader>
+          <TableRow className="border-b border-border hover:bg-transparent">
+            {columns.map((col, i) => (
+              <TableHead
+                key={i}
+                className={twMerge(
+                  typeRole.label,
+                  'h-9 whitespace-nowrap px-4 align-middle',
+                  col.align && ALIGN_CLASS[col.align],
+                  col.hideBelow && HIDE_CLASS[col.hideBelow],
+                  col.headerClassName ?? col.className,
+                )}
+              >
+                {col.header}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {items.map((item, index) => {
+            const interactive = onRowClick !== undefined;
+            return (
+              <TableRow
+                key={rowKey(item, index)}
+                tabIndex={interactive ? 0 : undefined}
+                onClick={
+                  interactive ? () => onRowClick(item, index) : undefined
+                }
+                onKeyDown={
+                  interactive
+                    ? (e: ReactKeyboardEvent) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          onRowClick(item, index);
+                        }
+                      }
+                    : undefined
+                }
+                className={twMerge(
+                  'border-b border-border/60 last:border-b-0',
+                  interactive &&
+                    twMerge(
+                      'cursor-pointer transition-colors hover:bg-[color:var(--bg-hover)]/60',
+                      focus.ring,
+                    ),
+                )}
+              >
+                {columns.map((col, i) => (
+                  <TableCell
+                    key={i}
+                    className={twMerge(
+                      'px-4 py-2.5 align-middle text-sm',
+                      col.align && ALIGN_CLASS[col.align],
+                      col.mono && 'font-mono text-[13px] tabular-nums',
+                      col.hideBelow && HIDE_CLASS[col.hideBelow],
+                      col.className,
+                    )}
+                  >
+                    {col.render(item, index)}
+                  </TableCell>
+                ))}
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+export default DataTable;

--- a/apps/tangle-cloud/src/components/chrome/FilterTray.tsx
+++ b/apps/tangle-cloud/src/components/chrome/FilterTray.tsx
@@ -44,7 +44,7 @@ const FilterTray: FC<Props> = ({
         <button
           type="button"
           className={twMerge(
-            'inline-flex h-9 items-center gap-2 rounded-md border border-border bg-muted/30 px-3 text-sm font-medium text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
+            'inline-flex h-9 items-center gap-2 rounded-md border border-border bg-muted/30 px-3 font-sans text-sm font-medium text-foreground not-italic transition-colors hover:bg-[color:var(--bg-hover)]',
             focus.ring,
           )}
         >
@@ -79,7 +79,7 @@ const FilterTray: FC<Props> = ({
                 variant="ghost"
                 size="sm"
                 onClick={onClear}
-                className="h-7 px-2 text-xs"
+                className="h-7 px-2 font-sans text-xs not-italic"
               >
                 Clear all
               </Button>

--- a/apps/tangle-cloud/src/components/chrome/FilterTray.tsx
+++ b/apps/tangle-cloud/src/components/chrome/FilterTray.tsx
@@ -44,7 +44,7 @@ const FilterTray: FC<Props> = ({
         <button
           type="button"
           className={twMerge(
-            'inline-flex h-9 items-center gap-2 rounded-md border border-border bg-transparent px-3 text-sm font-medium text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
+            'inline-flex h-9 items-center gap-2 rounded-md border border-border bg-muted/30 px-3 text-sm font-medium text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
             focus.ring,
           )}
         >

--- a/apps/tangle-cloud/src/components/chrome/Money.tsx
+++ b/apps/tangle-cloud/src/components/chrome/Money.tsx
@@ -1,0 +1,127 @@
+import { useCallback, useState, type FC } from 'react';
+import { twMerge } from 'tailwind-merge';
+import {
+  formatMoney,
+  type FormatMoneyOptions,
+  type MoneyView,
+} from '../../styles/chrome';
+
+type Props = {
+  /** Exact on-chain value. The component derives a lossless view from it. */
+  value: bigint | null | undefined;
+  /** Formatting contract — decimals, symbol, compact display. */
+  options?: FormatMoneyOptions;
+  /** Pre-built view (when the caller already computed one). Overrides `value`. */
+  view?: MoneyView;
+  /**
+   * Show the copy-full-precision affordance. Default true. Disable in extremely
+   * dense rows where copy lives elsewhere; the full value is still in `title`.
+   */
+  copyable?: boolean;
+  /** Render the unit/symbol after the number. Default true. */
+  showSymbol?: boolean;
+  /** Right-align (the default for amounts in tables/ledgers). */
+  align?: 'left' | 'right';
+  className?: string;
+};
+
+/**
+ * Canonical money cell. Renders the compact display from a {@link MoneyView},
+ * carries the unit, exposes the full-precision value on hover (`title`) and one
+ * click away (copy). This is the ONLY way money should render on the console —
+ * it makes the on-chain bigint exact, copyable, and auditable, which the brief
+ * mandates and the old `parseFloat` formatter violated.
+ *
+ *   <Money value={escrow.balance} options={{ decimals, symbol: 'TNT' }} />
+ *
+ * Empty values render an em-dash (never a fake `0`).
+ */
+const Money: FC<Props> = ({
+  value,
+  options,
+  view,
+  copyable = true,
+  showSymbol = true,
+  align = 'right',
+  className,
+}) => {
+  const money = view ?? formatMoney(value, options);
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = useCallback(() => {
+    if (money.isEmpty) return;
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return;
+
+    void navigator.clipboard.writeText(money.full).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    });
+  }, [money.full, money.isEmpty]);
+
+  const fullLabel = money.isEmpty
+    ? 'No value'
+    : `${money.full}${money.symbol ? ` ${money.symbol}` : ''}`;
+
+  return (
+    <span
+      className={twMerge(
+        'inline-flex items-baseline gap-1 font-mono text-[13px] tabular-nums',
+        align === 'right' && 'justify-end',
+        className,
+      )}
+      title={fullLabel}
+    >
+      <span className="text-foreground">{money.display}</span>
+      {showSymbol && money.symbol && !money.isEmpty && (
+        <span className="text-[11px] text-muted-foreground">
+          {money.symbol}
+        </span>
+      )}
+      {copyable && !money.isEmpty && (
+        <button
+          type="button"
+          onClick={onCopy}
+          title={`Copy full precision: ${fullLabel}`}
+          aria-label={`Copy full precision value ${fullLabel}`}
+          className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded text-muted-foreground/70 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--border-accent-hover)]"
+        >
+          {copied ? <CheckGlyph /> : <CopyGlyph />}
+        </button>
+      )}
+    </span>
+  );
+};
+
+const CopyGlyph: FC = () => (
+  <svg viewBox="0 0 16 16" fill="none" className="h-3 w-3" aria-hidden>
+    <rect
+      x="5.5"
+      y="5.5"
+      width="7"
+      height="7"
+      rx="1.2"
+      stroke="currentColor"
+      strokeWidth="1.2"
+    />
+    <path
+      d="M10.5 3.5H4.7c-.66 0-1.2.54-1.2 1.2v5.8"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+const CheckGlyph: FC = () => (
+  <svg viewBox="0 0 16 16" fill="none" className="h-3 w-3" aria-hidden>
+    <path
+      d="M3.5 8.5l3 3 6-6.5"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default Money;

--- a/apps/tangle-cloud/src/components/chrome/PageMotion.tsx
+++ b/apps/tangle-cloud/src/components/chrome/PageMotion.tsx
@@ -34,7 +34,9 @@ const PageMotion: FC<Props> = ({ children, className }) => {
   const [entering, setEntering] = useState(false);
 
   useEffect(() => {
-    setEntering(true);
+    queueMicrotask(() => {
+      setEntering(true);
+    });
     // Two rAFs: one to commit the entering state, one to clear it after the
     // browser has had a chance to render the initial keyframe state. The
     // CSS animation handles the actual transition; the attribute is just a

--- a/apps/tangle-cloud/src/components/chrome/PageToolbar.tsx
+++ b/apps/tangle-cloud/src/components/chrome/PageToolbar.tsx
@@ -45,12 +45,12 @@ const PageToolbar: FC<Props> = ({
     <div
       className={twMerge(
         chromeHeight.toolbar,
-        'flex w-full items-center gap-3 border-b border-border bg-background',
-        sticky && 'sticky top-0 z-20',
+        'flex w-full flex-wrap items-center gap-2 rounded-lg border border-border bg-[color:var(--bg-card)] px-2 py-1.5 shadow-[var(--shadow-card)] sm:flex-nowrap sm:gap-3',
+        sticky && 'sticky top-16 z-20',
         className,
       )}
     >
-      <div className="relative flex min-w-0 flex-1 items-center">
+      <div className="relative flex min-w-[180px] flex-[1_1_260px] items-center">
         <Search
           className="pointer-events-none absolute left-3 h-4 w-4 fill-current text-muted-foreground"
           aria-hidden
@@ -63,7 +63,7 @@ const PageToolbar: FC<Props> = ({
           autoFocus={search.autoFocus}
           className={twMerge(
             'h-9 w-full rounded-md border border-transparent bg-transparent pl-9 pr-3 text-sm leading-tight text-foreground placeholder:text-muted-foreground/70',
-            'hover:border-border',
+            'hover:border-border focus:border-[color:var(--border-accent-hover)]',
             focus.ring,
           )}
         />
@@ -95,7 +95,9 @@ const PageToolbar: FC<Props> = ({
       )}
 
       {trailing !== undefined && (
-        <div className="flex shrink-0 items-center gap-2">{trailing}</div>
+        <div className="flex flex-[1_1_100%] flex-wrap items-center justify-start gap-2 sm:flex-none sm:justify-end">
+          {trailing}
+        </div>
       )}
     </div>
   );

--- a/apps/tangle-cloud/src/components/chrome/PageToolbar.tsx
+++ b/apps/tangle-cloud/src/components/chrome/PageToolbar.tsx
@@ -62,7 +62,7 @@ const PageToolbar: FC<Props> = ({
           placeholder={search.placeholder}
           autoFocus={search.autoFocus}
           className={twMerge(
-            'h-9 w-full rounded-md border border-transparent bg-transparent pl-9 pr-3 text-sm leading-tight text-foreground placeholder:text-muted-foreground/70',
+            'h-9 w-full rounded-md border border-transparent bg-transparent pl-9 pr-3 font-sans text-sm leading-tight text-foreground not-italic placeholder:text-muted-foreground/70',
             'hover:border-border focus:border-[color:var(--border-accent-hover)]',
             focus.ring,
           )}

--- a/apps/tangle-cloud/src/components/chrome/ResultList.tsx
+++ b/apps/tangle-cloud/src/components/chrome/ResultList.tsx
@@ -53,12 +53,12 @@ function ResultList<T>({
   return (
     <div
       className={twMerge(
-        'overflow-hidden rounded-lg border border-border',
+        'overflow-hidden rounded-lg border border-border bg-[color:var(--bg-card)] shadow-[var(--shadow-card)]',
         className,
       )}
     >
       {/* Header */}
-      <div className="flex items-center border-b border-border bg-[color:var(--bg-card)]/40 px-4 py-2">
+      <div className="flex items-center border-b border-border bg-[color:var(--bg-elevated)]/80 px-4 py-2.5">
         {columns.map((col, i) => (
           <div
             key={i}
@@ -96,9 +96,9 @@ function ResultList<T>({
                   : undefined
               }
               className={twMerge(
-                'flex items-center border-b border-border/60 px-4 py-3 text-sm last:border-b-0',
+                'flex items-center border-b border-border/60 bg-[color:var(--bg-card)] px-4 py-3.5 text-sm last:border-b-0',
                 interactive &&
-                  'cursor-pointer transition-colors hover:bg-[color:var(--bg-hover)]/60',
+                  'cursor-pointer transition-colors hover:bg-[color:var(--bg-hover)]',
                 interactive && focus.ring,
               )}
             >

--- a/apps/tangle-cloud/src/components/chrome/StatusPill.tsx
+++ b/apps/tangle-cloud/src/components/chrome/StatusPill.tsx
@@ -38,7 +38,7 @@ const StatusPill: FC<Props> = ({
 }) => (
   <span
     className={twMerge(
-      'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-semibold leading-none',
+      'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold leading-none',
       statusPill[tone],
       className,
     )}

--- a/apps/tangle-cloud/src/components/chrome/StatusPill.tsx
+++ b/apps/tangle-cloud/src/components/chrome/StatusPill.tsx
@@ -1,38 +1,63 @@
 import type { FC, ReactNode } from 'react';
 import { twMerge } from 'tailwind-merge';
-import { statusPill, type StatusTone } from '../../styles/chrome';
+import { statusDot, statusPill, type StatusTone } from '../../styles/chrome';
 
 type Props = {
   tone?: StatusTone;
   children: ReactNode;
   className?: string;
-  /** Optional leading icon (sized 12px). */
+  /** Optional leading icon (sized 12px). Overrides the auto tone dot. */
   icon?: ReactNode;
+  /**
+   * Render a small leading tone dot when no `icon` is supplied. Default true.
+   * The dot reads the same hue as the pill border so the status is legible at a
+   * glance even before the label. `pending` tone pulses softly.
+   */
+  dot?: boolean;
 };
 
 /**
- * Outlined status pill — single tone per status, never filled. Use for
- * service state, audit state, capacity state, network state. **Not** for
- * decoration; pills should always reflect a model field the operator can act
- * on.
+ * Outlined status pill — single tone per status, never filled. The one
+ * canonical status badge for the whole console: service / instance / job /
+ * operator / payment state, audit state, capacity state.
+ *
+ * Pair with `statusToneFor(domain, status)` so a domain status maps to a tone
+ * in exactly one place:
+ *
+ *   <StatusPill tone={statusToneFor('service', 'Active')}>Active</StatusPill>
+ *
+ * **Not** for decoration; a pill should always reflect a model field the
+ * operator can act on.
  */
 const StatusPill: FC<Props> = ({
   tone = 'neutral',
   children,
   className,
   icon,
+  dot = true,
 }) => (
   <span
     className={twMerge(
-      'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold leading-none',
+      'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-semibold leading-none',
       statusPill[tone],
       className,
     )}
   >
-    {icon !== undefined && (
+    {icon !== undefined ? (
       <span className="inline-flex h-3 w-3 items-center justify-center">
         {icon}
       </span>
+    ) : (
+      dot && (
+        <span
+          aria-hidden
+          className={twMerge(
+            'inline-block h-1.5 w-1.5 shrink-0 rounded-full',
+            statusDot[tone],
+            tone === 'pending' && 'animate-pulse',
+          )}
+        />
+      )
     )}
     {children}
   </span>

--- a/apps/tangle-cloud/src/components/chrome/TopNavSlot.tsx
+++ b/apps/tangle-cloud/src/components/chrome/TopNavSlot.tsx
@@ -2,9 +2,14 @@ import {
   createContext,
   useContext,
   useEffect,
-  useState,
+  useMemo,
   type ReactNode,
 } from 'react';
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { twMerge } from 'tailwind-merge';
+import StatusPill from './StatusPill';
+import type { StatusTone } from '../../styles/chrome';
 
 /**
  * Lets a page inject content (pills, contextual actions) into the global top
@@ -46,4 +51,86 @@ export function useTopNavSlot(node: ReactNode): void {
     ctx.setContent(node);
     return () => ctx.setContent(null);
   }, [ctx, node]);
+}
+
+/**
+ * Ergonomic publish API for detail pages: declare the entity identity (the
+ * section breadcrumb + the entity name), an optional status, and an optional
+ * primary action, and this builds the canonical top-nav row and publishes it.
+ *
+ * This is the single place that owns the breadcrumb + identity + status +
+ * action layout, so every detail page reads identically in the chrome without
+ * re-implementing truncation, the `ml-auto` action group, or the breadcrumb
+ * separator. A detail page adopts the contextual top nav with one call:
+ *
+ *   useTopNavEntity({
+ *     section: 'Instances',
+ *     sectionHref: PagePath.INSTANCES,
+ *     name: service.name,
+ *     status: { label: service.status, tone: statusToneFor('service', service.status) },
+ *     actions: <Button size="sm">Submit job</Button>,
+ *   });
+ *
+ * Principle map #8: global controls live in the chrome; the contextual top bar
+ * carries entity identity + the single primary action.
+ */
+export type TopNavEntity = {
+  /** Section root label, e.g. "Instances" / "Blueprints". */
+  section: string;
+  /** Section root href; the label links back to the section catalog. */
+  sectionHref: string;
+  /** The entity name (truncates). The leaf of the breadcrumb. */
+  name: ReactNode;
+  /**
+   * Optional status pill rendered next to the name — the one canonical badge,
+   * never a hand-rolled chip. Use `statusToneFor(domain, status)` for the tone.
+   */
+  status?: { label: ReactNode; tone: StatusTone };
+  /** Optional right-aligned primary action(s). Keep to one button on most pages. */
+  actions?: ReactNode;
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useTopNavEntity(entity: TopNavEntity | null): void {
+  const { section, sectionHref, name, status, actions } = entity ?? {};
+  const statusLabel = status?.label;
+  const statusTone = status?.tone;
+
+  const node = useMemo<ReactNode>(() => {
+    if (!entity) return null;
+    return (
+      <>
+        <nav
+          aria-label="Breadcrumb"
+          className="flex min-w-0 items-center gap-1.5 text-[13px]"
+        >
+          <Link
+            to={sectionHref ?? '#'}
+            className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {section}
+          </Link>
+          <span aria-hidden className="text-muted-foreground/40">
+            /
+          </span>
+          <span className="truncate font-semibold text-foreground">{name}</span>
+        </nav>
+        {statusTone !== undefined && (
+          <span className="hidden shrink-0 md:inline-flex">
+            <StatusPill tone={statusTone}>{statusLabel}</StatusPill>
+          </span>
+        )}
+        {actions !== undefined && (
+          <div className={twMerge('ml-auto flex shrink-0 items-center gap-2')}>
+            {actions}
+          </div>
+        )}
+      </>
+    );
+    // `entity` is included so a null->object transition re-publishes; the
+    // primitive fields drive the memo so a parent that rebuilds the object each
+    // render (without changing values) doesn't thrash the publish effect.
+  }, [entity, section, sectionHref, name, statusLabel, statusTone, actions]);
+
+  useTopNavSlot(node);
 }

--- a/apps/tangle-cloud/src/components/chrome/ViewToggle.tsx
+++ b/apps/tangle-cloud/src/components/chrome/ViewToggle.tsx
@@ -79,7 +79,7 @@ const ViewButton: FC<{
       onClick={onClick}
       title={kind === 'grid' ? 'Grid view' : 'List view'}
       className={twMerge(
-        'inline-flex h-7 w-8 items-center justify-center rounded transition-colors',
+        'inline-flex h-7 w-8 items-center justify-center rounded font-sans not-italic transition-colors',
         active
           ? 'bg-[color:var(--bg-hover)] text-foreground'
           : 'text-muted-foreground hover:text-foreground',

--- a/apps/tangle-cloud/src/components/chrome/ViewToggle.tsx
+++ b/apps/tangle-cloud/src/components/chrome/ViewToggle.tsx
@@ -47,7 +47,7 @@ const ViewToggle: FC<Props> = ({ value, onChange, className }) => {
       role="radiogroup"
       aria-label="View"
       className={twMerge(
-        'inline-flex h-9 items-center rounded-md border border-border bg-transparent p-0.5',
+        'inline-flex h-9 items-center rounded-md border border-border bg-muted/30 p-0.5',
         className,
       )}
     >

--- a/apps/tangle-cloud/src/components/chrome/index.ts
+++ b/apps/tangle-cloud/src/components/chrome/index.ts
@@ -20,6 +20,11 @@
  *   </PageLayout>
  */
 
+export { default as CopyableId } from './CopyableId';
+
+export { default as DataTable } from './DataTable';
+export type { DataColumn } from './DataTable';
+
 export { default as EmptyState } from './EmptyState';
 export type { EmptyKind } from './EmptyState';
 
@@ -27,6 +32,8 @@ export { default as FilterTray } from './FilterTray';
 
 export { default as MetricStrip } from './MetricStrip';
 export type { Metric, MetricTone } from './MetricStrip';
+
+export { default as Money } from './Money';
 
 export { default as PageHeader } from './PageHeader';
 
@@ -41,3 +48,20 @@ export { default as StatusPill } from './StatusPill';
 
 export { default as ViewToggle } from './ViewToggle';
 export type { ResultView } from './ViewToggle';
+
+// Design-system contracts (tokens + helpers) — re-exported so surfaces have a
+// single import path for the whole chrome system. The status tone mapping and
+// the money formatter are the two canonical contracts every surface shares.
+export {
+  formatMoney,
+  statusDot,
+  statusPill,
+  statusToneFor,
+  typeRole,
+} from '../../styles/chrome';
+export type {
+  FormatMoneyOptions,
+  MoneyView,
+  StatusDomain,
+  StatusTone,
+} from '../../styles/chrome';

--- a/apps/tangle-cloud/src/components/sandbox/SandboxUi.tsx
+++ b/apps/tangle-cloud/src/components/sandbox/SandboxUi.tsx
@@ -33,7 +33,14 @@ import {
   TabsTrigger,
   Textarea,
 } from '@tangle-network/sandbox-ui/primitives';
-import type { ChangeEvent, ComponentProps, FC, ReactNode } from 'react';
+import {
+  forwardRef,
+  type ChangeEvent,
+  type ComponentProps,
+  type ComponentRef,
+  type FC,
+  type ReactNode,
+} from 'react';
 
 // Re-export the canonical tangle-cloud Text from the dedicated module so we
 // preserve the existing import surface (`import { Text } from '...sandbox/SandboxUi'`)
@@ -149,43 +156,54 @@ export type ButtonProps = Omit<
   disabledTooltip?: string;
 };
 
-export const Button: FC<ButtonProps> = ({
-  variant,
-  size,
-  isDisabled,
-  isLoading,
-  isJustIcon,
-  isFullWidth,
-  leftIcon,
-  rightIcon,
-  loadingText: _loadingText,
-  disabledTooltip: _disabledTooltip,
-  disabled,
-  className = '',
-  children,
-  ...props
-}) => (
-  <SandboxButton
-    variant={
-      variant === 'utility'
-        ? 'outline'
-        : variant === 'primary'
-          ? 'default'
-          : variant
-    }
-    size={isJustIcon ? 'icon' : size}
-    disabled={disabled || isDisabled}
-    loading={isLoading}
-    className={[isFullWidth ? 'w-full' : '', className]
-      .filter(Boolean)
-      .join(' ')}
-    {...props}
-  >
-    {leftIcon}
-    {children}
-    {rightIcon}
-  </SandboxButton>
+export const Button = forwardRef<
+  ComponentRef<typeof SandboxButton>,
+  ButtonProps
+>(
+  (
+    {
+      variant,
+      size,
+      isDisabled,
+      isLoading,
+      isJustIcon,
+      isFullWidth,
+      leftIcon,
+      rightIcon,
+      loadingText: _loadingText,
+      disabledTooltip: _disabledTooltip,
+      disabled,
+      className = '',
+      children,
+      ...props
+    },
+    ref,
+  ) => (
+    <SandboxButton
+      ref={ref}
+      variant={
+        variant === 'utility'
+          ? 'outline'
+          : variant === 'primary'
+            ? 'default'
+            : variant
+      }
+      size={isJustIcon ? 'icon' : size}
+      disabled={disabled || isDisabled}
+      loading={isLoading}
+      className={[isFullWidth ? 'w-full' : '', className]
+        .filter(Boolean)
+        .join(' ')}
+      {...props}
+    >
+      {leftIcon}
+      {children}
+      {rightIcon}
+    </SandboxButton>
+  ),
 );
+
+Button.displayName = 'Button';
 
 export type InputProps = Omit<
   ComponentProps<typeof SandboxInput>,
@@ -321,13 +339,51 @@ export const ModalFooterActions: FC<{
   </DialogFooter>
 );
 
+// Map every `color` label callers pass to a *distinct* Badge variant. The old
+// map only knew green→success / red→destructive, so blue/purple/yellow all
+// collapsed to one identical `outline` pill — Fixed vs Dynamic membership and
+// PayOnce vs Subscription vs EventDriven pricing rendered the same (audit
+// F1-svc). The Badge variant set is the source of truth:
+// default | secondary | destructive | outline | success | warning | info.
+//
+// New status badges should prefer the canonical `<StatusPill>` +
+// `statusToneFor(domain, status)` (src/components/chrome). This `Chip` is the
+// legacy color-string surface kept truthful for existing call sites.
+const CHIP_COLOR_TO_VARIANT: Record<
+  string,
+  | 'default'
+  | 'secondary'
+  | 'destructive'
+  | 'outline'
+  | 'success'
+  | 'warning'
+  | 'info'
+> = {
+  green: 'success',
+  emerald: 'success',
+  red: 'destructive',
+  rose: 'destructive',
+  yellow: 'warning',
+  amber: 'warning',
+  orange: 'warning',
+  blue: 'info',
+  cyan: 'info',
+  purple: 'secondary',
+  violet: 'secondary',
+  grey: 'outline',
+  gray: 'outline',
+  'dark-grey': 'outline',
+  'dark-gray': 'outline',
+  neutral: 'outline',
+};
+
 export const Chip: FC<{
   color?: string;
   className?: string;
   children: ReactNode;
 }> = ({ color, className, children }) => {
   const variant =
-    color === 'green' ? 'success' : color === 'red' ? 'destructive' : 'outline';
+    (color && CHIP_COLOR_TO_VARIANT[color.toLowerCase()]) ?? 'outline';
 
   return (
     <Badge variant={variant} className={className}>

--- a/apps/tangle-cloud/src/hooks/payments/useKeypair.ts
+++ b/apps/tangle-cloud/src/hooks/payments/useKeypair.ts
@@ -28,15 +28,19 @@ const useKeypair = () => {
 
   // Track current address to detect stale async completions
   const addressRef = useRef(address);
-  addressRef.current = address;
+  useEffect(() => {
+    addressRef.current = address;
+  }, [address]);
 
   useEffect(() => {
-    setKeypair(null);
-    setError(null);
-    setIsLoading(false); // Cancel any stuck loading state from previous address
-    setHasStoredKeypair(
-      !!address && localStorage.getItem(`${STORAGE_KEY}:${address}`) !== null,
-    );
+    queueMicrotask(() => {
+      setKeypair(null);
+      setError(null);
+      setIsLoading(false); // Cancel any stuck loading state from previous address
+      setHasStoredKeypair(
+        !!address && localStorage.getItem(`${STORAGE_KEY}:${address}`) !== null,
+      );
+    });
   }, [address]);
 
   const deriveKeypair = useCallback(async () => {

--- a/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
@@ -28,6 +28,7 @@ import type { Blueprint } from '@tangle-network/tangle-shared-ui/types/blueprint
 import {
   Dispatch,
   FC,
+  ReactNode,
   SetStateAction,
   useCallback,
   useDeferredValue,
@@ -56,6 +57,7 @@ import {
   dedupeBlueprintsByIdentity,
   type DedupedBlueprintRow,
 } from '../../blueprintApps/dedupe';
+import { BlueprintVisual } from '../../components/blueprints/BlueprintVisual';
 
 const PAGE_SIZE = 12;
 
@@ -67,6 +69,8 @@ type Props = {
   rowSelection?: RowSelectionState;
   onRowSelectionChange?: Dispatch<SetStateAction<RowSelectionState>>;
   onRegisterBlueprint?: (blueprint: Blueprint) => void;
+  toolbarAction?: ReactNode;
+  onRetry?: () => void;
 } & Omit<UseAllBlueprintsReturn, 'refetch'>;
 
 const pluralize = (label: string, count: number) =>
@@ -198,7 +202,7 @@ const CategoryFilterMenu: FC<{
         <button
           type="button"
           className={twMerge(
-            'inline-flex h-9 items-center gap-2 rounded-md border border-border bg-transparent px-3 text-sm font-medium text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
+            'inline-flex h-9 items-center gap-2 rounded-md border border-border bg-muted/30 px-3 text-sm font-medium text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
             focus.ring,
           )}
         >
@@ -285,6 +289,8 @@ const BlueprintListing: FC<Props> = ({
   isLoading,
   error,
   onRegisterBlueprint,
+  toolbarAction,
+  onRetry,
 }) => {
   const navigate = useNavigate();
   // Filter state lives in the URL — refresh persists the view, deep-links are
@@ -466,18 +472,26 @@ const BlueprintListing: FC<Props> = ({
             'Service blueprint — deploy when operators are available.';
 
           return (
-            <div className="min-w-0">
-              <div className="flex min-w-0 items-center gap-2">
-                <span className="truncate font-display font-bold text-foreground text-sm">
-                  {formatBlueprintName(blueprint.name)}
-                </span>
-                <span className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground">
-                  #{blueprint.id.toString()}
-                </span>
+            <div className="flex min-w-0 items-center gap-3">
+              <BlueprintVisual
+                blueprint={blueprint}
+                category={getBlueprintCategory(blueprint)}
+                compact
+                className="h-12 w-12 shrink-0 rounded-md"
+              />
+              <div className="min-w-0">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className="truncate font-display font-bold text-foreground text-[15px] leading-tight">
+                    {formatBlueprintName(blueprint.name)}
+                  </span>
+                  <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+                    #{blueprint.id.toString()}
+                  </span>
+                </div>
+                <p className="mt-1 line-clamp-1 text-muted-foreground text-sm leading-snug">
+                  {description}
+                </p>
               </div>
-              <p className="mt-0.5 line-clamp-1 text-muted-foreground text-xs">
-                {description}
-              </p>
             </div>
           );
         },
@@ -485,6 +499,7 @@ const BlueprintListing: FC<Props> = ({
       {
         header: 'Operators',
         className: 'w-44',
+        hideBelow: 'md' as const,
         render: (row: DedupedBlueprintRow) => (
           <BlueprintCapacityPill
             operatorCount={row.blueprint.operatorsCount ?? 0}
@@ -501,7 +516,7 @@ const BlueprintListing: FC<Props> = ({
           return (
             <StatusPill
               tone={statusToneFor('audit', audited ? 'Audited' : 'Unaudited')}
-              dot={audited}
+              dot={false}
             >
               {audited ? 'Audited' : 'Unaudited'}
             </StatusPill>
@@ -520,7 +535,7 @@ const BlueprintListing: FC<Props> = ({
       },
       {
         header: 'Actions',
-        className: 'w-48 justify-end',
+        className: 'w-40 justify-end sm:w-48',
         render: (row: DedupedBlueprintRow) => {
           const { blueprint } = row;
           const blueprintHref = `${PagePath.BLUEPRINTS}/${blueprint.id.toString()}`;
@@ -532,7 +547,7 @@ const BlueprintListing: FC<Props> = ({
                 <Link
                   to={`${blueprintHref}/deploy`}
                   onClick={(event) => event.stopPropagation()}
-                  className="rounded-md bg-primary px-2.5 py-1.5 text-center font-semibold text-primary-foreground text-xs transition-colors hover:bg-primary/90"
+                  className={catalogPrimaryActionClass}
                 >
                   Deploy
                 </Link>
@@ -550,7 +565,7 @@ const BlueprintListing: FC<Props> = ({
     [auditedStatus, onRegisterBlueprint],
   );
 
-  if (isLoading) {
+  if (isLoading && blueprintItems.length === 0) {
     return (
       <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
         {Array.from({ length: 6 }).map((_, idx) => (
@@ -560,13 +575,23 @@ const BlueprintListing: FC<Props> = ({
     );
   }
 
-  if (error) {
+  if (error && blueprintItems.length === 0) {
     return (
       <Card variant="sandbox" className="border-destructive/20">
-        <CardContent className="flex min-h-40 items-center justify-center p-8 text-center">
-          <p className="max-w-2xl text-muted-foreground text-sm">
-            {error.message}
-          </p>
+        <CardContent className="flex min-h-40 flex-col items-center justify-center gap-3 p-8 text-center">
+          <div>
+            <p className="font-semibold text-foreground">
+              Unable to refresh blueprints
+            </p>
+            <p className="mt-1 max-w-2xl text-muted-foreground text-sm">
+              {error.message}
+            </p>
+          </div>
+          {onRetry !== undefined && (
+            <Button variant="outline" size="sm" onClick={onRetry}>
+              Retry
+            </Button>
+          )}
         </CardContent>
       </Card>
     );
@@ -612,6 +637,7 @@ const BlueprintListing: FC<Props> = ({
         }}
         trailing={
           <div className="flex flex-wrap items-center gap-2">
+            {toolbarAction}
             {!showSelection && <ViewToggle value={view} onChange={setView} />}
             <CategoryFilterMenu
               categories={categories}
@@ -676,6 +702,12 @@ const BlueprintListing: FC<Props> = ({
         }
       />
 
+      {error && (
+        <div className="rounded-lg border border-[color:var(--md3-warning,#f59e0b)]/35 bg-[color:var(--md3-warning,#f59e0b)]/10 px-4 py-3 text-sm text-[color:var(--surface-warning-text,var(--md3-warning,#f59e0b))]">
+          Showing cached blueprint data. Latest refresh failed: {error.message}
+        </div>
+      )}
+
       {dedupedRows.length === 0 ? (
         <EmptyState
           kind="no-match"
@@ -687,14 +719,29 @@ const BlueprintListing: FC<Props> = ({
           }
         />
       ) : effectiveView === 'list' ? (
-        <ResultList
-          items={visibleRows}
-          columns={listColumns}
-          rowKey={(row) => row.blueprint.id.toString()}
-          onRowClick={(row) =>
-            navigate(`${PagePath.BLUEPRINTS}/${row.blueprint.id.toString()}`)
-          }
-        />
+        <>
+          <div className="space-y-3 md:hidden">
+            {visibleRows.map((row) => (
+              <MobileBlueprintRow
+                key={row.blueprint.id.toString()}
+                row={row}
+                isAudited={
+                  auditedStatus.get(row.blueprint.id.toString()) ?? false
+                }
+                onRegister={onRegisterBlueprint}
+              />
+            ))}
+          </div>
+          <ResultList
+            className="hidden md:block"
+            items={visibleRows}
+            columns={listColumns}
+            rowKey={(row) => row.blueprint.id.toString()}
+            onRowClick={(row) =>
+              navigate(`${PagePath.BLUEPRINTS}/${row.blueprint.id.toString()}`)
+            }
+          />
+        </>
       ) : (
         <div className="results-grid grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
           {visibleRows.map((row) => (
@@ -911,7 +958,8 @@ const BlueprintCapacityPill = ({
         'availability',
         hasOperators ? 'Available' : 'Limited',
       )}
-      className="text-[10px] uppercase tracking-wider"
+      dot={false}
+      className="text-xs"
     >
       {hasOperators ? (
         <>
@@ -922,6 +970,86 @@ const BlueprintCapacityPill = ({
         'Needs operators'
       )}
     </StatusPill>
+  );
+};
+
+const catalogActionClass =
+  'inline-flex min-h-8 flex-1 items-center justify-center rounded-md border border-border bg-muted/30 px-3 py-1.5 text-center text-xs font-semibold text-foreground transition-colors before:hidden after:hidden hover:bg-[color:var(--bg-hover)]';
+
+const catalogPrimaryActionClass =
+  'inline-flex min-h-8 flex-1 items-center justify-center rounded-md bg-primary px-3 py-1.5 text-center text-xs font-semibold text-primary-foreground transition-colors before:hidden after:hidden hover:bg-primary/90';
+
+const MobileBlueprintRow = ({
+  row,
+  isAudited,
+  onRegister,
+}: {
+  row: DedupedBlueprintRow;
+  isAudited: boolean;
+  onRegister?: (blueprint: Blueprint) => void;
+}) => {
+  const { blueprint } = row;
+  const blueprintHref = `${PagePath.BLUEPRINTS}/${blueprint.id.toString()}`;
+  const operatorCount = blueprint.operatorsCount ?? 0;
+  const hasOperators = operatorCount > 0;
+  const description =
+    blueprint.description?.trim() ||
+    'Service blueprint — deploy when operators are available.';
+
+  return (
+    <article className="rounded-lg border border-border bg-[color:var(--bg-card)] p-3 shadow-[var(--shadow-card)]">
+      <Link
+        to={blueprintHref}
+        className={twMerge('flex min-w-0 gap-3', focus.ring)}
+      >
+        <BlueprintVisual
+          blueprint={blueprint}
+          category={getBlueprintCategory(blueprint)}
+          compact
+          className="h-14 w-14 shrink-0 rounded-md"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <h3 className="truncate font-display text-base font-bold leading-tight tracking-normal text-foreground">
+              {formatBlueprintName(blueprint.name)}
+            </h3>
+            <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+              #{blueprint.id.toString()}
+            </span>
+          </div>
+          <p className="mt-1 line-clamp-2 text-sm leading-snug text-muted-foreground">
+            {description}
+          </p>
+        </div>
+      </Link>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <BlueprintCapacityPill operatorCount={operatorCount} />
+        <StatusPill
+          tone={statusToneFor('audit', isAudited ? 'Audited' : 'Unaudited')}
+          dot={false}
+          className="text-xs"
+        >
+          {isAudited ? 'Audited' : 'Unaudited'}
+        </StatusPill>
+      </div>
+
+      <div className="mt-3 flex gap-2">
+        {hasOperators && (
+          <Link
+            to={`${blueprintHref}/deploy`}
+            className={catalogPrimaryActionClass}
+          >
+            Deploy
+          </Link>
+        )}
+        <RegisterCapacityButton
+          blueprint={blueprint}
+          onRegister={onRegister}
+          isPrimary={!hasOperators}
+        />
+      </div>
+    </article>
   );
 };
 
@@ -973,7 +1101,7 @@ const BlueprintCard = ({
   return (
     <div
       className={twMerge(
-        'group relative flex min-h-[180px] flex-col gap-3 rounded-lg border border-border bg-[color:var(--bg-card)] p-5 transition-all',
+        'group relative flex min-h-[260px] flex-col gap-3 rounded-lg border border-border bg-[color:var(--bg-card)] p-4 shadow-[var(--shadow-card)] transition-all',
         // Subtle hover: lift one pixel, tighten border accent. No gradient
         // glow. The card already has enough visual weight from its content.
         'hover:-translate-y-px hover:border-[color:var(--border-accent-hover)]',
@@ -989,6 +1117,13 @@ const BlueprintCard = ({
         to={blueprintHref}
         className="absolute inset-0 z-10"
         aria-label={`Open ${blueprint.name}`}
+      />
+
+      <BlueprintVisual
+        blueprint={blueprint}
+        category={getBlueprintCategory(blueprint)}
+        compact
+        className="h-28 rounded-md"
       />
 
       {/* Watermark ID — mono, low-contrast, top-right. The card's identity
@@ -1019,10 +1154,10 @@ const BlueprintCard = ({
 
       {/* Header — name + 1-line description. */}
       <div className={twMerge('min-w-0', isSelectable && 'pl-8')}>
-        <h3 className="line-clamp-1 pr-12 font-display font-bold text-base leading-tight tracking-tight text-foreground">
+        <h3 className="line-clamp-1 pr-12 font-display font-bold text-base leading-tight tracking-normal text-foreground">
           {displayName}
         </h3>
-        <p className="mt-1 line-clamp-2 pr-12 text-xs leading-relaxed text-muted-foreground">
+        <p className="mt-1 line-clamp-2 pr-12 text-sm leading-snug text-muted-foreground">
           {description}
         </p>
       </div>
@@ -1034,7 +1169,8 @@ const BlueprintCard = ({
         {isAudited && (
           <StatusPill
             tone={statusToneFor('audit', 'Audited')}
-            className="text-[10px] uppercase tracking-wider"
+            dot={false}
+            className="text-xs"
           >
             Audited
           </StatusPill>
@@ -1055,20 +1191,13 @@ const BlueprintCard = ({
        * On non-hover devices (touch) the actions are always visible — the
        * `group-hover:` selector only matches on pointer hover, so this is
        * automatic. */}
-      <div
-        className={twMerge(
-          'actions relative z-20 mt-2 flex gap-2 opacity-0 transition-opacity',
-          'group-hover:opacity-100 group-focus-within:opacity-100',
-          // Always visible on touch — `pointer: coarse` means no hover layer.
-          '[@media(pointer:coarse)]:opacity-100',
-        )}
-      >
+      <div className={twMerge('actions relative z-20 mt-2 flex gap-2')}>
         {hasOperators ? (
           <>
             <Link
               to={`${blueprintHref}/deploy`}
               onClick={(e) => e.stopPropagation()}
-              className="flex-1 rounded-md bg-primary px-2 py-1.5 text-center text-xs font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+              className={catalogPrimaryActionClass}
             >
               Deploy
             </Link>
@@ -1101,10 +1230,7 @@ const RegisterCapacityButton = ({
   <button
     type="button"
     className={twMerge(
-      'flex-1 rounded-md px-2 py-1.5 text-xs font-semibold transition-colors',
-      isPrimary
-        ? 'bg-primary text-primary-foreground hover:bg-primary/90'
-        : 'border border-border bg-transparent text-muted-foreground hover:bg-[color:var(--bg-hover)] hover:text-foreground',
+      isPrimary ? catalogPrimaryActionClass : catalogActionClass,
     )}
     onClick={(event) => {
       event.preventDefault();

--- a/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
@@ -61,9 +61,19 @@ import { BlueprintVisual } from '../../components/blueprints/BlueprintVisual';
 
 const PAGE_SIZE = 12;
 
-type AudienceFilter = 'all' | 'customers' | 'operators';
+type AvailabilityFilter = 'all' | 'deployable' | 'capacity';
 type ManifestFilter = 'all' | 'verified' | 'fallback';
 type AuditFilter = 'all' | 'audited';
+type FilterOption<T extends string> = {
+  value: T;
+  label: string;
+  description?: string;
+};
+type CatalogStat = {
+  label: string;
+  value: number;
+  detail: string;
+};
 
 type Props = {
   rowSelection?: RowSelectionState;
@@ -75,6 +85,23 @@ type Props = {
 
 const pluralize = (label: string, count: number) =>
   count === 1 ? label : `${label}s`;
+
+const availabilityOptions: FilterOption<AvailabilityFilter>[] = [
+  { value: 'all', label: 'All' },
+  { value: 'deployable', label: 'Deployable' },
+  { value: 'capacity', label: 'Needs capacity' },
+];
+
+const sourceOptions: FilterOption<ManifestFilter>[] = [
+  { value: 'all', label: 'All sources' },
+  { value: 'verified', label: 'Pinned source' },
+  { value: 'fallback', label: 'Chain-only' },
+];
+
+const trustOptions: FilterOption<AuditFilter>[] = [
+  { value: 'all', label: 'All trust' },
+  { value: 'audited', label: 'Audited' },
+];
 
 /**
  * Title-case a single tag so the catalog renders consistent chips even if
@@ -184,6 +211,13 @@ const matchesSearch = (blueprint: Blueprint, query: string) => {
   return haystack.includes(query);
 };
 
+const getBlueprintDescription = (blueprint: Blueprint) =>
+  blueprint.description?.trim() ||
+  'Service blueprint ready for deployment once capacity is available.';
+
+const getModeCount = (row: DedupedBlueprintRow) =>
+  row.modes?.length ?? (row.aliases.length > 0 ? row.aliases.length + 1 : 1);
+
 /**
  * Multi-select category dropdown for the toolbar. Replaces the old
  * full-width segmented row — categories collapse into one pill with a
@@ -202,7 +236,7 @@ const CategoryFilterMenu: FC<{
         <button
           type="button"
           className={twMerge(
-            'inline-flex h-9 items-center gap-2 rounded-md border border-border bg-muted/30 px-3 text-sm font-medium text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
+            'inline-flex h-9 items-center gap-2 rounded-md border border-border bg-muted/30 px-3 font-sans text-sm font-medium text-foreground not-italic transition-colors hover:bg-[color:var(--bg-hover)]',
             focus.ring,
           )}
         >
@@ -234,7 +268,7 @@ const CategoryFilterMenu: FC<{
               <button
                 type="button"
                 onClick={onClear}
-                className="text-xs text-muted-foreground hover:text-foreground"
+                className="font-sans text-xs text-muted-foreground not-italic hover:text-foreground"
               >
                 Clear
               </button>
@@ -253,7 +287,7 @@ const CategoryFilterMenu: FC<{
                   type="button"
                   onClick={() => onToggle(category)}
                   className={twMerge(
-                    'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
+                    'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left font-sans text-sm text-foreground not-italic transition-colors hover:bg-[color:var(--bg-hover)]',
                     focus.ring,
                   )}
                 >
@@ -281,6 +315,106 @@ const CategoryFilterMenu: FC<{
     </Popover.Root>
   );
 };
+
+const BlueprintCatalogHeader: FC<{
+  matchCount: number;
+  totalCount: number;
+  stats: CatalogStat[];
+}> = ({ matchCount, totalCount, stats }) => (
+  <section className="border-b border-border pb-5">
+    <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+      <div className="max-w-3xl">
+        <h1 className={twMerge(typeRole.display, 'text-foreground')}>
+          Blueprints
+        </h1>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+          Live service catalog with capacity, source, and trust signals for the
+          selected network.
+        </p>
+        <div className="mt-3 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          <span className={typeRole.mono}>
+            {matchCount.toLocaleString()}
+            {matchCount !== totalCount && (
+              <span className="opacity-60">
+                {' / '}
+                {totalCount.toLocaleString()}
+              </span>
+            )}
+          </span>
+          <span>{pluralize('blueprint', matchCount)}</span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4 lg:min-w-[520px]">
+        {stats.map((stat) => (
+          <div key={stat.label} className="border-l border-border pl-3">
+            <div className="font-mono text-2xl leading-none tabular-nums text-foreground">
+              {stat.value.toLocaleString()}
+            </div>
+            <div className={twMerge(typeRole.label, 'mt-1')}>{stat.label}</div>
+            <div className="mt-1 text-xs leading-tight text-muted-foreground">
+              {stat.detail}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+function FilterSegment<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+  stacked = false,
+}: {
+  label: string;
+  options: FilterOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  stacked?: boolean;
+}) {
+  return (
+    <div className={twMerge(stacked ? 'space-y-2' : 'flex items-center gap-2')}>
+      {stacked && <span className={typeRole.label}>{label}</span>}
+      <div
+        role="radiogroup"
+        aria-label={label}
+        className={twMerge(
+          'inline-flex min-h-9 rounded-md border border-border bg-muted/30 p-0.5',
+          stacked && 'grid w-full grid-cols-1 gap-1 bg-transparent p-0',
+        )}
+      >
+        {options.map((option) => {
+          const active = option.value === value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => onChange(option.value)}
+              className={twMerge(
+                'inline-flex min-h-8 items-center justify-center rounded px-3 font-sans text-sm font-medium not-italic transition-colors',
+                active
+                  ? 'bg-[color:var(--bg-hover)] text-foreground shadow-[inset_0_0_0_1px_var(--border-accent)]'
+                  : 'text-muted-foreground hover:text-foreground',
+                stacked && 'justify-start border border-border bg-muted/20',
+                stacked &&
+                  active &&
+                  'border-[color:var(--border-accent-hover)]',
+                focus.ring,
+              )}
+            >
+              <span>{option.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
 const BlueprintListing: FC<Props> = ({
   rowSelection,
@@ -322,10 +456,11 @@ const BlueprintListing: FC<Props> = ({
     },
     [selectedCategories, setCategoryParam],
   );
-  const [audienceFilter, setAudienceFilter] = useUrlState<AudienceFilter>(
-    'avail',
-    enumCodec(['all', 'customers', 'operators'] as const, 'all'),
-  );
+  const [availabilityFilter, setAvailabilityFilter] =
+    useUrlState<AvailabilityFilter>(
+      'avail',
+      enumCodec(['all', 'deployable', 'capacity'] as const, 'all'),
+    );
   const [manifestFilter, setManifestFilter] = useUrlState<ManifestFilter>(
     'source',
     enumCodec(['all', 'verified', 'fallback'] as const, 'all'),
@@ -379,14 +514,14 @@ const BlueprintListing: FC<Props> = ({
       }
 
       if (
-        audienceFilter === 'customers' &&
+        availabilityFilter === 'deployable' &&
         (blueprint.operatorsCount ?? 0) <= 0
       ) {
         return false;
       }
 
       if (
-        audienceFilter === 'operators' &&
+        availabilityFilter === 'capacity' &&
         (blueprint.operatorsCount ?? 0) >= 3
       ) {
         return false;
@@ -410,7 +545,7 @@ const BlueprintListing: FC<Props> = ({
       return true;
     });
   }, [
-    audienceFilter,
+    availabilityFilter,
     auditFilter,
     auditedStatus,
     blueprintItems,
@@ -425,7 +560,7 @@ const BlueprintListing: FC<Props> = ({
     setPage(0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    audienceFilter,
+    availabilityFilter,
     auditFilter,
     deferredSearchQuery,
     manifestFilter,
@@ -442,6 +577,47 @@ const BlueprintListing: FC<Props> = ({
     () => dedupeBlueprintsByIdentity(filteredBlueprints),
     [filteredBlueprints],
   );
+  const allDedupedRows = useMemo(
+    () => dedupeBlueprintsByIdentity(blueprintItems),
+    [blueprintItems],
+  );
+  const catalogStats = useMemo<CatalogStat[]>(() => {
+    let deployable = 0;
+    let capacityNeeded = 0;
+    let pinnedSource = 0;
+    let audited = 0;
+
+    for (const { blueprint } of allDedupedRows) {
+      const operatorCount = blueprint.operatorsCount ?? 0;
+      if (operatorCount > 0) deployable += 1;
+      if (operatorCount < 3) capacityNeeded += 1;
+      if (hasVerifiedManifest(blueprint)) pinnedSource += 1;
+      if (auditedStatus.get(blueprint.id.toString()) === true) audited += 1;
+    }
+
+    return [
+      {
+        label: 'Deployable',
+        value: deployable,
+        detail: 'ready now',
+      },
+      {
+        label: 'Need capacity',
+        value: capacityNeeded,
+        detail: 'below target',
+      },
+      {
+        label: 'Pinned',
+        value: pinnedSource,
+        detail: 'verified source',
+      },
+      {
+        label: 'Audited',
+        value: audited,
+        detail: 'trust signal',
+      },
+    ];
+  }, [allDedupedRows, auditedStatus]);
   const totalPages = Math.max(1, Math.ceil(dedupedRows.length / PAGE_SIZE));
   const safePage = Math.min(page, totalPages - 1);
   const visibleRows = dedupedRows.slice(
@@ -451,7 +627,7 @@ const BlueprintListing: FC<Props> = ({
   const hasActiveFilters =
     searchQuery.trim() !== '' ||
     selectedCategories.length > 0 ||
-    audienceFilter !== 'all' ||
+    availabilityFilter !== 'all' ||
     manifestFilter !== 'all' ||
     auditFilter !== 'all';
 
@@ -464,44 +640,17 @@ const BlueprintListing: FC<Props> = ({
     () => [
       {
         header: 'Blueprint',
-        className: 'min-w-0 flex-[2]',
-        render: (row: DedupedBlueprintRow) => {
-          const { blueprint } = row;
-          const description =
-            blueprint.description?.trim() ||
-            'Service blueprint — deploy when operators are available.';
-
-          return (
-            <div className="flex min-w-0 items-center gap-3">
-              <BlueprintVisual
-                blueprint={blueprint}
-                category={getBlueprintCategory(blueprint)}
-                compact
-                className="h-12 w-12 shrink-0 rounded-md"
-              />
-              <div className="min-w-0">
-                <div className="flex min-w-0 items-center gap-2">
-                  <span className="truncate font-display font-bold text-foreground text-[15px] leading-tight">
-                    {formatBlueprintName(blueprint.name)}
-                  </span>
-                  <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
-                    #{blueprint.id.toString()}
-                  </span>
-                </div>
-                <p className="mt-1 line-clamp-1 text-muted-foreground text-sm leading-snug">
-                  {description}
-                </p>
-              </div>
-            </div>
-          );
-        },
+        className: 'min-w-0 flex-[2.4]',
+        render: (row: DedupedBlueprintRow) => (
+          <BlueprintIdentitySummary row={row} />
+        ),
       },
       {
-        header: 'Operators',
-        className: 'w-44',
+        header: 'Capacity',
+        className: 'w-40',
         hideBelow: 'md' as const,
         render: (row: DedupedBlueprintRow) => (
-          <BlueprintCapacityPill
+          <BlueprintCapacityCell
             operatorCount={row.blueprint.operatorsCount ?? 0}
           />
         ),
@@ -524,18 +673,35 @@ const BlueprintListing: FC<Props> = ({
         },
       },
       {
-        header: 'Instances',
-        className: 'w-28 justify-end',
+        header: 'Source',
+        className: 'w-32',
+        hideBelow: 'lg' as const,
+        render: (row: DedupedBlueprintRow) => {
+          const verified = hasVerifiedManifest(row.blueprint);
+          return (
+            <StatusPill
+              tone={verified ? 'success' : 'neutral'}
+              dot={false}
+              className="text-[12px]"
+            >
+              {verified ? 'Pinned' : 'Chain-only'}
+            </StatusPill>
+          );
+        },
+      },
+      {
+        header: 'Usage',
+        className: 'w-24 justify-end',
         hideBelow: 'lg' as const,
         render: (row: DedupedBlueprintRow) => (
-          <span className="font-mono text-[12px] tabular-nums text-muted-foreground">
+          <span className="font-mono text-[13px] tabular-nums text-muted-foreground">
             {(row.blueprint.instancesCount ?? 0).toLocaleString()}
           </span>
         ),
       },
       {
         header: 'Actions',
-        className: 'w-40 justify-end sm:w-48',
+        className: 'w-52 justify-end sm:w-56',
         render: (row: DedupedBlueprintRow) => {
           const { blueprint } = row;
           const blueprintHref = `${PagePath.BLUEPRINTS}/${blueprint.id.toString()}`;
@@ -567,10 +733,17 @@ const BlueprintListing: FC<Props> = ({
 
   if (isLoading && blueprintItems.length === 0) {
     return (
-      <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
-        {Array.from({ length: 6 }).map((_, idx) => (
-          <Skeleton key={idx} className="h-[360px] rounded-lg" />
-        ))}
+      <div className="space-y-5">
+        <BlueprintCatalogHeader
+          matchCount={0}
+          totalCount={0}
+          stats={catalogStats}
+        />
+        <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, idx) => (
+            <Skeleton key={idx} className="h-[360px] rounded-lg" />
+          ))}
+        </div>
       </div>
     );
   }
@@ -602,37 +775,47 @@ const BlueprintListing: FC<Props> = ({
       <EmptyState
         kind="no-data"
         title="No blueprints on this network"
-        description="Register an operator, switch networks, or publish a blueprint to make it available for deployment."
+        description="Add capacity, switch networks, or publish a blueprint to make services available for deployment."
       />
     );
   }
 
-  // Count active non-default filters — drives the FilterTray's active badge
-  // so the operator sees at a glance how many constraints they have on.
-  const activeFilterCount =
-    (audienceFilter !== 'all' ? 1 : 0) +
-    (manifestFilter !== 'all' ? 1 : 0) +
-    (auditFilter !== 'all' ? 1 : 0);
+  const trayFilterCount =
+    (manifestFilter !== 'all' ? 1 : 0) + (auditFilter !== 'all' ? 1 : 0);
 
   const resetAllFilters = () => {
     setSearchQuery('');
     setCategoryParam('');
-    setAudienceFilter('all');
+    setAvailabilityFilter('all');
     setManifestFilter('all');
     setAuditFilter('all');
   };
 
   return (
     <div className="space-y-5">
+      <BlueprintCatalogHeader
+        matchCount={dedupedRows.length}
+        totalCount={allDedupedRows.length}
+        stats={catalogStats}
+      />
+
       <PageToolbar
         search={{
           value: searchQuery,
           onChange: setSearchQuery,
-          placeholder: 'Search blueprints, services, publishers, or IDs',
+          placeholder: 'Search name, publisher, tag, or #id',
         }}
+        filters={
+          <FilterSegment
+            label="Availability"
+            options={availabilityOptions}
+            value={availabilityFilter}
+            onChange={setAvailabilityFilter}
+          />
+        }
         count={{
           matches: dedupedRows.length,
-          total: blueprintItems.length,
+          total: allDedupedRows.length,
           noun: 'matches',
         }}
         trailing={
@@ -646,57 +829,25 @@ const BlueprintListing: FC<Props> = ({
               onClear={() => setCategoryParam('')}
             />
             <FilterTray
-              activeCount={activeFilterCount}
+              activeCount={trayFilterCount}
               onClear={resetAllFilters}
-              trayTitle="Catalog filters"
+              trayTitle="Source and trust"
             >
-              <label className="block space-y-1.5">
-                <span className={typeRole.label}>Availability</span>
-                <select
-                  value={audienceFilter}
-                  onChange={(event) =>
-                    setAudienceFilter(
-                      event.currentTarget.value as AudienceFilter,
-                    )
-                  }
-                  className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none hover:bg-[color:var(--bg-hover)] focus:border-[color:var(--border-accent-hover)]"
-                >
-                  <option value="all">All availability</option>
-                  <option value="customers">Has operators</option>
-                  <option value="operators">Needs capacity</option>
-                </select>
-              </label>
+              <FilterSegment
+                label="Source"
+                options={sourceOptions}
+                value={manifestFilter}
+                onChange={setManifestFilter}
+                stacked
+              />
 
-              <label className="block space-y-1.5">
-                <span className={typeRole.label}>Source</span>
-                <select
-                  value={manifestFilter}
-                  onChange={(event) =>
-                    setManifestFilter(
-                      event.currentTarget.value as ManifestFilter,
-                    )
-                  }
-                  className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none hover:bg-[color:var(--bg-hover)] focus:border-[color:var(--border-accent-hover)]"
-                >
-                  <option value="all">All sources</option>
-                  <option value="verified">Pinned source</option>
-                  <option value="fallback">Chain-only</option>
-                </select>
-              </label>
-
-              <label className="block space-y-1.5">
-                <span className={typeRole.label}>Trust</span>
-                <select
-                  value={auditFilter}
-                  onChange={(event) =>
-                    setAuditFilter(event.currentTarget.value as AuditFilter)
-                  }
-                  className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none hover:bg-[color:var(--bg-hover)] focus:border-[color:var(--border-accent-hover)]"
-                >
-                  <option value="all">All blueprints</option>
-                  <option value="audited">Audited only</option>
-                </select>
-              </label>
+              <FilterSegment
+                label="Trust"
+                options={trustOptions}
+                value={auditFilter}
+                onChange={setAuditFilter}
+                stacked
+              />
             </FilterTray>
           </div>
         }
@@ -945,7 +1096,70 @@ const useAuditedStatusMap = (blueprintIds: bigint[]): Map<string, boolean> => {
   return map;
 };
 
-const BlueprintCapacityPill = ({
+const BlueprintIdentitySummary = ({ row }: { row: DedupedBlueprintRow }) => {
+  const { blueprint } = row;
+  const category = getBlueprintCategory(blueprint);
+  const modeCount = getModeCount(row);
+
+  return (
+    <div className="flex min-w-0 items-center gap-3">
+      <BlueprintVisual
+        blueprint={blueprint}
+        category={category}
+        compact
+        className="h-14 w-14 shrink-0 rounded-md"
+      />
+      <div className="min-w-0">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate font-display text-[15px] font-bold leading-tight text-foreground">
+            {formatBlueprintName(blueprint.name)}
+          </span>
+          <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+            #{blueprint.id.toString()}
+          </span>
+        </div>
+        <p className="mt-1 line-clamp-1 text-sm leading-snug text-muted-foreground">
+          {getBlueprintDescription(blueprint)}
+        </p>
+        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+          <BlueprintMetaChip>{category}</BlueprintMetaChip>
+          {modeCount > 1 && (
+            <BlueprintMetaChip>
+              {modeCount} {pluralize('mode', modeCount)}
+            </BlueprintMetaChip>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const BlueprintMetaChip = ({ children }: { children: ReactNode }) => (
+  <span className="rounded border border-border bg-muted/20 px-1.5 py-0.5 font-sans text-[11px] font-medium leading-none text-muted-foreground not-italic">
+    {children}
+  </span>
+);
+
+const BlueprintCapacityCell = ({
+  operatorCount,
+}: {
+  operatorCount: number;
+}) => {
+  const hasOperators = operatorCount > 0;
+
+  return (
+    <div className="flex min-w-0 flex-col items-start gap-1.5">
+      <BlueprintCapacitySignal operatorCount={operatorCount} />
+      <span className="font-mono text-[12px] tabular-nums text-muted-foreground">
+        {hasOperators
+          ? `${operatorCount.toLocaleString()} registered`
+          : '0 registered'}
+      </span>
+    </div>
+  );
+};
+
+const BlueprintCapacitySignal = ({
   operatorCount,
 }: {
   operatorCount: number;
@@ -959,25 +1173,18 @@ const BlueprintCapacityPill = ({
         hasOperators ? 'Available' : 'Limited',
       )}
       dot={false}
-      className="text-xs"
+      className="text-[12px]"
     >
-      {hasOperators ? (
-        <>
-          <span className="font-mono tabular-nums">{operatorCount}</span>{' '}
-          {pluralize('operator', operatorCount)}
-        </>
-      ) : (
-        'Needs operators'
-      )}
+      {hasOperators ? 'Ready' : 'Needs capacity'}
     </StatusPill>
   );
 };
 
 const catalogActionClass =
-  'inline-flex min-h-8 flex-1 items-center justify-center rounded-md border border-border bg-muted/30 px-3 py-1.5 text-center text-xs font-semibold text-foreground transition-colors before:hidden after:hidden hover:bg-[color:var(--bg-hover)]';
+  'inline-flex min-h-8 flex-1 items-center justify-center rounded-md border border-border bg-muted/30 px-3 py-1.5 text-center font-sans text-xs font-semibold text-foreground not-italic transition-colors before:hidden after:hidden marker:hidden hover:bg-[color:var(--bg-hover)] whitespace-nowrap';
 
 const catalogPrimaryActionClass =
-  'inline-flex min-h-8 flex-1 items-center justify-center rounded-md bg-primary px-3 py-1.5 text-center text-xs font-semibold text-primary-foreground transition-colors before:hidden after:hidden hover:bg-primary/90';
+  'inline-flex min-h-8 flex-1 items-center justify-center rounded-md bg-primary px-3 py-1.5 text-center font-sans text-xs font-semibold text-primary-foreground not-italic transition-colors before:hidden after:hidden marker:hidden hover:bg-primary/90 whitespace-nowrap';
 
 const MobileBlueprintRow = ({
   row,
@@ -992,9 +1199,7 @@ const MobileBlueprintRow = ({
   const blueprintHref = `${PagePath.BLUEPRINTS}/${blueprint.id.toString()}`;
   const operatorCount = blueprint.operatorsCount ?? 0;
   const hasOperators = operatorCount > 0;
-  const description =
-    blueprint.description?.trim() ||
-    'Service blueprint — deploy when operators are available.';
+  const description = getBlueprintDescription(blueprint);
 
   return (
     <article className="rounded-lg border border-border bg-[color:var(--bg-card)] p-3 shadow-[var(--shadow-card)]">
@@ -1024,13 +1229,20 @@ const MobileBlueprintRow = ({
       </Link>
 
       <div className="mt-3 flex flex-wrap items-center gap-2">
-        <BlueprintCapacityPill operatorCount={operatorCount} />
+        <BlueprintCapacitySignal operatorCount={operatorCount} />
         <StatusPill
           tone={statusToneFor('audit', isAudited ? 'Audited' : 'Unaudited')}
           dot={false}
-          className="text-xs"
+          className="text-[12px]"
         >
           {isAudited ? 'Audited' : 'Unaudited'}
+        </StatusPill>
+        <StatusPill
+          tone={hasVerifiedManifest(blueprint) ? 'success' : 'neutral'}
+          dot={false}
+          className="text-[12px]"
+        >
+          {hasVerifiedManifest(blueprint) ? 'Pinned' : 'Chain-only'}
         </StatusPill>
       </div>
 
@@ -1053,27 +1265,6 @@ const MobileBlueprintRow = ({
   );
 };
 
-/**
- * Catalog card — the operator/customer's primary scan surface.
- *
- * Hard rule: ONE fact per visual line, three lines of information total.
- *
- *   Line 1: title (large, primary read)
- *   Line 2: one-line description (truncated)
- *   Line 3: status — "Ready · N operators" OR "Needs operators"
- *
- * Everything else is hover-revealed (action buttons) or absent (publisher
- * address, category pill, deployment-modes pill, source-pinning pill,
- * three-cell metric grid, github link). The detail page is one click away
- * and surfaces those facts where they belong.
- *
- * Distinctive identity (so the wall doesn't look like a shadcn template
- * gallery): the blueprint id renders as a large mono "watermark" in the
- * top-right corner — like a tactical card chip number. Featured /
- * audited blueprints get a 2px accent stripe on the left border, not a
- * full perimeter glow. Visual identity comes from typography and
- * proportion, not from gradients.
- */
 const BlueprintCard = ({
   row,
   isSelectable,
@@ -1090,29 +1281,24 @@ const BlueprintCard = ({
   onRegister?: (blueprint: Blueprint) => void;
 }) => {
   const { blueprint } = row;
-  const description =
-    blueprint.description?.trim() ||
-    'Service blueprint — deploy when operators are available.';
+  const description = getBlueprintDescription(blueprint);
   const blueprintHref = `${PagePath.BLUEPRINTS}/${blueprint.id.toString()}`;
   const operatorCount = blueprint.operatorsCount ?? 0;
   const hasOperators = operatorCount > 0;
   const isFeatured = blueprint.isBoosted === true || isAudited;
   const displayName = formatBlueprintName(blueprint.name);
+  const modeCount = getModeCount(row);
+  const sourcePinned = hasVerifiedManifest(blueprint);
   return (
     <div
       className={twMerge(
         'group relative flex min-h-[260px] flex-col gap-3 rounded-lg border border-border bg-[color:var(--bg-card)] p-4 shadow-[var(--shadow-card)] transition-all',
-        // Subtle hover: lift one pixel, tighten border accent. No gradient
-        // glow. The card already has enough visual weight from its content.
         'hover:-translate-y-px hover:border-[color:var(--border-accent-hover)]',
         isFeatured && 'border-l-2 border-l-[color:var(--border-accent-hover)]',
         isSelected &&
           'border-[color:var(--border-accent-hover)] shadow-[0_0_0_1px_var(--border-accent-hover)]',
       )}
     >
-      {/* Whole-card link — keeps the deploy/register buttons interactive
-       * because they have z-20 and stopPropagation. Aria label on the
-       * link is the source of truth; the visible title is a styled span. */}
       <Link
         to={blueprintHref}
         className="absolute inset-0 z-10"
@@ -1126,8 +1312,6 @@ const BlueprintCard = ({
         className="h-28 rounded-md"
       />
 
-      {/* Watermark ID — mono, low-contrast, top-right. The card's identity
-       * marker; not a UI element, not actionable. */}
       <span
         aria-hidden
         className="pointer-events-none absolute right-4 top-4 select-none font-mono text-xs tabular-nums text-foreground/15"
@@ -1135,8 +1319,6 @@ const BlueprintCard = ({
         #{blueprint.id.toString().padStart(3, '0')}
       </span>
 
-      {/* Selection checkbox (drawer mode) — top-left so it never collides
-       * with the watermark or with the hover-revealed actions. */}
       {isSelectable && (
         <label
           className="absolute left-4 top-4 z-20 flex h-7 w-7 cursor-pointer items-center justify-center rounded border border-border bg-background/80 backdrop-blur transition-colors hover:bg-background"
@@ -1152,7 +1334,6 @@ const BlueprintCard = ({
         </label>
       )}
 
-      {/* Header — name + 1-line description. */}
       <div className={twMerge('min-w-0', isSelectable && 'pl-8')}>
         <h3 className="line-clamp-1 pr-12 font-display font-bold text-base leading-tight tracking-normal text-foreground">
           {displayName}
@@ -1162,18 +1343,28 @@ const BlueprintCard = ({
         </p>
       </div>
 
-      {/* Status row — one chip, mono operator count, audit/trust if present.
-       * Everything is bottom-anchored so cards align by their last line. */}
       <div className="mt-auto flex flex-wrap items-center gap-2 pt-2">
-        <BlueprintCapacityPill operatorCount={operatorCount} />
+        <BlueprintCapacitySignal operatorCount={operatorCount} />
         {isAudited && (
           <StatusPill
             tone={statusToneFor('audit', 'Audited')}
             dot={false}
-            className="text-xs"
+            className="text-[12px]"
           >
             Audited
           </StatusPill>
+        )}
+        <StatusPill
+          tone={sourcePinned ? 'success' : 'neutral'}
+          dot={false}
+          className="text-[12px]"
+        >
+          {sourcePinned ? 'Pinned' : 'Chain-only'}
+        </StatusPill>
+        {modeCount > 1 && (
+          <BlueprintMetaChip>
+            {modeCount} {pluralize('mode', modeCount)}
+          </BlueprintMetaChip>
         )}
         {(blueprint.instancesCount ?? 0) > 0 && (
           <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
@@ -1182,15 +1373,6 @@ const BlueprintCard = ({
         )}
       </div>
 
-      {/* Hover-revealed actions. Hidden by default — single click on the
-       * card opens the detail page; the actions are for power-users who
-       * want to jump straight to deploy/register without the detail step.
-       * `z-20` + `stopPropagation` keeps them clickable inside the overlay
-       * link.
-       *
-       * On non-hover devices (touch) the actions are always visible — the
-       * `group-hover:` selector only matches on pointer hover, so this is
-       * automatic. */}
       <div className={twMerge('actions relative z-20 mt-2 flex gap-2')}>
         {hasOperators ? (
           <>
@@ -1238,6 +1420,6 @@ const RegisterCapacityButton = ({
       onRegister?.(blueprint);
     }}
   >
-    Register
+    Add capacity
   </button>
 );

--- a/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
@@ -6,7 +6,16 @@ import {
   Skeleton,
 } from '../../components/sandbox/SandboxUi';
 import { formatBlueprintName } from '../../components/blueprints/blueprintVisualUtils';
-import { EmptyState, FilterTray, PageToolbar } from '../../components/chrome';
+import {
+  EmptyState,
+  FilterTray,
+  PageToolbar,
+  ResultList,
+  StatusPill,
+  ViewToggle,
+  statusToneFor,
+  type ResultView,
+} from '../../components/chrome';
 import {
   enumCodec,
   intCodec,
@@ -40,7 +49,7 @@ import {
   type Auditor,
 } from '@tangle-network/tangle-shared-ui/blueprintApps/trustScore';
 import { auditorFallbackRegistry } from '../../auditors';
-import { Link } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 import { twMerge } from 'tailwind-merge';
 import { PagePath } from '../../types';
 import {
@@ -277,12 +286,17 @@ const BlueprintListing: FC<Props> = ({
   error,
   onRegisterBlueprint,
 }) => {
+  const navigate = useNavigate();
   // Filter state lives in the URL — refresh persists the view, deep-links are
   // shareable, the back button works. Defaults are omitted from the URL so a
   // bare /blueprints stays clean. `replace: true` (in `useUrlState`) means
   // every keystroke doesn't pollute the history stack.
   const [page, setPage] = useUrlState('page', intCodec(0));
   const [searchQuery, setSearchQuery] = useUrlState('q', stringCodec(''));
+  const [view, setView] = useUrlState<ResultView>(
+    'view',
+    enumCodec(['grid', 'list'] as const, 'list'),
+  );
   // Multi-select categories, comma-joined in the URL (empty = all). Single
   // dropdown in the toolbar replaces the old full-width category row.
   const [categoryParam, setCategoryParam] = useUrlState(
@@ -322,7 +336,8 @@ const BlueprintListing: FC<Props> = ({
     return Array.from(blueprints.values()).sort((a, b) => {
       if (a.isBoosted && !b.isBoosted) return -1;
       if (!a.isBoosted && b.isBoosted) return 1;
-      return Number(b.id - a.id);
+      if (a.id === b.id) return 0;
+      return a.id < b.id ? 1 : -1;
     });
   }, [blueprints]);
 
@@ -395,11 +410,14 @@ const BlueprintListing: FC<Props> = ({
     blueprintItems,
     deferredSearchQuery,
     manifestFilter,
-    categoryParam,
+    selectedCategories,
   ]);
 
+  // `useUrlState` returns a new setter each render; depending on it creates a
+  // page-reset loop. Filter values are the actual synchronization boundary.
   useEffect(() => {
     setPage(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     audienceFilter,
     auditFilter,
@@ -434,6 +452,103 @@ const BlueprintListing: FC<Props> = ({
   const showSelection =
     typeof rowSelection !== 'undefined' &&
     typeof onRowSelectionChange === 'function';
+  const effectiveView = showSelection ? 'grid' : view;
+
+  const listColumns = useMemo(
+    () => [
+      {
+        header: 'Blueprint',
+        className: 'min-w-0 flex-[2]',
+        render: (row: DedupedBlueprintRow) => {
+          const { blueprint } = row;
+          const description =
+            blueprint.description?.trim() ||
+            'Service blueprint — deploy when operators are available.';
+
+          return (
+            <div className="min-w-0">
+              <div className="flex min-w-0 items-center gap-2">
+                <span className="truncate font-display font-bold text-foreground text-sm">
+                  {formatBlueprintName(blueprint.name)}
+                </span>
+                <span className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground">
+                  #{blueprint.id.toString()}
+                </span>
+              </div>
+              <p className="mt-0.5 line-clamp-1 text-muted-foreground text-xs">
+                {description}
+              </p>
+            </div>
+          );
+        },
+      },
+      {
+        header: 'Operators',
+        className: 'w-44',
+        render: (row: DedupedBlueprintRow) => (
+          <BlueprintCapacityPill
+            operatorCount={row.blueprint.operatorsCount ?? 0}
+          />
+        ),
+      },
+      {
+        header: 'Trust',
+        className: 'w-28',
+        hideBelow: 'md' as const,
+        render: (row: DedupedBlueprintRow) => {
+          const audited =
+            auditedStatus.get(row.blueprint.id.toString()) ?? false;
+          return (
+            <StatusPill
+              tone={statusToneFor('audit', audited ? 'Audited' : 'Unaudited')}
+              dot={audited}
+            >
+              {audited ? 'Audited' : 'Unaudited'}
+            </StatusPill>
+          );
+        },
+      },
+      {
+        header: 'Instances',
+        className: 'w-28 justify-end',
+        hideBelow: 'lg' as const,
+        render: (row: DedupedBlueprintRow) => (
+          <span className="font-mono text-[12px] tabular-nums text-muted-foreground">
+            {(row.blueprint.instancesCount ?? 0).toLocaleString()}
+          </span>
+        ),
+      },
+      {
+        header: 'Actions',
+        className: 'w-48 justify-end',
+        render: (row: DedupedBlueprintRow) => {
+          const { blueprint } = row;
+          const blueprintHref = `${PagePath.BLUEPRINTS}/${blueprint.id.toString()}`;
+          const hasOperators = (blueprint.operatorsCount ?? 0) > 0;
+
+          return (
+            <div className="flex w-full justify-end gap-2">
+              {hasOperators && (
+                <Link
+                  to={`${blueprintHref}/deploy`}
+                  onClick={(event) => event.stopPropagation()}
+                  className="rounded-md bg-primary px-2.5 py-1.5 text-center font-semibold text-primary-foreground text-xs transition-colors hover:bg-primary/90"
+                >
+                  Deploy
+                </Link>
+              )}
+              <RegisterCapacityButton
+                blueprint={blueprint}
+                onRegister={onRegisterBlueprint}
+                isPrimary={!hasOperators}
+              />
+            </div>
+          );
+        },
+      },
+    ],
+    [auditedStatus, onRegisterBlueprint],
+  );
 
   if (isLoading) {
     return (
@@ -496,7 +611,8 @@ const BlueprintListing: FC<Props> = ({
           noun: 'matches',
         }}
         trailing={
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            {!showSelection && <ViewToggle value={view} onChange={setView} />}
             <CategoryFilterMenu
               categories={categories}
               selected={selectedCategories}
@@ -568,6 +684,15 @@ const BlueprintListing: FC<Props> = ({
             hasActiveFilters && (
               <Button onClick={resetAllFilters}>Clear all filters</Button>
             )
+          }
+        />
+      ) : effectiveView === 'list' ? (
+        <ResultList
+          items={visibleRows}
+          columns={listColumns}
+          rowKey={(row) => row.blueprint.id.toString()}
+          onRowClick={(row) =>
+            navigate(`${PagePath.BLUEPRINTS}/${row.blueprint.id.toString()}`)
           }
         />
       ) : (
@@ -747,7 +872,7 @@ const useAuditedStatusMap = (blueprintIds: bigint[]): Map<string, boolean> => {
         const nowSeconds = Math.floor(Date.now() / 1000);
         const hasAuditedAttestation = attestations.some((row) => {
           if (row.revoked) return false;
-          if (row.expiresAt !== 0n && Number(row.expiresAt) <= nowSeconds) {
+          if (row.expiresAt !== 0n && row.expiresAt <= BigInt(nowSeconds)) {
             return false;
           }
           if (row.kind === AttestationKind.SELF) return false;
@@ -771,6 +896,33 @@ const useAuditedStatusMap = (blueprintIds: bigint[]): Map<string, boolean> => {
     map.set(id.toString(), queries[idx]?.data?.hasAuditedAttestation ?? false);
   });
   return map;
+};
+
+const BlueprintCapacityPill = ({
+  operatorCount,
+}: {
+  operatorCount: number;
+}) => {
+  const hasOperators = operatorCount > 0;
+
+  return (
+    <StatusPill
+      tone={statusToneFor(
+        'availability',
+        hasOperators ? 'Available' : 'Limited',
+      )}
+      className="text-[10px] uppercase tracking-wider"
+    >
+      {hasOperators ? (
+        <>
+          <span className="font-mono tabular-nums">{operatorCount}</span>{' '}
+          {pluralize('operator', operatorCount)}
+        </>
+      ) : (
+        'Needs operators'
+      )}
+    </StatusPill>
+  );
 };
 
 /**
@@ -878,36 +1030,14 @@ const BlueprintCard = ({
       {/* Status row — one chip, mono operator count, audit/trust if present.
        * Everything is bottom-anchored so cards align by their last line. */}
       <div className="mt-auto flex flex-wrap items-center gap-2 pt-2">
-        <span
-          className={twMerge(
-            'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider',
-            hasOperators
-              ? 'border-[color:var(--md3-tertiary,#10b981)]/40 bg-[color:var(--md3-tertiary,#10b981)]/8 text-[color:var(--md3-tertiary,#10b981)]'
-              : 'border-[color:var(--md3-warning,#f59e0b)]/40 bg-[color:var(--md3-warning,#f59e0b)]/8 text-[color:var(--md3-warning,#f59e0b)]',
-          )}
-        >
-          <span
-            aria-hidden
-            className={twMerge(
-              'h-1.5 w-1.5 rounded-full',
-              hasOperators
-                ? 'bg-[color:var(--md3-tertiary,#10b981)]'
-                : 'bg-[color:var(--md3-warning,#f59e0b)]',
-            )}
-          />
-          {hasOperators ? (
-            <>
-              <span className="font-mono tabular-nums">{operatorCount}</span>{' '}
-              {pluralize('operator', operatorCount)}
-            </>
-          ) : (
-            'Needs operators'
-          )}
-        </span>
+        <BlueprintCapacityPill operatorCount={operatorCount} />
         {isAudited && (
-          <span className="inline-flex items-center gap-1 rounded-full border border-[color:var(--border-accent)] bg-transparent px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-foreground/80">
+          <StatusPill
+            tone={statusToneFor('audit', 'Audited')}
+            className="text-[10px] uppercase tracking-wider"
+          >
             Audited
-          </span>
+          </StatusPill>
         )}
         {(blueprint.instancesCount ?? 0) > 0 && (
           <span className="font-mono text-[11px] tabular-nums text-muted-foreground">

--- a/apps/tangle-cloud/src/pages/blueprints/RegistrationDrawer/RegistrationDrawer.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/RegistrationDrawer/RegistrationDrawer.tsx
@@ -556,10 +556,6 @@ const RegistrationDrawer: FC<RegistrationDrawerProps> = ({
           <DialogDescription className="sr-only">
             Register an active operator for one or more selected blueprints.
           </DialogDescription>
-          <Button variant="ghost" size="icon" onClick={handleClose}>
-            <span aria-hidden>x</span>
-            <span className="sr-only">Close registration panel</span>
-          </Button>
         </div>
 
         {renderGatedContent()}

--- a/apps/tangle-cloud/src/pages/blueprints/[id]/deploy/DeploySteps/OperatorSelectionStep.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/[id]/deploy/DeploySteps/OperatorSelectionStep.tsx
@@ -127,7 +127,9 @@ export const SelectOperatorsStep: FC<SelectOperatorsStepProps> = ({
       nextKeys.every((key) => rowSelection[key]);
 
     if (!isSame) {
-      setRowSelection(nextSelection);
+      queueMicrotask(() => {
+        setRowSelection(nextSelection);
+      });
     }
   }, [rowSelection, selectedOperators]);
 

--- a/apps/tangle-cloud/src/pages/blueprints/[id]/deploy/DeploySteps/PaymentStep.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/[id]/deploy/DeploySteps/PaymentStep.tsx
@@ -71,15 +71,19 @@ export const PaymentStep: FC<PaymentStepProps> = ({
     }
 
     if (!selectedCommitment && creditAccounts[0]?.commitment) {
-      setValue('creditCommitment', creditAccounts[0].commitment, {
-        shouldDirty: false,
+      queueMicrotask(() => {
+        setValue('creditCommitment', creditAccounts[0].commitment, {
+          shouldDirty: false,
+        });
       });
     }
   }, [creditAccounts, paymentMethod, selectedCommitment, setValue]);
 
   useEffect(() => {
     if (!fundingAssetId && selectableAssets[0]?.id) {
-      setFundingAssetId(selectableAssets[0].id);
+      queueMicrotask(() => {
+        setFundingAssetId(selectableAssets[0].id);
+      });
     }
   }, [fundingAssetId, selectableAssets]);
 

--- a/apps/tangle-cloud/src/pages/blueprints/[id]/deploy/page.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/[id]/deploy/page.tsx
@@ -440,8 +440,8 @@ const DeployPage: FC = () => {
 
   return (
     <RequireWallet
-      title="Connect wallet to create an instance"
-      description="Connect to choose operators, set permitted callers, and submit a service request transaction."
+      title={`Connect wallet to create ${blueprintResult.details.name}`}
+      description="Connect to choose operators, set permitted callers, and submit a service request transaction for this blueprint."
       eyebrow="Service instance"
       checks={['Operators', 'Payment', 'Request']}
     >

--- a/apps/tangle-cloud/src/pages/blueprints/manage/page.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/manage/page.tsx
@@ -839,11 +839,13 @@ const UpdateMetadataModal: FC<UpdateMetadataModalProps> = ({
       return;
     }
 
-    setMetadataUri(blueprint.metadataUri ?? '');
-    setPreviewError(null);
-    setPreviewData(null);
-    setIsLoadingPreview(false);
-    reset();
+    queueMicrotask(() => {
+      setMetadataUri(blueprint.metadataUri ?? '');
+      setPreviewError(null);
+      setPreviewData(null);
+      setIsLoadingPreview(false);
+      reset();
+    });
     return () => {
       cancelInFlightPreviewRequest();
     };

--- a/apps/tangle-cloud/src/pages/blueprints/page.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/page.tsx
@@ -69,10 +69,12 @@ const Page: FC = () => {
       return;
     }
 
-    handleRegisterBlueprint(blueprint);
-    const nextParams = new URLSearchParams(searchParams);
-    nextParams.delete('register');
-    setSearchParams(nextParams, { replace: true });
+    queueMicrotask(() => {
+      handleRegisterBlueprint(blueprint);
+      const nextParams = new URLSearchParams(searchParams);
+      nextParams.delete('register');
+      setSearchParams(nextParams, { replace: true });
+    });
   }, [
     blueprints,
     handleRegisterBlueprint,

--- a/apps/tangle-cloud/src/pages/blueprints/page.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/page.tsx
@@ -10,28 +10,18 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router';
 import { twMerge } from 'tailwind-merge';
-import useRoleStore, { Role } from '../../stores/roleStore';
 import { PagePath } from '../../types';
 import pollWithBackoff from '../../utils/pollWithBackoff';
 import BlueprintListing from './BlueprintListing';
 import RegistrationDrawer from './RegistrationDrawer';
-import { PageHeader } from '../../components/chrome';
 
 const BLUEPRINT_DOCS_LINK =
   'https://docs.tangle.tools/developers/blueprints/introduction';
-
-const ROLE_TITLE = {
-  [Role.OPERATOR]: 'Blueprints',
-  [Role.DEPLOYER]: 'Blueprints',
-} satisfies Record<Role, string>;
-
-const HAS_BLUEPRINTS_TITLE = 'Blueprints';
 
 const pluralize = (label: string, count: number) =>
   count === 1 ? label : `${label}s`;
 
 const Page: FC = () => {
-  const role = useRoleStore((store) => store.role);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
@@ -156,43 +146,20 @@ const Page: FC = () => {
     });
   }, []);
 
-  const title = hasOwnedBlueprints ? HAS_BLUEPRINTS_TITLE : ROLE_TITLE[role];
-  // No subtitle on a catalog page — the visible content IS the subtitle.
-  // Adding "Find blueprints, create service instances, ..." steals 24px of
-  // vertical space for copy the operator already knows by being on this
-  // page. Catalog tier = title + toolbar + grid, nothing else above content.
-  // Catalog-wide stats (total, ready, needs-capacity, your-registrations)
-  // belong on the home dashboard, not above a search bar.
+  const toolbarAction = hasOwnedBlueprints ? (
+    <Button asChild variant="outline" size="sm">
+      <Link to={PagePath.BLUEPRINTS_MANAGE}>Manage</Link>
+    </Button>
+  ) : (
+    <Button variant="sandbox" asChild size="sm">
+      <a href={BLUEPRINT_DOCS_LINK} target="_blank" rel="noreferrer">
+        Publish
+      </a>
+    </Button>
+  );
 
   return (
     <div className="space-y-4">
-      <PageHeader
-        density="compact"
-        title={title}
-        action={
-          <>
-            {hasOwnedBlueprints && (
-              <Button asChild variant="ghost" size="sm">
-                <Link to={PagePath.OPERATORS}>Operators</Link>
-              </Button>
-            )}
-            <Button variant="sandbox" asChild size="sm">
-              <a
-                href={
-                  hasOwnedBlueprints
-                    ? PagePath.BLUEPRINTS_MANAGE
-                    : BLUEPRINT_DOCS_LINK
-                }
-                target={hasOwnedBlueprints ? undefined : '_blank'}
-                rel={hasOwnedBlueprints ? undefined : 'noreferrer'}
-              >
-                {hasOwnedBlueprints ? 'Manage blueprints' : 'Publish blueprint'}
-              </a>
-            </Button>
-          </>
-        }
-      />
-
       <BlueprintListing
         blueprints={blueprints}
         isLoading={isLoading}
@@ -200,6 +167,8 @@ const Page: FC = () => {
         rowSelection={isOperator ? rowSelection : undefined}
         onRowSelectionChange={isOperator ? setRowSelection : undefined}
         onRegisterBlueprint={handleRegisterBlueprint}
+        toolbarAction={toolbarAction}
+        onRetry={() => void refetch()}
       />
 
       <AnimatePresence>

--- a/apps/tangle-cloud/src/pages/blueprints/page.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/page.tsx
@@ -147,11 +147,21 @@ const Page: FC = () => {
   }, []);
 
   const toolbarAction = hasOwnedBlueprints ? (
-    <Button asChild variant="outline" size="sm">
+    <Button
+      asChild
+      variant="outline"
+      size="sm"
+      className="font-sans not-italic"
+    >
       <Link to={PagePath.BLUEPRINTS_MANAGE}>Manage</Link>
     </Button>
   ) : (
-    <Button variant="sandbox" asChild size="sm">
+    <Button
+      variant="sandbox"
+      asChild
+      size="sm"
+      className="font-sans not-italic"
+    >
       <a href={BLUEPRINT_DOCS_LINK} target="_blank" rel="noreferrer">
         Publish
       </a>
@@ -199,8 +209,12 @@ const Page: FC = () => {
               </Button>
             </div>
 
-            <Button variant="sandbox" onClick={() => setIsDrawerOpen(true)}>
-              Register
+            <Button
+              variant="sandbox"
+              className="font-sans not-italic"
+              onClick={() => setIsDrawerOpen(true)}
+            >
+              Add capacity
             </Button>
           </motion.div>
         )}

--- a/apps/tangle-cloud/src/pages/earnings/page.tsx
+++ b/apps/tangle-cloud/src/pages/earnings/page.tsx
@@ -36,7 +36,9 @@ const EarningsPage: FC = () => {
   );
 
   useEffect(() => {
-    setEventsPageIndex((current) => Math.min(current, totalEventPages - 1));
+    queueMicrotask(() => {
+      setEventsPageIndex((current) => Math.min(current, totalEventPages - 1));
+    });
   }, [totalEventPages]);
 
   const visibleEvents = useMemo(() => {

--- a/apps/tangle-cloud/src/pages/instances/Instances/UpdateBlueprintModel/ServiceRequestDetailModal.tsx
+++ b/apps/tangle-cloud/src/pages/instances/Instances/UpdateBlueprintModel/ServiceRequestDetailModal.tsx
@@ -244,7 +244,9 @@ const ServiceRequestDetailModal: FC<Props> = ({
   const requestId = selectedRequest?.requestId;
   useEffect(() => {
     if (requestId !== undefined) {
-      setView('details');
+      queueMicrotask(() => {
+        setView('details');
+      });
     }
   }, [requestId]);
 

--- a/apps/tangle-cloud/src/pages/operators/page.tsx
+++ b/apps/tangle-cloud/src/pages/operators/page.tsx
@@ -3,7 +3,6 @@ import {
   useOperators,
 } from '@tangle-network/tangle-shared-ui/data/graphql/useOperators';
 import {
-  Badge,
   Button,
   Card,
   CardContent,
@@ -20,17 +19,23 @@ import {
 import { Search } from '@tangle-network/icons';
 import {
   type ChangeEvent,
-  type CSSProperties,
   type FC,
   useCallback,
   useMemo,
   useState,
 } from 'react';
-import { formatUnits, type Address } from 'viem';
+import { type Address } from 'viem';
 import { useNavigate } from 'react-router';
 import { PagePath } from '../../types';
 import { useAccount } from 'wagmi';
-import { MetricStrip, PageHeader } from '../../components/chrome';
+import {
+  formatMoney,
+  MetricStrip,
+  Money,
+  PageHeader,
+  StatusPill,
+  statusToneFor,
+} from '../../components/chrome';
 import type { Metric } from '../../components/chrome';
 import createStakeDelegateUrl from './createStakeDelegateUrl';
 
@@ -88,7 +93,11 @@ const Page: FC = () => {
       },
       {
         label: 'Total stake',
-        value: formatStake(totalStake),
+        value: formatMoney(totalStake, {
+          decimals: 18,
+          symbol: 'TNT',
+          displayDecimals: 2,
+        }).display,
         sublabel: 'TNT delegated',
         loading: isLoading,
       },
@@ -365,8 +374,9 @@ const OperatorTableRow = ({
       <TableCell className="py-4">
         <div className="flex min-w-0 items-center gap-3">
           <span
-            className="h-8 w-1 shrink-0 rounded-full"
-            style={getOperatorAccent(address)}
+            className={`h-8 w-1 shrink-0 rounded-full ${getOperatorAccentClass(
+              address,
+            )}`}
           />
           <OperatorIdenticon address={address} />
           <div className="min-w-0">
@@ -380,32 +390,24 @@ const OperatorTableRow = ({
         </div>
       </TableCell>
       <TableCell className="py-4 font-semibold text-foreground text-sm">
-        {formatStake(operator.stakingStake)}
-        <span className="ml-1 text-muted-foreground text-xs">TNT</span>
+        <Money
+          value={operator.stakingStake}
+          options={{ decimals: 18, symbol: 'TNT', displayDecimals: 2 }}
+          align="left"
+        />
       </TableCell>
       <TableCell className="py-4 font-semibold text-foreground text-sm">
         {formatCount(operator.stakingDelegationCount)}
       </TableCell>
       <TableCell className="py-4">
-        <Badge
-          variant={
-            delegationMode === 2
-              ? 'success'
-              : delegationMode === 1
-                ? 'outline'
-                : 'secondary'
-          }
-        >
+        <StatusPill tone={getDelegationModeTone(delegationMode)}>
           {delegationModeLabel}
-        </Badge>
+        </StatusPill>
       </TableCell>
       <TableCell className="py-4">
-        <Badge
-          variant={status === 'ACTIVE' ? 'success' : 'outline'}
-          dot={status === 'ACTIVE'}
-        >
+        <StatusPill tone={statusToneFor('operator', status)}>
           {formatStatus(status)}
-        </Badge>
+        </StatusPill>
       </TableCell>
       <TableCell className="py-4">
         <div className="flex justify-end gap-2">
@@ -433,12 +435,9 @@ const OperatorTableRow = ({
 
 const OperatorIdenticon = ({ address }: { address: string }) => (
   <div
-    // The inline `style` from `getOperatorIdenticonStyle` paints a saturated
-    // hue gradient as the actual background, so the `bg-card` fallback only
-    // shows for the brief render before the style applies. `text-primary-
-    // foreground` keeps the contrast stable across both themes.
-    className="grid h-9 w-9 shrink-0 place-items-center rounded-lg border border-border bg-card font-display font-extrabold text-primary-foreground text-xs shadow-[var(--shadow-card)]"
-    style={getOperatorIdenticonStyle(address)}
+    className={`grid h-9 w-9 shrink-0 place-items-center rounded-lg border bg-[var(--accent-surface-soft)] font-display font-extrabold text-foreground text-xs shadow-[var(--shadow-card)] ${getOperatorIdenticonClass(
+      address,
+    )}`}
   >
     {address.slice(2, 4).toUpperCase()}
   </div>
@@ -449,35 +448,42 @@ const shortenAddress = (address: string) => {
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
 };
 
-const formatStake = (value: bigint | null) =>
-  value === null
-    ? '-'
-    : Number(formatUnits(value, 18)).toLocaleString(undefined, {
-        maximumFractionDigits: 2,
-      });
-
 const formatCount = (value: bigint | null) =>
   value === null ? '-' : value.toLocaleString();
 
 const hashAddress = (address: string) =>
   Array.from(address).reduce((hash, char) => {
-    return (hash * 31 + char.charCodeAt(0)) % 360;
+    return (hash * 31 + char.charCodeAt(0)) % 997;
   }, 0);
 
-const getOperatorIdenticonStyle = (address: string) => {
-  const hue = hashAddress(address);
-  return {
-    backgroundColor: '#111827',
-    backgroundImage: `linear-gradient(135deg, hsl(${hue} 82% 40%), hsl(${(hue + 42) % 360} 82% 32%))`,
-  };
-};
+const OPERATOR_ACCENT_CLASSES = [
+  'bg-[color:var(--border-accent-hover)]',
+  'bg-[color:var(--md3-tertiary,#10b981)]',
+  'bg-[color:var(--md3-warning,#f59e0b)]',
+  'bg-muted-foreground/70',
+] as const;
 
-const getOperatorAccent = (address: string): CSSProperties => {
-  const hue = hashAddress(address);
-  return {
-    background: `linear-gradient(180deg, hsl(${hue} 82% 58%), hsl(${(hue + 42) % 360} 82% 50%))`,
-  };
-};
+const OPERATOR_IDENTICON_CLASSES = [
+  'border-[color:var(--border-accent-hover)]/60',
+  'border-[color:var(--md3-tertiary,#10b981)]/50',
+  'border-[color:var(--md3-warning,#f59e0b)]/50',
+  'border-border',
+] as const;
+
+const getOperatorBucket = (address: string) =>
+  hashAddress(address) % OPERATOR_ACCENT_CLASSES.length;
+
+const getOperatorAccentClass = (address: string) =>
+  OPERATOR_ACCENT_CLASSES[getOperatorBucket(address)];
+
+const getOperatorIdenticonClass = (address: string) =>
+  OPERATOR_IDENTICON_CLASSES[getOperatorBucket(address)];
+
+const getDelegationModeTone = (mode: number | null) =>
+  statusToneFor(
+    'availability',
+    mode === 2 ? 'Available' : mode === 1 ? 'Limited' : 'Unavailable',
+  );
 
 const getDelegationModeLabel = (mode: number | null) => {
   if (mode === 2) return 'Open';

--- a/apps/tangle-cloud/src/pages/rewards/page.tsx
+++ b/apps/tangle-cloud/src/pages/rewards/page.tsx
@@ -179,24 +179,26 @@ const RewardsPage: FC = () => {
     [pendingRows, selectedTokenSet],
   );
   useEffect(() => {
-    if (pendingRows.length === 0) {
-      setSelectedTokenSet(new Set());
-      return;
-    }
-
-    setSelectedTokenSet((current) => {
-      const activeTokens = new Set(
-        pendingRows.map((row) => row.token.toLowerCase()),
-      );
-      const next = new Set(
-        [...current].filter((token) => activeTokens.has(token)),
-      );
-
-      if (next.size === current.size) {
-        return current;
+    queueMicrotask(() => {
+      if (pendingRows.length === 0) {
+        setSelectedTokenSet(new Set());
+        return;
       }
 
-      return next;
+      setSelectedTokenSet((current) => {
+        const activeTokens = new Set(
+          pendingRows.map((row) => row.token.toLowerCase()),
+        );
+        const next = new Set(
+          [...current].filter((token) => activeTokens.has(token)),
+        );
+
+        if (next.size === current.size) {
+          return current;
+        }
+
+        return next;
+      });
     });
   }, [pendingRows]);
 

--- a/apps/tangle-cloud/src/pages/services/[id]/JobHistoryTable.tsx
+++ b/apps/tangle-cloud/src/pages/services/[id]/JobHistoryTable.tsx
@@ -17,10 +17,10 @@ import {
   EmptyState,
   SkeletonTable,
 } from '@tangle-network/sandbox-ui/primitives';
+import { StatusPill, statusToneFor } from '../../../components/chrome';
 import type { JobCall } from '@tangle-network/tangle-shared-ui/data/graphql';
 import { isOptimisticJob } from '@tangle-network/tangle-shared-ui/data/graphql/useJobs';
 import type { BlueprintJobDefinition } from '@tangle-network/tangle-shared-ui/data/services';
-import { twMerge } from 'tailwind-merge';
 import { JobResultsModal } from './JobResultsModal';
 
 interface Props {
@@ -61,11 +61,7 @@ const makeColumns = (jobDefinitions?: BlueprintJobDefinition[]) => [
     cell: (info) => {
       const job = info.row.original;
       if (isOptimisticJob(job)) {
-        return (
-          <span className="px-2 py-1 rounded text-xs bg-primary/20 text-primary animate-pulse">
-            Confirming...
-          </span>
-        );
+        return <StatusPill tone="pending">Confirming</StatusPill>;
       }
       return (
         <Text variant="body2" className="font-mono">
@@ -114,24 +110,12 @@ const makeColumns = (jobDefinitions?: BlueprintJobDefinition[]) => [
     cell: (info) => {
       const job = info.row.original;
       if (isOptimisticJob(job)) {
-        return (
-          <span className="px-2 py-1 rounded text-xs bg-primary/20 text-primary animate-pulse">
-            Confirming
-          </span>
-        );
+        return <StatusPill tone="pending">Confirming</StatusPill>;
       }
       const completed = info.getValue();
+      const label = completed ? 'Completed' : 'Pending';
       return (
-        <span
-          className={twMerge(
-            'px-2 py-1 rounded text-xs',
-            completed
-              ? 'bg-green-500/20 text-green-400'
-              : 'bg-yellow-500/20 text-yellow-400',
-          )}
-        >
-          {completed ? 'Completed' : 'Pending'}
-        </span>
+        <StatusPill tone={statusToneFor('job', label)}>{label}</StatusPill>
       );
     },
   }),

--- a/apps/tangle-cloud/src/pages/services/[id]/JobSubmissionForm.tsx
+++ b/apps/tangle-cloud/src/pages/services/[id]/JobSubmissionForm.tsx
@@ -336,7 +336,9 @@ export const JobSubmissionForm: FC<Props> = ({ serviceId, blueprint }) => {
   // Initialize form values when schema changes
   useEffect(() => {
     if (hasSchema) {
-      setFormValues(selectedSchema.map(getDefaultValue));
+      queueMicrotask(() => {
+        setFormValues(selectedSchema.map(getDefaultValue));
+      });
     }
   }, [hasSchema, selectedSchema]);
 

--- a/apps/tangle-cloud/src/pages/services/[id]/MetadataJsonInput.tsx
+++ b/apps/tangle-cloud/src/pages/services/[id]/MetadataJsonInput.tsx
@@ -59,7 +59,9 @@ export const MetadataJsonInput: FC<Props> = ({
   // submit). The string compare avoids clobbering in-progress edits while the
   // user is typing.
   useEffect(() => {
-    setDraftJson((current) => (current === value ? current : (value ?? '')));
+    queueMicrotask(() => {
+      setDraftJson((current) => (current === value ? current : (value ?? '')));
+    });
   }, [value]);
 
   const parsed = useMemo(() => parseMetadata(draftJson), [draftJson]);

--- a/apps/tangle-cloud/src/pages/services/[id]/OperatorExitPanel.tsx
+++ b/apps/tangle-cloud/src/pages/services/[id]/OperatorExitPanel.tsx
@@ -109,6 +109,9 @@ const OperatorExitPanel: FC<Props> = ({
 }) => {
   const [selectedOperatorForForceExit, setSelectedOperatorForForceExit] =
     useState<Address | null>(null);
+  const [nowSeconds, setNowSeconds] = useState(() =>
+    Math.floor(Date.now() / 1000),
+  );
   const [countdown, setCountdown] = useState<string>('');
 
   const { data: exitConfig, isLoading: isLoadingConfig } =
@@ -129,13 +132,21 @@ const OperatorExitPanel: FC<Props> = ({
     useServiceOperators(serviceId);
   const { data: latestBlock } = useBlock({ watch: true });
 
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setNowSeconds(Math.floor(Date.now() / 1000));
+    }, 1000);
+
+    return () => clearInterval(intervalId);
+  }, []);
+
   // Compute offset between chain time and wall clock to handle
   // environments where block.timestamp drifts from real time
   // (e.g., local dev with evm_increaseTime).
   const chainTimeOffset = useMemo(() => {
     if (!latestBlock) return 0;
-    return Number(latestBlock.timestamp) - Math.floor(Date.now() / 1000);
-  }, [latestBlock]);
+    return Number(latestBlock.timestamp) - nowSeconds;
+  }, [latestBlock, nowSeconds]);
 
   const isLoading =
     isLoadingConfig ||
@@ -185,13 +196,14 @@ const OperatorExitPanel: FC<Props> = ({
 
   const canExecuteNow =
     exitRequest && exitStatus === ExitStatus.Scheduled
-      ? BigInt(Math.floor(Date.now() / 1000) + chainTimeOffset) >=
-        exitRequest.executeAfter
+      ? BigInt(nowSeconds + chainTimeOffset) >= exitRequest.executeAfter
       : false;
 
   useEffect(() => {
     if (exitStatus !== ExitStatus.Scheduled || !exitRequest || canExecuteNow) {
-      setCountdown('');
+      queueMicrotask(() => {
+        setCountdown('');
+      });
       return;
     }
 
@@ -209,7 +221,7 @@ const OperatorExitPanel: FC<Props> = ({
       setCountdown(formatDuration(BigInt(remaining)));
     };
 
-    updateCountdown();
+    queueMicrotask(updateCountdown);
     const interval = setInterval(updateCountdown, 1000);
 
     return () => clearInterval(interval);

--- a/apps/tangle-cloud/src/pages/services/[id]/ServiceOnChainDetails.tsx
+++ b/apps/tangle-cloud/src/pages/services/[id]/ServiceOnChainDetails.tsx
@@ -3,14 +3,19 @@
  * pricing model, and membership configuration.
  */
 
-import { type ComponentProps, type FC, type ReactNode } from 'react';
+import { type ComponentProps, type FC, type ReactNode, useState } from 'react';
 import {
-  Badge,
   Button as SandboxButton,
   Card,
   Skeleton,
 } from '@tangle-network/sandbox-ui/primitives';
 import { Text } from '../../../components/sandbox/SandboxUi';
+import {
+  Money,
+  StatusPill,
+  formatMoney,
+  statusToneFor,
+} from '../../../components/chrome';
 import {
   useServiceDetails,
   useServiceEscrow,
@@ -25,7 +30,6 @@ import { MembershipModel } from '@tangle-network/tangle-shared-ui/data/services/
 import { formatTtl, formatCreatedAt } from '../../../types/serviceRequest';
 import { useChainId } from 'wagmi';
 import { chainsConfig } from '@tangle-network/dapp-config/chains';
-import { formatUnits } from 'viem';
 
 interface Props {
   serviceId: bigint;
@@ -63,16 +67,6 @@ const Button: FC<ButtonProps> = ({
   />
 );
 
-const Chip: FC<{ color?: string; children: ReactNode }> = ({
-  color,
-  children,
-}) => {
-  const variant =
-    color === 'green' ? 'success' : color === 'red' ? 'destructive' : 'outline';
-
-  return <Badge variant={variant}>{children}</Badge>;
-};
-
 const ServiceOnChainDetails: FC<Props> = ({
   serviceId,
   blueprintId,
@@ -97,6 +91,7 @@ const ServiceOnChainDetails: FC<Props> = ({
     txHash: billingTxHash,
     reset: resetBillingState,
   } = useBillSubscriptionTx();
+  const [now] = useState(() => BigInt(Math.floor(Date.now() / 1000)));
 
   const isLoading =
     isLoadingDetails || isLoadingEscrow || isLoadingConfig || isLoadingToken;
@@ -127,6 +122,10 @@ const ServiceOnChainDetails: FC<Props> = ({
   const tokenSymbol =
     tokenMetadata?.symbol ?? (isNativeToken ? 'ETH' : 'TOKEN');
   const tokenDecimals = tokenMetadata?.decimals ?? 18;
+  const moneyOptions = {
+    decimals: tokenDecimals,
+    symbol: tokenSymbol,
+  };
   const explorerBaseUrl = activeChain?.blockExplorers?.default?.url;
 
   const isSubscriptionService =
@@ -140,7 +139,6 @@ const ServiceOnChainDetails: FC<Props> = ({
   const hasEscrowForNextBill =
     hasSubscriptionConfig && escrowBalance >= subscriptionRate;
   const isServiceActive = serviceDetails?.status === ServiceStatus.Active;
-  const now = BigInt(Math.floor(Date.now() / 1000));
   const lastPaymentAt = serviceDetails?.lastPaymentAt ?? BigInt(0);
   const nextBillingAt =
     hasSubscriptionConfig && serviceDetails
@@ -166,12 +164,28 @@ const ServiceOnChainDetails: FC<Props> = ({
     await executeBillSubscription({ serviceId });
   };
 
-  const formatAmount = (amount: bigint | undefined): string => {
+  const renderMoney = (
+    amount: bigint | null | undefined,
+    suffix?: ReactNode,
+  ): ReactNode => {
+    if (amount === null || amount === undefined) {
+      return EMPTY_VALUE_PLACEHOLDER;
+    }
+
+    return (
+      <span className="inline-flex flex-wrap items-baseline gap-1.5">
+        <Money value={amount} options={moneyOptions} align="left" />
+        {suffix !== undefined && (
+          <span className="text-muted-foreground text-xs">{suffix}</span>
+        )}
+      </span>
+    );
+  };
+
+  const formatAmountForDetail = (amount: bigint | undefined): string => {
     if (amount === undefined) return EMPTY_VALUE_PLACEHOLDER;
-    const formatted = Number(formatUnits(amount, tokenDecimals));
-    return Number.isFinite(formatted)
-      ? formatted.toLocaleString(undefined, { maximumFractionDigits: 4 })
-      : formatUnits(amount, tokenDecimals);
+    const view = formatMoney(amount, moneyOptions);
+    return `${view.full} ${view.symbol}`.trim();
   };
 
   const getMembershipLabel = (
@@ -181,30 +195,17 @@ const ServiceOnChainDetails: FC<Props> = ({
     return membership === MembershipModel.Fixed ? 'Fixed' : 'Dynamic';
   };
 
-  const getMembershipChipColor = (membership: MembershipModel | undefined) => {
-    if (membership === undefined) return 'dark-grey';
-    return membership === MembershipModel.Fixed ? 'blue' : 'purple';
+  const getPricingLabel = (
+    pricing: ServicePricingModel | undefined,
+  ): string => {
+    if (pricing === undefined) return EMPTY_VALUE_PLACEHOLDER;
+    return getServicePricingModelLabel(pricing);
   };
 
-  const getPricingChipColor = (pricing: ServicePricingModel | undefined) => {
-    if (pricing === undefined) return 'dark-grey';
-    switch (pricing) {
-      case ServicePricingModel.PayOnce:
-        return 'green';
-      case ServicePricingModel.Subscription:
-        return 'yellow';
-      case ServicePricingModel.EventDriven:
-        return 'blue';
-      default:
-        return 'dark-grey';
-    }
-  };
-
-  const formatSubscriptionRate = (): string => {
+  const formatSubscriptionRate = (): ReactNode => {
     if (!blueprintConfig || blueprintConfig.subscriptionRate === BigInt(0)) {
       return EMPTY_VALUE_PLACEHOLDER;
     }
-    const rate = formatAmount(blueprintConfig.subscriptionRate);
     const intervalSeconds = Number(blueprintConfig.subscriptionInterval);
     const intervalLabel =
       intervalSeconds >= 86400
@@ -212,14 +213,14 @@ const ServiceOnChainDetails: FC<Props> = ({
         : intervalSeconds >= 3600
           ? `${Math.floor(intervalSeconds / 3600)} hour(s)`
           : `${Math.floor(intervalSeconds / 60)} minute(s)`;
-    return `${rate} ${tokenSymbol} / ${intervalLabel}`;
+    return renderMoney(blueprintConfig.subscriptionRate, `/ ${intervalLabel}`);
   };
 
-  const formatEventRate = (): string => {
+  const formatEventRate = (): ReactNode => {
     if (!blueprintConfig || blueprintConfig.eventRate === BigInt(0)) {
       return EMPTY_VALUE_PLACEHOLDER;
     }
-    return `${formatAmount(blueprintConfig.eventRate)} ${tokenSymbol} / job`;
+    return renderMoney(blueprintConfig.eventRate, '/ job');
   };
 
   return (
@@ -260,19 +261,27 @@ const ServiceOnChainDetails: FC<Props> = ({
         <DetailItem
           label="Membership"
           value={
-            <Chip color={getMembershipChipColor(serviceDetails?.membership)}>
+            <StatusPill
+              tone={statusToneFor(
+                'membership',
+                getMembershipLabel(serviceDetails?.membership),
+              )}
+            >
               {getMembershipLabel(serviceDetails?.membership)}
-            </Chip>
+            </StatusPill>
           }
         />
         <DetailItem
           label="Pricing"
           value={
-            <Chip color={getPricingChipColor(serviceDetails?.pricing)}>
-              {serviceDetails?.pricing !== undefined
-                ? getServicePricingModelLabel(serviceDetails.pricing)
-                : EMPTY_VALUE_PLACEHOLDER}
-            </Chip>
+            <StatusPill
+              tone={statusToneFor(
+                'payment',
+                getPricingLabel(serviceDetails?.pricing),
+              )}
+            >
+              {getPricingLabel(serviceDetails?.pricing)}
+            </StatusPill>
           }
         />
         <DetailItem
@@ -294,20 +303,16 @@ const ServiceOnChainDetails: FC<Props> = ({
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
           <DetailItem
             label="Escrow Balance"
-            value={
-              <span className="text-green-400 font-semibold">
-                {formatAmount(escrow?.balance)} {tokenSymbol}
-              </span>
-            }
+            value={renderMoney(escrow?.balance)}
             highlight
           />
           <DetailItem
             label="Total Deposited"
-            value={`${formatAmount(escrow?.totalDeposited)} ${tokenSymbol}`}
+            value={renderMoney(escrow?.totalDeposited)}
           />
           <DetailItem
             label="Total Released"
-            value={`${formatAmount(escrow?.totalReleased)} ${tokenSymbol}`}
+            value={renderMoney(escrow?.totalReleased)}
           />
           <DetailItem
             label="Last Payment"
@@ -347,15 +352,9 @@ const ServiceOnChainDetails: FC<Props> = ({
           <DetailItem
             label="Billability"
             value={
-              <span
-                className={
-                  canBillSubscription
-                    ? 'text-green-400 font-semibold'
-                    : 'text-yellow-400 font-semibold'
-                }
-              >
+              <StatusPill tone={canBillSubscription ? 'success' : 'warning'}>
                 {canBillSubscription ? 'Billable now' : 'Not billable yet'}
-              </span>
+              </StatusPill>
             }
           />
         </div>
@@ -388,14 +387,19 @@ const ServiceOnChainDetails: FC<Props> = ({
               ok={hasSubscriptionConfig}
               detail={
                 hasSubscriptionConfig
-                  ? `${formatAmount(subscriptionRate)} ${tokenSymbol} every ${formatTtl(subscriptionInterval)}`
+                  ? renderMoney(
+                      subscriptionRate,
+                      `every ${formatTtl(subscriptionInterval)}`,
+                    )
                   : 'Missing subscription rate or interval'
               }
             />
             <BillingCondition
               label="Escrow can cover next bill"
               ok={hasEscrowForNextBill}
-              detail={`${formatAmount(escrowBalance)} / ${formatAmount(subscriptionRate)} ${tokenSymbol}`}
+              detail={`${formatAmountForDetail(
+                escrowBalance,
+              )} / ${formatAmountForDetail(subscriptionRate)}`}
             />
             <BillingCondition
               label="Billing window is due"
@@ -418,15 +422,13 @@ const ServiceOnChainDetails: FC<Props> = ({
 
           {isBillingSuccess && billingTxHash && (
             <div className="mt-3">
-              <Text variant="body2" className="text-green-400">
-                Subscription billed successfully.
-              </Text>
+              <StatusPill tone="success">Subscription billed</StatusPill>
               {explorerBaseUrl ? (
                 <a
                   href={`${explorerBaseUrl}/tx/${billingTxHash}`}
                   target="_blank"
                   rel="noreferrer"
-                  className="underline body2 text-green-300"
+                  className="body2 mt-2 inline-flex underline text-muted-foreground hover:text-foreground"
                 >
                   View transaction
                 </a>
@@ -457,17 +459,17 @@ interface DetailItemProps {
 const BillingCondition: FC<{
   label: string;
   ok: boolean;
-  detail: string | null;
+  detail: ReactNode | null;
 }> = ({ label, ok, detail }) => (
   <div className="p-2 rounded border border-border">
     <Text variant="body2" fw="semibold">
       {label}
     </Text>
-    <Text variant="body2" className={ok ? 'text-green-400' : 'text-yellow-400'}>
+    <StatusPill tone={ok ? 'success' : 'warning'}>
       {ok ? 'Yes' : 'No'}
-    </Text>
+    </StatusPill>
     {detail && (
-      <Text variant="body3" className="text-muted-foreground mt-1">
+      <Text variant="body3" className="mt-1 text-muted-foreground">
         {detail}
       </Text>
     )}
@@ -478,7 +480,7 @@ const DetailItem: FC<DetailItemProps> = ({ label, value, highlight }) => (
   <div
     className={
       highlight
-        ? 'p-3 rounded-lg bg-green-500/10 border border-green-500/20'
+        ? 'rounded-lg border border-[color:var(--border-accent)] bg-[var(--accent-surface-soft)] p-3'
         : undefined
     }
   >

--- a/apps/tangle-cloud/src/pages/services/[id]/page.tsx
+++ b/apps/tangle-cloud/src/pages/services/[id]/page.tsx
@@ -42,7 +42,6 @@ import {
 } from '@tangle-network/tangle-shared-ui/data/services';
 import { addressesEqual } from '@tangle-network/tangle-shared-ui/utils/safeParseAddress';
 import useEvmOperatorInfo from '../../../hooks/useEvmOperatorInfo';
-import { twMerge } from 'tailwind-merge';
 import { Address, getAddress, isAddress, zeroAddress } from 'viem';
 import { JobSubmissionForm } from './JobSubmissionForm';
 import { JobHistoryTable } from './JobHistoryTable';
@@ -54,6 +53,7 @@ import { PagePath } from '../../../types';
 import BlueprintHostCard from '../../../components/blueprintApps/BlueprintHostCard';
 import ServiceUpgradePanel from '../../../components/binaryUpgrade/ServiceUpgradePanel';
 import ServiceUpgradeBadge from '../../../components/binaryUpgrade/ServiceUpgradeBadge';
+import { StatusPill, statusToneFor } from '../../../components/chrome';
 
 const EMPTY_VALUE_PLACEHOLDER = '-';
 const CARD_SURFACE = 'sandbox' as const;
@@ -252,26 +252,30 @@ const ServiceDetailPage: FC = () => {
     operatorAddress ?? undefined,
     { enabled: !!operatorAddress && isOperator },
   );
+  const ownerAddress = onChainDetails?.owner;
+  const servicePermittedCallers = service?.permittedCallers;
 
   // Determine if user is the owner
   const isOwner = useMemo(() => {
-    if (!address || !onChainDetails?.owner) return false;
-    return addressesEqual(onChainDetails.owner, address);
-  }, [address, onChainDetails?.owner]);
+    if (!address || !ownerAddress) return false;
+    return addressesEqual(ownerAddress, address);
+  }, [address, ownerAddress]);
 
   useEffect(() => {
-    setCallerInput('');
-    setCallerInputError(null);
-    setRemovingCaller(null);
+    const timeoutId = window.setTimeout(() => {
+      setCallerInput('');
+      setCallerInputError(null);
+      setRemovingCaller(null);
+    }, 0);
+
+    return () => window.clearTimeout(timeoutId);
   }, [serviceId]);
 
   const permittedCallers = useMemo(() => {
-    const owner = onChainDetails?.owner
-      ? getAddress(onChainDetails.owner)
-      : null;
+    const owner = ownerAddress ? getAddress(ownerAddress) : null;
     const callers = new Map<string, Address>();
 
-    for (const caller of service?.permittedCallers ?? []) {
+    for (const caller of servicePermittedCallers ?? []) {
       if (!isAddress(caller, { strict: false })) {
         continue;
       }
@@ -292,7 +296,7 @@ const ServiceDetailPage: FC = () => {
       (caller) => !addressesEqual(caller, owner),
     );
     return [owner, ...withoutOwner];
-  }, [onChainDetails?.owner, service?.permittedCallers]);
+  }, [ownerAddress, servicePermittedCallers]);
 
   // User can submit jobs if they are the owner or a permitted caller
   const canSubmitJobs = useMemo(() => {
@@ -314,10 +318,10 @@ const ServiceDetailPage: FC = () => {
     () =>
       validatePermittedCallerInput({
         value: callerInput,
-        owner: onChainDetails?.owner,
+        owner: ownerAddress,
         permittedCallers,
       }),
-    [callerInput, onChainDetails?.owner, permittedCallers],
+    [callerInput, ownerAddress, permittedCallers],
   );
 
   const canAddPermittedCaller =
@@ -517,16 +521,9 @@ const ServiceDetailPage: FC = () => {
           <InfoItem
             label="Status"
             value={
-              <span
-                className={twMerge(
-                  'px-2 py-1 rounded text-sm',
-                  service.status === 'ACTIVE'
-                    ? 'bg-green-500/20 text-green-400'
-                    : 'bg-muted text-muted-foreground',
-                )}
-              >
+              <StatusPill tone={statusToneFor('service', service.status)}>
                 {service.status}
-              </span>
+              </StatusPill>
             }
           />
           <InfoItem
@@ -618,15 +615,12 @@ const ServiceDetailPage: FC = () => {
             <div className="rounded-lg border border-border p-3">
               <Text variant="body2" className="text-muted-foreground">
                 Connected account access:{' '}
-                <span
-                  className={
-                    canSubmitJobs
-                      ? 'text-green-400 font-semibold'
-                      : 'text-yellow-300 font-semibold'
-                  }
+                <StatusPill
+                  tone={canSubmitJobs ? 'success' : 'warning'}
+                  className="ml-1 align-middle"
                 >
                   {canSubmitJobs ? 'Allowed' : 'Not allowed'}
-                </span>
+                </StatusPill>
               </Text>
             </div>
 

--- a/apps/tangle-cloud/src/styles.css
+++ b/apps/tangle-cloud/src/styles.css
@@ -46,13 +46,16 @@ body {
 .tangle-cloud-shell[data-sandbox-theme='tangle'] {
   color-scheme: dark;
   /* prettier-ignore */
-  --bg-root: radial-gradient(ellipse 70% 48% at 18% 0%, rgba(99, 102, 241, 0.14), transparent), radial-gradient(ellipse 48% 36% at 82% 6%, rgba(20, 184, 166, 0.09), transparent), linear-gradient(180deg, #0a0a14 0%, #07070d 100%);
-  --bg-card: #1b1a2c;
-  --bg-elevated: #262448;
-  --bg-hover: rgba(129, 140, 248, 0.16);
+  --bg-root: radial-gradient(ellipse 60% 36% at 16% 0%, rgba(79, 70, 229, 0.1), transparent), radial-gradient(ellipse 44% 30% at 84% 4%, rgba(20, 184, 166, 0.08), transparent), linear-gradient(180deg, #090b10 0%, #07080c 100%);
+  --bg-card: #151922;
+  --bg-elevated: #202737;
+  --bg-hover: rgba(116, 126, 194, 0.18);
+  --text-primary: #dbe3f0;
+  --text-muted: #9aa7ba;
+  --text-secondary: #c3ccdc;
   --border-subtle: rgba(116, 126, 194, 0.12);
-  --border-default: rgba(128, 138, 213, 0.24);
-  --border-hover: rgba(151, 161, 245, 0.48);
+  --border-default: rgba(135, 146, 172, 0.26);
+  --border-hover: rgba(151, 161, 245, 0.46);
   --border-accent: rgba(129, 140, 248, 0.36);
   --border-accent-hover: rgba(129, 140, 248, 0.55);
   --accent-surface-soft: rgba(99, 102, 241, 0.12);
@@ -254,11 +257,6 @@ body {
   border: 1px solid var(--border-subtle);
   background: var(--bg-card);
   box-shadow: var(--shadow-card);
-}
-
-.results-grid {
-  content-visibility: auto;
-  contain-intrinsic-size: 800px;
 }
 
 /* Page-to-page transition triggered by PageMotion when react-router's

--- a/apps/tangle-cloud/src/styles/chrome.ts
+++ b/apps/tangle-cloud/src/styles/chrome.ts
@@ -23,10 +23,9 @@
 export const typeRole = {
   /** Page H1. One per page. */
   display:
-    'font-display font-extrabold text-3xl sm:text-4xl tracking-[-0.035em] leading-[1.05]',
+    'font-display font-extrabold text-3xl sm:text-4xl tracking-normal leading-[1.08]',
   /** Section heads, card titles. */
-  section:
-    'font-display font-semibold text-lg leading-tight tracking-[-0.012em]',
+  section: 'font-display font-semibold text-lg leading-tight tracking-normal',
   /** Default body copy. */
   body: 'text-sm leading-relaxed',
   /** Control labels, eyebrows. Always uppercase, always tracked. */
@@ -57,7 +56,7 @@ export const chromeHeight = {
   headerCompact: 'min-h-[60px] py-3',
   headerDefault: 'min-h-[80px] py-4',
   headerHero: 'min-h-[120px] py-6',
-  toolbar: 'h-11', // 44px
+  toolbar: 'min-h-11', // 44px minimum; wraps on narrow screens.
   metricStrip: 'min-h-[56px] py-3',
   tray: 'w-[420px]',
 } as const;

--- a/apps/tangle-cloud/src/styles/chrome.ts
+++ b/apps/tangle-cloud/src/styles/chrome.ts
@@ -63,22 +63,169 @@ export const chromeHeight = {
 } as const;
 
 // ── Status palette ───────────────────────────────────────────────────────────
-// Three status tones. Outlined pills only — `border-{color} bg-{color}/8` —
-// never filled. One color per status. Used at boundaries (state of a service,
-// audit state, capacity state). Never decorative.
+// Six status tones, one per *meaning*. Outlined pills only —
+// `border-{color} bg-{color}/8` — never filled. One color per status. Used at
+// boundaries (state of a service/instance/job/operator/payment, audit state,
+// capacity state). Never decorative.
+//
+// The tone enum is closed on purpose: surfaces map a domain status to one of
+// these six and the pill renders identically everywhere. A status can never
+// silently collapse to a default (the bug F1-svc: a Chip color map that only
+// knew green/red, so blue/purple/yellow all rendered the same neutral pill).
+//
+// Tone meanings:
+//   neutral  — inert / unknown / placeholder (default; no signal)
+//   info     — informational, in the accent family (e.g. Fixed membership,
+//              EventDriven pricing, an in-band state worth surfacing)
+//   success  — healthy / active / live / approved / billable / audited
+//   warning  — needs attention / pending action / degraded / stale / not-yet
+//   danger   — failed / rejected / slashed / terminated / disputed
+//   pending  — in-flight / provisioning / indexing / awaiting confirmation
+//              (rendered with a soft pulsing dot by StatusPill)
 
-export type StatusTone = 'neutral' | 'success' | 'warning' | 'danger' | 'info';
+export type StatusTone =
+  | 'neutral'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'pending';
 
 export const statusPill: Record<StatusTone, string> = {
   neutral: 'border border-border bg-transparent text-muted-foreground',
+  info: 'border border-[color:var(--border-accent)] bg-[var(--accent-surface-soft)] text-foreground',
   success:
     'border border-[color:var(--md3-tertiary,#10b981)]/40 bg-[color:var(--md3-tertiary,#10b981)]/8 text-[color:var(--md3-tertiary,#10b981)]',
   warning:
     'border border-[color:var(--md3-warning,#f59e0b)]/40 bg-[color:var(--md3-warning,#f59e0b)]/8 text-[color:var(--md3-warning,#f59e0b)]',
   danger:
     'border border-[color:var(--md3-error,#ef4444)]/40 bg-[color:var(--md3-error,#ef4444)]/8 text-[color:var(--md3-error,#ef4444)]',
-  info: 'border border-[color:var(--border-accent)] bg-[var(--accent-surface-soft)] text-foreground',
+  pending:
+    'border border-[color:var(--border-accent)] bg-[var(--accent-surface-soft)] text-[color:var(--border-accent-hover)]',
 } as const;
+
+// The leading dot color for each tone — kept in sync with `statusPill` so the
+// StatusPill auto-dot and any tone-aware indicator read the same hue.
+export const statusDot: Record<StatusTone, string> = {
+  neutral: 'bg-muted-foreground/40',
+  info: 'bg-[color:var(--border-accent-hover)]',
+  success: 'bg-[color:var(--md3-tertiary,#10b981)]',
+  warning: 'bg-[color:var(--md3-warning,#f59e0b)]',
+  danger: 'bg-[color:var(--md3-error,#ef4444)]',
+  pending: 'bg-[color:var(--border-accent-hover)]',
+} as const;
+
+// ── Canonical domain → tone mapping ──────────────────────────────────────────
+// `statusToneFor(domain, status)` is the single place the app decides which
+// tone a given domain status earns. Surfaces NEVER hand-roll
+// `color === 'green' ? 'success' : …`; they call this. Adding a new status
+// value is a one-line edit here, not a sweep across N files.
+//
+// Each domain maps its *string* status label (the value surfaces already have
+// in hand — enum label, indexer field, derived flag) to a tone. Unknown values
+// fall through to `neutral`, which is the honest default: no fake signal.
+
+export type StatusDomain =
+  | 'service' // service lifecycle: Pending | Active | Terminated
+  | 'instance' // instance / request approval: Pending | Approved | Rejected | Active | Terminated
+  | 'job' // job execution: Submitted | Running | Completed | Failed
+  | 'operator' // operator state: Active | Inactive | Leaving | Slashed
+  | 'payment' // payment / pricing model: PayOnce | Subscription | EventDriven
+  | 'membership' // membership model: Fixed | Dynamic
+  | 'audit' // audit / attestation: Audited | Unaudited | Pending
+  | 'availability' // capacity: Available | Limited | Unavailable
+  | 'billing'; // subscription billability: Billable | NotBillable | Due | Paid
+
+const TONE_BY_DOMAIN: Record<StatusDomain, Record<string, StatusTone>> = {
+  service: {
+    pending: 'pending',
+    active: 'success',
+    terminated: 'danger',
+  },
+  instance: {
+    pending: 'pending',
+    approved: 'success',
+    active: 'success',
+    rejected: 'danger',
+    terminated: 'danger',
+    indexing: 'pending',
+    submitted: 'pending',
+  },
+  job: {
+    submitted: 'pending',
+    pending: 'pending',
+    running: 'pending',
+    completed: 'success',
+    succeeded: 'success',
+    failed: 'danger',
+    errored: 'danger',
+  },
+  operator: {
+    active: 'success',
+    online: 'success',
+    inactive: 'neutral',
+    offline: 'warning',
+    leaving: 'warning',
+    exiting: 'warning',
+    slashed: 'danger',
+    disabled: 'danger',
+  },
+  payment: {
+    // Distinct tones so PayOnce / Subscription / EventDriven are never
+    // visually identical (the F1-svc collapse). These are *informational*
+    // category badges, not health signals — kept in the accent/neutral family.
+    payonce: 'info',
+    subscription: 'success',
+    eventdriven: 'warning',
+  },
+  membership: {
+    // Fixed vs Dynamic must be distinguishable.
+    fixed: 'info',
+    dynamic: 'success',
+  },
+  audit: {
+    audited: 'success',
+    verified: 'success',
+    unaudited: 'neutral',
+    pending: 'pending',
+    failed: 'danger',
+  },
+  availability: {
+    available: 'success',
+    limited: 'warning',
+    degraded: 'warning',
+    unavailable: 'danger',
+  },
+  billing: {
+    billable: 'success',
+    due: 'warning',
+    notbillable: 'neutral',
+    notyet: 'warning',
+    paid: 'success',
+  },
+} as const;
+
+/**
+ * Map a domain status to its canonical {@link StatusTone}. Pass the status as a
+ * string (enum label, indexer field, or a derived label) plus the domain so the
+ * same word can mean different things in different contexts (an `active`
+ * service and an `active` operator both read success, but `pending` is a
+ * `pending` tone for a service yet there is no such status for membership).
+ *
+ * Returns `neutral` for any unknown status — the honest default. Matching is
+ * case/space/dash-insensitive so `'PayOnce'`, `'pay_once'`, and `'pay once'`
+ * all resolve.
+ */
+export function statusToneFor(
+  domain: StatusDomain,
+  status: string | number | null | undefined,
+): StatusTone {
+  if (status === null || status === undefined) return 'neutral';
+  const key = String(status)
+    .toLowerCase()
+    .replace(/[\s_-]+/g, '');
+  return TONE_BY_DOMAIN[domain][key] ?? 'neutral';
+}
 
 // ── Surface roles ────────────────────────────────────────────────────────────
 // Eight roles. Bound to brand tokens. Anything not in this list is a bug.
@@ -99,3 +246,150 @@ export const surface = {
 export const focus = {
   ring: 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--border-accent-hover)] focus-visible:ring-offset-2 focus-visible:ring-offset-background',
 } as const;
+
+// ── Money contract ───────────────────────────────────────────────────────────
+// On a money/permissions console the value on screen MUST be the exact on-chain
+// bigint, never a lossy float. The bug this kills (F1-acct, F5-svc): bigints
+// pushed through `Number(formatUnits(...)).toLocaleString({maxFractionDigits:4})`
+// — which silently truncates precision and drops the unit, so an auditor can
+// neither trust nor copy the number.
+//
+// `formatMoney` is a *view* over the exact bigint: it returns a compact display
+// string for the cell, the full-precision decimal string for the copy
+// affordance, and the unit. The `<Money>` chrome component renders this view
+// with a copy-full-precision button. Surfaces format money ONE way: through
+// this contract.
+
+export type MoneyView = {
+  /** Compact, human display — e.g. `1,234.56` or `1.2M`. Lossy by design; the
+   *  cell stays scannable. Never the source of truth. */
+  display: string;
+  /** Full-precision decimal string — every significant digit the bigint holds.
+   *  This is what the copy affordance writes to the clipboard. */
+  full: string;
+  /** The raw on-chain integer as a string (wei-equivalent), for power users /
+   *  debugging. */
+  raw: string;
+  /** Token symbol / unit. Provenance always travels with the number. */
+  symbol: string;
+  /** Decimals used to scale `raw` → `full`. */
+  decimals: number;
+  /** True when the source value was missing — render an em-dash, not `0`. */
+  isEmpty: boolean;
+};
+
+export type FormatMoneyOptions = {
+  /** Token decimals. Default 18. */
+  decimals?: number;
+  /** Token symbol / unit. Default `''` (caller should always pass one). */
+  symbol?: string;
+  /** Significant fraction digits in the *compact display* only — `full` is
+   *  always complete. Default 4. */
+  displayDecimals?: number;
+  /** Collapse large magnitudes to K/M/B in the compact display. Default true. */
+  compact?: boolean;
+};
+
+const EM_DASH = '—';
+
+function trimTrailingZeros(decimalStr: string): string {
+  if (!decimalStr.includes('.')) return decimalStr;
+  return decimalStr.replace(/\.?0+$/, '');
+}
+
+/**
+ * Build a {@link MoneyView} from an exact on-chain bigint. Lossless: `full` is
+ * derived by integer-only division of the raw value, never by `Number()`.
+ *
+ *   formatMoney(1234567890000000000n, { decimals: 18, symbol: 'TNT' })
+ *   // → { display: '1.2346', full: '1.23456789', raw: '1234567890000000000',
+ *   //     symbol: 'TNT', decimals: 18, isEmpty: false }
+ */
+export function formatMoney(
+  value: bigint | null | undefined,
+  options: FormatMoneyOptions = {},
+): MoneyView {
+  const {
+    decimals = 18,
+    symbol = '',
+    displayDecimals = 4,
+    compact = true,
+  } = options;
+
+  if (value === null || value === undefined) {
+    return {
+      display: EM_DASH,
+      full: EM_DASH,
+      raw: '',
+      symbol,
+      decimals,
+      isEmpty: true,
+    };
+  }
+
+  const negative = value < 0n;
+  const abs = negative ? -value : value;
+  const base = 10n ** BigInt(decimals);
+  const whole = abs / base;
+  const fraction = abs % base;
+
+  // Lossless full-precision decimal string from integer arithmetic.
+  const fractionStr =
+    decimals > 0
+      ? fraction.toString().padStart(decimals, '0').replace(/0+$/, '')
+      : '';
+  const full =
+    (negative ? '-' : '') +
+    (fractionStr.length > 0
+      ? `${whole.toString()}.${fractionStr}`
+      : whole.toString());
+
+  // Compact display. We round the fractional part to `displayDecimals` for the
+  // cell only; the source of truth stays in `full`.
+  const wholeNum = whole; // bigint, may exceed Number range
+  let display: string;
+  if (compact && wholeNum >= 1_000_000n) {
+    const units: Array<[bigint, string]> = [
+      [1_000_000_000_000n, 'T'],
+      [1_000_000_000n, 'B'],
+      [1_000_000n, 'M'],
+    ];
+    const [unitBase, suffix] = units.find(([u]) => wholeNum >= u) ?? [
+      1_000_000n,
+      'M',
+    ];
+    // One decimal of the compacted magnitude, integer-only.
+    const scaled = (wholeNum * 10n) / unitBase;
+    const head = scaled / 10n;
+    const tenth = scaled % 10n;
+    display =
+      (negative ? '-' : '') +
+      (tenth > 0n
+        ? `${head.toString()}.${tenth.toString()}`
+        : head.toString()) +
+      suffix;
+  } else {
+    // wholeNum is < 1e6 here, safe to render with group separators.
+    const wholeDisplay = Number(wholeNum).toLocaleString('en-US');
+    const roundedFraction =
+      displayDecimals > 0 && fractionStr.length > 0
+        ? `.${trimTrailingZeros(
+            fraction
+              .toString()
+              .padStart(decimals, '0')
+              .slice(0, displayDecimals),
+          ).replace(/^\./, '')}`.replace(/\.$/, '')
+        : '';
+    const fracClean = roundedFraction === '.' ? '' : roundedFraction;
+    display = (negative ? '-' : '') + wholeDisplay + fracClean;
+  }
+
+  return {
+    display: display === '' ? '0' : display,
+    full,
+    raw: value.toString(),
+    symbol,
+    decimals,
+    isEmpty: false,
+  };
+}

--- a/apps/tangle-dapp/src/components/account/TransferModal.tsx
+++ b/apps/tangle-dapp/src/components/account/TransferModal.tsx
@@ -112,14 +112,18 @@ const TransferModal: FC<TransferModalProps> = ({ isOpen, onClose }) => {
 
     if (!selectedToken) {
       // Set default token when first available
-      setSelectedToken(tokenOptions[0]);
+      queueMicrotask(() => {
+        setSelectedToken(tokenOptions[0]);
+      });
     } else {
       // Update selectedToken when balance changes in tokenOptions
       const updatedToken = tokenOptions.find(
         (t) => t.address === selectedToken.address,
       );
       if (updatedToken && updatedToken.balance !== selectedToken.balance) {
-        setSelectedToken(updatedToken);
+        queueMicrotask(() => {
+          setSelectedToken(updatedToken);
+        });
       }
     }
   }, [tokenOptions]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/apps/tangle-dapp/src/data/credits/useCredits.ts
+++ b/apps/tangle-dapp/src/data/credits/useCredits.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useChainId, useReadContract } from 'wagmi';
 import { useQuery } from '@tanstack/react-query';
 import { type Hex, type Address } from 'viem';
@@ -18,6 +18,8 @@ import {
   resolveCreditsTreeUrl,
 } from './resolveCreditsAddress';
 
+const getNowSeconds = () => BigInt(Math.floor(Date.now() / 1000));
+
 // This represents the structure of our credits data
 export type CreditsData = {
   amount: bigint;
@@ -34,6 +36,7 @@ export type CreditsData = {
 export default function useCredits() {
   const activeEvmAddress = useEvmAddress();
   const chainId = useChainId();
+  const [nowSeconds, setNowSeconds] = useState(getNowSeconds);
   const creditsAddress = resolveCreditsAddress(chainId);
   const isSupportedNetwork = creditsAddress !== null;
   const creditsTreeUrl = resolveCreditsTreeUrl(chainId);
@@ -58,6 +61,14 @@ export default function useCredits() {
     gcTime: 30 * 60 * 1000,
   });
 
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setNowSeconds(getNowSeconds());
+    }, 1000);
+
+    return () => clearInterval(intervalId);
+  }, []);
+
   const claimData = useMemo<CreditsClaimData | null>(() => {
     if (!activeEvmAddress || !creditsTree) {
       return null;
@@ -73,10 +84,9 @@ export default function useCredits() {
 
   const timeRemaining = useMemo(() => {
     if (!creditsWindow) return BigInt(0);
-    const now = BigInt(Math.floor(Date.now() / 1000));
-    if (creditsWindow.endTs <= now) return BigInt(0);
-    return creditsWindow.endTs - now;
-  }, [creditsWindow]);
+    if (creditsWindow.endTs <= nowSeconds) return BigInt(0);
+    return creditsWindow.endTs - nowSeconds;
+  }, [creditsWindow, nowSeconds]);
 
   const {
     data: onchainRoot,
@@ -135,8 +145,9 @@ export default function useCredits() {
     }
 
     const alreadyClaimed = Boolean(hasClaimed);
-    const now = BigInt(Math.floor(Date.now() / 1000));
-    const windowComplete = creditsWindow ? now >= creditsWindow.endTs : true;
+    const windowComplete = creditsWindow
+      ? nowSeconds >= creditsWindow.endTs
+      : true;
     return {
       amount: alreadyClaimed ? BigInt(0) : claimData.amount,
       totalAmount: claimData.amount,
@@ -155,6 +166,7 @@ export default function useCredits() {
     proofValid,
     rootMatches,
     timeRemaining,
+    nowSeconds,
   ]);
 
   const rootMismatchError =

--- a/apps/tangle-dapp/src/data/evm/useViemPublicClientWithChain.ts
+++ b/apps/tangle-dapp/src/data/evm/useViemPublicClientWithChain.ts
@@ -1,19 +1,15 @@
-import { useEffect, useState } from 'react';
-import { Chain, createPublicClient, http, PublicClient } from 'viem';
+import { useMemo } from 'react';
+import { Chain, createPublicClient, http } from 'viem';
 
 const useViemPublicClientWithChain = (chain: Chain) => {
-  const [publicClient, setPublicClient] = useState<PublicClient | null>(null);
-
-  useEffect(() => {
-    const newPublicClient = createPublicClient({
-      chain,
-      transport: http(),
-    });
-
-    setPublicClient(newPublicClient);
-  }, [chain]);
-
-  return publicClient;
+  return useMemo(
+    () =>
+      createPublicClient({
+        chain,
+        transport: http(),
+      }),
+    [chain],
+  );
 };
 
 export default useViemPublicClientWithChain;

--- a/apps/tangle-dapp/src/features/claimRewards/components/ClaimRewardsDropdown.tsx
+++ b/apps/tangle-dapp/src/features/claimRewards/components/ClaimRewardsDropdown.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { type FC, useCallback, useMemo, useState } from 'react';
 import { formatUnits } from 'viem';
 import { useAccount } from 'wagmi';
 import { VipDiamondLine, Spinner } from '@tangle-network/icons';
@@ -10,6 +10,7 @@ import {
   DropdownButton,
   Typography,
   Button,
+  useClientReady,
 } from '@tangle-network/ui-components';
 import { twMerge } from 'tailwind-merge';
 import usePendingRewards from '../../../data/rewards/usePendingRewards';
@@ -156,11 +157,7 @@ const ClaimRewardsDropdownContent: FC = () => {
 };
 
 const ClaimRewardsDropdown: FC = () => {
-  const [isClient, setIsClient] = useState(false);
-
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
+  const isClient = useClientReady();
 
   if (!isClient) {
     return null;

--- a/apps/tangle-dapp/src/hooks/useClaimedEras.ts
+++ b/apps/tangle-dapp/src/hooks/useClaimedEras.ts
@@ -1,7 +1,7 @@
 import useLocalStorage, {
   LocalStorageKey,
 } from '@tangle-network/tangle-shared-ui/hooks/useLocalStorage';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { SubstrateAddress } from '@tangle-network/ui-components/types/address';
 import { NetworkId } from '@tangle-network/ui-components/constants/networks';
 
@@ -26,17 +26,7 @@ export const useClaimedEras = () => {
   const storage = useLocalStorage(LocalStorageKey.CLAIMED_ERAS_BY_VALIDATOR);
   const [claimedErasByValidator, setClaimedErasByValidator] =
     useState<ClaimedErasByValidator>({});
-
-  /**
-   * Initializes the claimed eras state from local storage when available.
-   * This ensures persistence of claimed eras data across page refreshes.
-   */
-  useEffect(() => {
-    const storedData = storage.valueOpt?.value ?? null;
-    if (storedData) {
-      setClaimedErasByValidator(storedData);
-    }
-  }, [storage.valueOpt]);
+  const claimedEras = storage.valueOpt?.value ?? claimedErasByValidator;
 
   const addClaimedEras = useCallback(
     (
@@ -46,11 +36,10 @@ export const useClaimedEras = () => {
     ) => {
       const validatorKey = createValidatorKey(networkId, validatorAddress);
       const newClaimedEras = {
-        ...claimedErasByValidator,
-        [validatorKey]: [
-          ...(claimedErasByValidator[validatorKey] || []),
-          ...eras,
-        ].sort((a, b) => a - b),
+        ...claimedEras,
+        [validatorKey]: [...(claimedEras[validatorKey] || []), ...eras].sort(
+          (a, b) => a - b,
+        ),
       };
 
       setClaimedErasByValidator(newClaimedEras);
@@ -58,20 +47,20 @@ export const useClaimedEras = () => {
 
       return newClaimedEras;
     },
-    [claimedErasByValidator, storage],
+    [claimedEras, storage],
   );
 
   const getClaimedEras = useCallback(
     (networkId: NetworkId, validatorAddress: SubstrateAddress): number[] => {
       const validatorKey = createValidatorKey(networkId, validatorAddress);
-      return claimedErasByValidator[validatorKey] || [];
+      return claimedEras[validatorKey] || [];
     },
-    [claimedErasByValidator],
+    [claimedEras],
   );
 
   return {
     addClaimedEras,
     getClaimedEras,
-    claimedErasByValidator,
+    claimedErasByValidator: claimedEras,
   };
 };

--- a/apps/tangle-dapp/src/hooks/useCustomInputValue.ts
+++ b/apps/tangle-dapp/src/hooks/useCustomInputValue.ts
@@ -71,14 +71,27 @@ function useCustomInputValue<T>({
     }
 
     const parsedValue = parse(cleanDisplayValue);
+    let cancelled = false;
 
     if (parsedValue instanceof Error) {
-      setErrorMessage(parsedValue.message);
+      queueMicrotask(() => {
+        if (!cancelled) {
+          setErrorMessage(parsedValue.message);
+        }
+      });
     } else {
-      setErrorMessage(null);
-      setValueOnConsumer(parsedValue);
-      setDisplayValue(formatDisplayValue(parsedValue));
+      queueMicrotask(() => {
+        if (!cancelled) {
+          setErrorMessage(null);
+          setValueOnConsumer(parsedValue);
+          setDisplayValue(formatDisplayValue(parsedValue));
+        }
+      });
     }
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     format,
     formatDisplayValue,

--- a/apps/tangle-dapp/src/pages/claim/migration/components/SubstrateWalletModal.tsx
+++ b/apps/tangle-dapp/src/pages/claim/migration/components/SubstrateWalletModal.tsx
@@ -68,8 +68,6 @@ const SubstrateWalletModal: FC<SubstrateWalletModalProps> = ({
   useEffect(() => {
     if (!isOpen) return;
 
-    setError(null);
-
     const detected = new Set<string>();
     for (const wallet of SUBSTRATE_WALLETS) {
       const ext = window.injectedWeb3?.[wallet.name];
@@ -77,7 +75,11 @@ const SubstrateWalletModal: FC<SubstrateWalletModalProps> = ({
         detected.add(wallet.id);
       }
     }
-    setInstalledWallets(detected);
+
+    queueMicrotask(() => {
+      setError(null);
+      setInstalledWallets(detected);
+    });
   }, [isOpen]);
 
   const handleConnect = useCallback(

--- a/apps/tangle-dapp/src/pages/claim/migration/hooks/useClaimEligibility.ts
+++ b/apps/tangle-dapp/src/pages/claim/migration/hooks/useClaimEligibility.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   type Hex,
   formatUnits,
@@ -26,6 +26,7 @@ import {
 const MIGRATION_RPC_URL = import.meta.env.VITE_MIGRATION_RPC_URL as
   | string
   | undefined;
+const getNowSeconds = () => BigInt(Math.floor(Date.now() / 1000));
 
 // TangleMigration contract ABI (partial - only functions we use)
 const TANGLE_MIGRATION_ABI = [
@@ -866,6 +867,7 @@ export const generateChallenge = (
  */
 const useClaimEligibility = ({ ss58Address }: UseClaimEligibilityOptions) => {
   const chainId = useChainId();
+  const [nowSeconds, setNowSeconds] = useState(getNowSeconds);
   const migrationConfig = useMemo(() => {
     if (!chainId) return null;
     return getMigrationContractsByChainId(chainId);
@@ -886,6 +888,14 @@ const useClaimEligibility = ({ ss58Address }: UseClaimEligibilityOptions) => {
     if (chainId === 84532) return 'https://sepolia.base.org';
     return 'http://localhost:8545';
   }, [chainId]);
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setNowSeconds(getNowSeconds());
+    }, 1000);
+
+    return () => clearInterval(intervalId);
+  }, []);
 
   /**
    * Create a viem public client for direct contract reads.
@@ -1061,10 +1071,9 @@ const useClaimEligibility = ({ ss58Address }: UseClaimEligibilityOptions) => {
   // Calculate time remaining
   const timeRemaining = useMemo(() => {
     if (!claimDeadline) return BigInt(0);
-    const now = BigInt(Math.floor(Date.now() / 1000));
-    if (claimDeadline <= now) return BigInt(0);
-    return claimDeadline - now;
-  }, [claimDeadline]);
+    if (claimDeadline <= nowSeconds) return BigInt(0);
+    return claimDeadline - nowSeconds;
+  }, [claimDeadline, nowSeconds]);
 
   // Compute eligibility from proofs data
   const claimData = useMemo((): ClaimData | null => {
@@ -1120,9 +1129,7 @@ const useClaimEligibility = ({ ss58Address }: UseClaimEligibilityOptions) => {
         formattedBalance: '1,000',
         isPaused: false,
         unlockedBps: 1000, // Mock 10% unlocked for dev mode
-        unlockTimestamp: BigInt(
-          Math.floor(Date.now() / 1000) + 180 * 24 * 60 * 60,
-        ), // 180 days from now
+        unlockTimestamp: nowSeconds + BigInt(180 * 24 * 60 * 60), // 180 days from now
       };
     }
 
@@ -1166,6 +1173,7 @@ const useClaimEligibility = ({ ss58Address }: UseClaimEligibilityOptions) => {
     ss58Address,
     unlockedBps,
     unlockTimestamp,
+    nowSeconds,
   ]);
 
   // In dev mode, don't wait for contract reads since they're disabled anyway

--- a/apps/tangle-dapp/src/pages/claim/migration/hooks/useSubmitClaim.ts
+++ b/apps/tangle-dapp/src/pages/claim/migration/hooks/useSubmitClaim.ts
@@ -162,7 +162,9 @@ const useSubmitClaim = () => {
       return;
     }
 
-    setRelayerSuccess(true);
+    queueMicrotask(() => {
+      setRelayerSuccess(true);
+    });
     console.log('[useSubmitClaim] Relayer transaction confirmed!');
   }, [isRelayerConfirmed]);
 

--- a/apps/tangle-dapp/src/pages/claim/migration/index.tsx
+++ b/apps/tangle-dapp/src/pages/claim/migration/index.tsx
@@ -67,7 +67,9 @@ const MigrationClaimPage: FC = () => {
   // Sync recipient address with connected wallet when it changes
   useEffect(() => {
     if (evmAddress && !recipientAddress) {
-      setRecipientAddress(evmAddress);
+      queueMicrotask(() => {
+        setRecipientAddress(evmAddress);
+      });
     }
   }, [evmAddress, recipientAddress]);
 

--- a/libs/abstract-api-provider/src/index.ts
+++ b/libs/abstract-api-provider/src/index.ts
@@ -4,3 +4,4 @@
 export * from './account';
 export * from './webb-provider.interface';
 export * from './transaction-events';
+export * from './types';

--- a/libs/abstract-api-provider/src/webb-provider.interface.ts
+++ b/libs/abstract-api-provider/src/webb-provider.interface.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ApiConfig } from '@tangle-network/dapp-config';
-import { EventBus } from '@tangle-network/dapp-types/EventBus';
+import { EventBus } from '@tangle-network/dapp-types';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { AccountsAdapter } from './account/Accounts.adapter';
 

--- a/libs/api-provider-environment/src/ConnectWallet/index.ts
+++ b/libs/api-provider-environment/src/ConnectWallet/index.ts
@@ -1,15 +1,19 @@
 'use client';
 
-import type { SupportedBrowsers } from '@tangle-network/browser-utils/platform/getPlatformMetaData';
-import getPlatformMetaData from '@tangle-network/browser-utils/platform/getPlatformMetaData';
-import type { WalletConfig } from '@tangle-network/dapp-config';
-import chainsPopulated from '@tangle-network/dapp-config/chains/chainsPopulated';
 import {
+  getPlatformMetaData,
+  type SupportedBrowsers,
+} from '@tangle-network/browser-utils';
+import {
+  chainsPopulated,
+  type WalletConfig,
+} from '@tangle-network/dapp-config';
+import {
+  WalletNotInstalledError,
   WebbError,
   WebbErrorCodes,
   type WalletId,
 } from '@tangle-network/dapp-types';
-import WalletNotInstalledError from '@tangle-network/dapp-types/errors/WalletNotInstalledError';
 import assert from 'assert';
 import { useObservableState } from 'observable-hooks';
 import { useCallback, useEffect, useMemo } from 'react';

--- a/libs/api-provider-environment/src/ConnectWallet/subjects.ts
+++ b/libs/api-provider-environment/src/ConnectWallet/subjects.ts
@@ -1,6 +1,5 @@
 import type { WalletConfig } from '@tangle-network/dapp-config';
-import type { WebbError } from '@tangle-network/dapp-types/WebbError';
-import { Maybe } from '@tangle-network/dapp-types/utils/types';
+import type { Maybe, WebbError } from '@tangle-network/dapp-types';
 import { BehaviorSubject } from 'rxjs';
 
 /**

--- a/libs/api-provider-environment/src/WebbProvider/index.tsx
+++ b/libs/api-provider-environment/src/WebbProvider/index.tsx
@@ -5,32 +5,31 @@ import {
   type Account,
   type WebbApiProvider,
 } from '@tangle-network/abstract-api-provider';
-import { LoggerService } from '@tangle-network/browser-utils/logger';
 import {
+  LoggerService,
   netStorageFactory,
   type NetworkStorage,
-} from '@tangle-network/browser-utils/storage';
+} from '@tangle-network/browser-utils';
 import {
   ApiConfig,
   chainsConfig,
   chainsPopulated,
+  getWagmiConfig,
   WALLET_CONFIG,
   type Chain,
   type Wallet,
 } from '@tangle-network/dapp-config';
-import getWagmiConfig from '@tangle-network/dapp-config/wagmi-config';
 import {
+  ChainType,
+  WalletNotInstalledError,
   WalletId,
   WebbError,
   WebbErrorCodes,
-  type BareProps,
-} from '@tangle-network/dapp-types';
-import WalletNotInstalledError from '@tangle-network/dapp-types/errors/WalletNotInstalledError';
-import type { Maybe, Nullable } from '@tangle-network/dapp-types/utils/types';
-import {
-  ChainType,
   calculateTypedChainId,
-} from '@tangle-network/dapp-types/TypedChainId';
+  type BareProps,
+  type Maybe,
+  type Nullable,
+} from '@tangle-network/dapp-types';
 import { WebbWeb3Provider } from '@tangle-network/web3-api-provider';
 import { useUIContext } from '@tangle-network/ui-components';
 import useWagmiHydration from '@tangle-network/ui-components/hooks/useWagmiHydration';

--- a/libs/api-provider-environment/src/app-event/app-events.class.ts
+++ b/libs/api-provider-environment/src/app-event/app-events.class.ts
@@ -1,7 +1,11 @@
 import { Account } from '@tangle-network/abstract-api-provider';
-import { EventBus } from '@tangle-network/dapp-types/EventBus';
 import { Chain, Wallet } from '@tangle-network/dapp-config';
-import { TypedChainId, WalletId, WebbError } from '@tangle-network/dapp-types';
+import {
+  EventBus,
+  TypedChainId,
+  WalletId,
+  WebbError,
+} from '@tangle-network/dapp-types';
 
 type WalletConnectionStatus = 'idle' | 'loading' | 'sucess' | 'failed';
 

--- a/libs/api-provider-environment/src/hooks/useActiveChain.ts
+++ b/libs/api-provider-environment/src/hooks/useActiveChain.ts
@@ -1,5 +1,5 @@
 import type { Chain } from '@tangle-network/dapp-config';
-import { Maybe, Nullable } from '@tangle-network/dapp-types/utils/types';
+import { Maybe, Nullable } from '@tangle-network/dapp-types';
 import { useObservableState } from 'observable-hooks';
 import { BehaviorSubject } from 'rxjs';
 

--- a/libs/api-provider-environment/src/hooks/useActiveWallet.ts
+++ b/libs/api-provider-environment/src/hooks/useActiveWallet.ts
@@ -1,5 +1,5 @@
 import type { WalletConfig } from '@tangle-network/dapp-config';
-import { Maybe } from '@tangle-network/dapp-types/utils/types';
+import { Maybe } from '@tangle-network/dapp-types';
 import { useObservableState } from 'observable-hooks';
 import { BehaviorSubject } from 'rxjs';
 

--- a/libs/api-provider-environment/src/hooks/useWallets.ts
+++ b/libs/api-provider-environment/src/hooks/useWallets.ts
@@ -1,4 +1,4 @@
-import { ManagedWallet } from '@tangle-network/dapp-config/wallets';
+import { ManagedWallet } from '@tangle-network/dapp-config';
 import { useEffect, useState } from 'react';
 import { useWebContext } from '../webb-context';
 

--- a/libs/api-provider-environment/src/transaction/utils/makeExplorerUrl.ts
+++ b/libs/api-provider-environment/src/transaction/utils/makeExplorerUrl.ts
@@ -1,6 +1,6 @@
 import { encodeAddress } from '@polkadot/util-crypto';
-import { WebbProviderType } from '@tangle-network/abstract-api-provider/types';
-import { chainsConfig as substrateChainsConfig } from '@tangle-network/dapp-config/chains/substrate';
+import { WebbProviderType } from '@tangle-network/abstract-api-provider';
+import { substrateChainsConfig } from '@tangle-network/dapp-config';
 
 export const isPolkadotJsDashboard = (explorerUrl: string): boolean => {
   return explorerUrl.includes('polkadot.js.org/apps');

--- a/libs/api-provider-environment/src/utils/waitForConfigReady.ts
+++ b/libs/api-provider-environment/src/utils/waitForConfigReady.ts
@@ -1,4 +1,4 @@
-import type getWagmiConfig from '@tangle-network/dapp-config/wagmi-config';
+import type { getWagmiConfig } from '@tangle-network/dapp-config';
 
 export default async function waitForConfigReady(
   config: ReturnType<typeof getWagmiConfig>,

--- a/libs/api-provider-environment/src/webb-context/webb-context.ts
+++ b/libs/api-provider-environment/src/webb-context/webb-context.ts
@@ -9,7 +9,7 @@ import {
   type Chain,
   type Wallet,
 } from '@tangle-network/dapp-config';
-import type { Maybe, Nullable } from '@tangle-network/dapp-types/utils/types';
+import type { Maybe, Nullable } from '@tangle-network/dapp-types';
 import { AppEvent, type TAppEvent } from '../app-event';
 import { createContext, useContext } from 'react';
 

--- a/libs/dapp-config/src/api-config.ts
+++ b/libs/dapp-config/src/api-config.ts
@@ -1,10 +1,7 @@
 // Copyright 2024 @tangle-network/
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  WebbError,
-  WebbErrorCodes,
-} from '@tangle-network/dapp-types/WebbError';
+import { WebbError, WebbErrorCodes } from '@tangle-network/dapp-types';
 import values from 'lodash/values';
 import { ChainConfig } from './chains/chain-config.interface';
 import { WalletConfig } from './wallets/wallet-config.interface';

--- a/libs/dapp-config/src/chains/chain-config.interface.ts
+++ b/libs/dapp-config/src/chains/chain-config.interface.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 @tangle-network/
 // SPDX-License-Identifier: Apache-2.0
 
-import { ChainType } from '@tangle-network/dapp-types/TypedChainId';
+import { ChainType } from '@tangle-network/dapp-types';
 import type { Chain } from 'viem/chains';
 
 import type { AppEnvironment } from '../types';

--- a/libs/dapp-config/src/chains/chainsPopulated.ts
+++ b/libs/dapp-config/src/chains/chainsPopulated.ts
@@ -1,4 +1,4 @@
-import { calculateTypedChainId } from '@tangle-network/dapp-types/TypedChainId';
+import { calculateTypedChainId } from '@tangle-network/dapp-types';
 import { Chain } from '../api-config';
 import getWalletIdsForTypedChainId from '../utils/getWalletIdsForTypedChainId';
 import { chainsConfig } from './chain-config';

--- a/libs/dapp-config/src/chains/evm/customChains/anvilLocal.ts
+++ b/libs/dapp-config/src/chains/evm/customChains/anvilLocal.ts
@@ -1,4 +1,4 @@
-import { EVMChainId } from '@tangle-network/dapp-types/ChainId';
+import { EVMChainId } from '@tangle-network/dapp-types';
 import { defineChain } from 'viem';
 
 // Tangle logo as base64 encoded SVG data URI

--- a/libs/dapp-config/src/chains/evm/customChains/arbitrumSepolia.ts
+++ b/libs/dapp-config/src/chains/evm/customChains/arbitrumSepolia.ts
@@ -1,4 +1,4 @@
-import { EVMChainId } from '@tangle-network/dapp-types/ChainId';
+import { EVMChainId } from '@tangle-network/dapp-types';
 import { defineChain } from 'viem';
 
 const arbitrumSepolia = defineChain({

--- a/libs/dapp-config/src/chains/evm/customChains/baseSepolia.ts
+++ b/libs/dapp-config/src/chains/evm/customChains/baseSepolia.ts
@@ -1,4 +1,4 @@
-import { EVMChainId } from '@tangle-network/dapp-types/ChainId';
+import { EVMChainId } from '@tangle-network/dapp-types';
 import { defineChain } from 'viem';
 
 const baseSepolia = defineChain({

--- a/libs/dapp-config/src/chains/evm/customChains/tangleLocalEvm.ts
+++ b/libs/dapp-config/src/chains/evm/customChains/tangleLocalEvm.ts
@@ -1,4 +1,4 @@
-import { EVMChainId } from '@tangle-network/dapp-types/ChainId';
+import { EVMChainId } from '@tangle-network/dapp-types';
 import { defineChain } from 'viem';
 
 import { TANGLE_LOCAL_HTTP_RPC_ENDPOINT } from '../../../constants';

--- a/libs/dapp-config/src/chains/evm/customChains/tangleMainnetEVM.ts
+++ b/libs/dapp-config/src/chains/evm/customChains/tangleMainnetEVM.ts
@@ -1,4 +1,4 @@
-import { EVMChainId } from '@tangle-network/dapp-types/ChainId';
+import { EVMChainId } from '@tangle-network/dapp-types';
 import { defineChain } from 'viem';
 
 import {

--- a/libs/dapp-config/src/chains/evm/customChains/tangleTestnetEVM.ts
+++ b/libs/dapp-config/src/chains/evm/customChains/tangleTestnetEVM.ts
@@ -1,4 +1,4 @@
-import { EVMChainId } from '@tangle-network/dapp-types/ChainId';
+import { EVMChainId } from '@tangle-network/dapp-types';
 import { defineChain } from 'viem';
 
 import {

--- a/libs/dapp-config/src/chains/evm/index.tsx
+++ b/libs/dapp-config/src/chains/evm/index.tsx
@@ -1,8 +1,7 @@
 // Copyright 2024 @tangle-network/
 // SPDX-License-Identifier: Apache-2.0
 
-import { PresetTypedChainId } from '@tangle-network/dapp-types/ChainId';
-import { ChainType } from '@tangle-network/dapp-types/TypedChainId';
+import { ChainType, PresetTypedChainId } from '@tangle-network/dapp-types';
 import {
   mainnet,
   arbitrumGoerli,

--- a/libs/dapp-config/src/chains/solana/index.ts
+++ b/libs/dapp-config/src/chains/solana/index.ts
@@ -1,6 +1,6 @@
 import { PresetTypedChainId, SolanaChainId } from '@tangle-network/dapp-types';
 import { ChainConfig } from '../chain-config.interface';
-import { ChainType } from '@tangle-network/dapp-types/TypedChainId';
+import { ChainType } from '@tangle-network/dapp-types';
 
 export const chainsConfig = {
   [PresetTypedChainId.SolanaMainnet]: {

--- a/libs/dapp-config/src/chains/substrate/index.tsx
+++ b/libs/dapp-config/src/chains/substrate/index.tsx
@@ -1,8 +1,8 @@
 import {
+  ChainType,
   PresetTypedChainId,
   SubstrateChainId,
 } from '@tangle-network/dapp-types';
-import { ChainType } from '@tangle-network/dapp-types/TypedChainId';
 import {
   TANGLE_LOCAL_WS_RPC_ENDPOINT,
   TANGLE_MAINNET_NATIVE_EXPLORER_URL,

--- a/libs/dapp-config/src/index.ts
+++ b/libs/dapp-config/src/index.ts
@@ -6,3 +6,8 @@ export * from './contracts';
 export * from './tokenMetadata';
 export * from './utils';
 export * from './wallets';
+export { chainsConfig as substrateChainsConfig } from './chains/substrate';
+export {
+  config as wagmiConfig,
+  default as getWagmiConfig,
+} from './wagmi-config';

--- a/libs/dapp-config/src/tokenMetadata.ts
+++ b/libs/dapp-config/src/tokenMetadata.ts
@@ -6,7 +6,7 @@
  * metadata collisions when users switch between networks.
  */
 
-import EVMChainId from '@tangle-network/dapp-types/EVMChainId';
+import { EVMChainId } from '@tangle-network/dapp-types';
 import { Address } from 'viem';
 
 export interface TokenMetadata {

--- a/libs/dapp-config/src/utils/findSubstrateWallet.ts
+++ b/libs/dapp-config/src/utils/findSubstrateWallet.ts
@@ -3,8 +3,7 @@ import type {
   InjectedExtension,
   Unsubcall,
 } from '@polkadot/extension-inject/types';
-import { WalletId } from '@tangle-network/dapp-types';
-import WalletNotInstalledError from '@tangle-network/dapp-types/errors/WalletNotInstalledError';
+import { WalletId, WalletNotInstalledError } from '@tangle-network/dapp-types';
 import { WALLET_CONFIG } from '../wallets';
 
 function ensureAccountsSubscribe(

--- a/libs/dapp-config/src/wallets/wallet-config.interface.ts
+++ b/libs/dapp-config/src/wallets/wallet-config.interface.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { InjectedWindowProvider } from '@polkadot/extension-inject/types';
-import type { SupportedBrowsers } from '@tangle-network/browser-utils/platform/getPlatformMetaData';
+import type { SupportedBrowsers } from '@tangle-network/browser-utils';
 
 export interface WalletConfig {
   id: number;

--- a/libs/dapp-config/src/wallets/wallets-config.tsx
+++ b/libs/dapp-config/src/wallets/wallets-config.tsx
@@ -1,6 +1,6 @@
-import { SupportedBrowsers } from '@tangle-network/browser-utils/platform';
+import { SupportedBrowsers } from '@tangle-network/browser-utils';
 import { PresetTypedChainId } from '@tangle-network/dapp-types';
-import { WalletId } from '@tangle-network/dapp-types/WalletId';
+import { WalletId } from '@tangle-network/dapp-types';
 import {
   CoinbaseIcon,
   KeplrIcon,

--- a/libs/dapp-types/src/index.ts
+++ b/libs/dapp-types/src/index.ts
@@ -3,6 +3,7 @@
 
 export * from './ChainId';
 export * from './Currency';
+export * from './EventBus';
 export * from './Props';
 export * from './Storage';
 export { default as Storage } from './Storage';
@@ -10,6 +11,7 @@ export * from './WalletId';
 export * from './WebbError';
 export * from './utils';
 export * from './TypedChainId';
+export { default as WalletNotInstalledError } from './errors/WalletNotInstalledError';
 
 export const zeroAddress = '0x0000000000000000000000000000000000000000';
 export const ZERO = 'ZERO';

--- a/libs/dapp-types/src/utils/index.ts
+++ b/libs/dapp-types/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { default as isNotNullOrUndefined } from './isDefined';
 export { default as isPrimitive } from './isPrimitive';
 export { default as isValidUrl } from './isValidUrl';
+export * from './types';

--- a/libs/icons/src/TokenIcon.tsx
+++ b/libs/icons/src/TokenIcon.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import cx from 'classnames';
-import { MouseEventHandler, cloneElement, useMemo, useRef } from 'react';
+import { cloneElement, useMemo } from 'react';
 import { twMerge } from 'tailwind-merge';
 import Spinner from './Spinner';
 import { TokenIconBase } from './types';
@@ -47,11 +47,6 @@ export const TokenIcon: React.FC<Props> = ({ spinnerSize, ...props }) => {
     [classNameProp, name, onClick],
   );
 
-  // Prevent infinite loop when the passed onClick not use useCallback.
-  const onClickRef = useRef<
-    MouseEventHandler<SVGElement | HTMLDivElement> | undefined
-  >(onClick);
-
   if (error !== undefined) {
     return <span>{error.message}</span>;
   } else if (loading) {
@@ -70,12 +65,12 @@ export const TokenIcon: React.FC<Props> = ({ spinnerSize, ...props }) => {
     };
 
     return isActive ? (
-      <div className="relative" onClick={onClickRef.current}>
+      <div className="relative">
         {cloneElement(svgElement, props)}
         <span className="inline-block absolute w-1.5 h-1.5 bg-green-50 dark:bg-green-40 rounded-full top-0 right-0" />
       </div>
     ) : (
-      cloneElement(svgElement, { ...props, onClick: onClickRef.current })
+      cloneElement(svgElement, props)
     );
   }
 

--- a/libs/icons/src/useDynamicSVGImport.tsx
+++ b/libs/icons/src/useDynamicSVGImport.tsx
@@ -39,10 +39,15 @@ export function useDynamicSVGImport(
   const currentNameRef = useRef<string>('');
 
   const [importedIcon, setImportedIcon] = useState<
-    React.ReactElement<React.SVGProps<SVGElement>, 'svg'> | undefined
+    | {
+        key: string;
+        svgElement:
+          | React.ReactElement<React.SVGProps<SVGElement>, 'svg'>
+          | undefined;
+        loading: boolean;
+      }
+    | undefined
   >();
-
-  const [loading, setLoading] = useState(true);
 
   const { onCompleted } = options;
 
@@ -50,15 +55,15 @@ export function useDynamicSVGImport(
     typeof name === 'string' ? name.trim().toLowerCase() : 'placeholder';
 
   const type = options.type ?? 'token';
+  const iconKey = `${type}:${normalizedName}`;
 
   useEffect(() => {
-    currentNameRef.current = normalizedName;
-
-    setLoading(true);
+    currentNameRef.current = iconKey;
 
     const importIcon = async (): Promise<void> => {
       // Store the name we're currently processing
       const processingName = normalizedName;
+      const processingKey = iconKey;
 
       try {
         const mod = await getIcon(type, processingName);
@@ -67,12 +72,16 @@ export function useDynamicSVGImport(
         >;
 
         // Only update state if this is still the current name
-        if (processingName === currentNameRef.current) {
-          setImportedIcon(<Icon />);
+        if (processingKey === currentNameRef.current) {
+          setImportedIcon({
+            key: processingKey,
+            svgElement: <Icon />,
+            loading: false,
+          });
           onCompleted?.(processingName, Icon);
         }
       } catch {
-        const isCurrentNameMatch = processingName === currentNameRef.current;
+        const isCurrentNameMatch = processingKey === currentNameRef.current;
 
         // Fallback to default icon
         const DefaultIcon =
@@ -85,24 +94,26 @@ export function useDynamicSVGImport(
               >);
 
         if (isCurrentNameMatch) {
-          setImportedIcon(<DefaultIcon />);
+          setImportedIcon({
+            key: processingKey,
+            svgElement: <DefaultIcon />,
+            loading: false,
+          });
           onCompleted?.(processingName, DefaultIcon);
-        }
-      } finally {
-        if (processingName === currentNameRef.current) {
-          setLoading(false);
         }
       }
     };
 
     importIcon().catch(console.error);
-  }, [normalizedName, onCompleted, type]);
+  }, [iconKey, normalizedName, onCompleted, type]);
+
+  const isCurrentIcon = importedIcon?.key === iconKey;
 
   // Never returns an error since we always fall back to default icon
   return {
     error: undefined as Error | undefined,
-    loading,
-    svgElement: importedIcon,
+    loading: !isCurrentIcon || importedIcon.loading,
+    svgElement: isCurrentIcon ? importedIcon.svgElement : undefined,
   };
 }
 

--- a/libs/tangle-shared-ui/src/components/ConnectWalletButton/WalletDropdown.tsx
+++ b/libs/tangle-shared-ui/src/components/ConnectWalletButton/WalletDropdown.tsx
@@ -70,7 +70,7 @@ const WalletDropdown: FC<WalletDropdownProps> = ({
             variant="body1"
             fw="bold"
             component="p"
-            className="truncate dark:text-mono-0 sr-only sm:not-sr-only"
+            className="max-w-[96px] truncate font-mono text-sm text-inherit"
           >
             {shortenHex(accountAddress)}
           </Typography>

--- a/libs/tangle-shared-ui/src/components/NetworkSelectorDropdown/CustomRpcEndpointInput.tsx
+++ b/libs/tangle-shared-ui/src/components/NetworkSelectorDropdown/CustomRpcEndpointInput.tsx
@@ -1,7 +1,10 @@
 import { Save, SaveWithBg } from '@tangle-network/icons';
 import { Input } from '@tangle-network/ui-components';
-import { FC, useCallback, useEffect, useRef, useState } from 'react';
-import useLocalStorage, { LocalStorageKey } from '../../hooks/useLocalStorage';
+import { FC, useCallback, useState } from 'react';
+import {
+  getJsonFromLocalStorage,
+  LocalStorageKey,
+} from '../../hooks/useLocalStorage';
 
 export type CustomRpcEndpointInputProps = {
   id: string;
@@ -14,33 +17,18 @@ const CustomRpcEndpointInput: FC<CustomRpcEndpointInputProps> = ({
   placeholder,
   setCustomNetwork,
 }) => {
-  const { refresh: getCachedCustomRpcEndpoint } = useLocalStorage(
-    LocalStorageKey.CUSTOM_RPC_ENDPOINT,
-  );
+  const [value, setValue] = useState(() => {
+    if (typeof localStorage === 'undefined') {
+      return '';
+    }
 
-  const [value, setValue] = useState('');
-  const wasValueSetRef = useRef(false);
+    return getJsonFromLocalStorage(LocalStorageKey.CUSTOM_RPC_ENDPOINT) ?? '';
+  });
 
   const handleSave = useCallback(
     () => setCustomNetwork(value),
     [value, setCustomNetwork],
   );
-
-  // On mount, load the cached custom RPC endpoint. If it
-  // exists, set it as the initial value of the input.
-  useEffect(() => {
-    // Don't set the value more than once.
-    if (wasValueSetRef.current) {
-      return;
-    }
-
-    const cachedCustomRpcEndpoint = getCachedCustomRpcEndpoint();
-
-    if (cachedCustomRpcEndpoint.value !== null && value === '') {
-      setValue(cachedCustomRpcEndpoint.value);
-      wasValueSetRef.current = true;
-    }
-  }, [getCachedCustomRpcEndpoint, value]);
 
   const rightIcon =
     value !== '' ? (

--- a/libs/tangle-shared-ui/src/components/NetworkSelectorDropdown/index.tsx
+++ b/libs/tangle-shared-ui/src/components/NetworkSelectorDropdown/index.tsx
@@ -105,14 +105,14 @@ const NetworkSelectionButton: FC<NetworkSelectionButtonProps> = ({
       return false;
     }
     return network.evmChainId !== chainId;
-  }, [isConnected, network?.evmChainId, chainId]);
+  }, [isConnected, network, chainId]);
 
   const switchToCorrectEvmChain = useCallback(() => {
     if (!network?.evmChainId || !switchChain) {
       return;
     }
     switchChain({ chainId: network.evmChainId });
-  }, [network?.evmChainId, switchChain]);
+  }, [network, switchChain]);
 
   return (
     <div className="flex items-center gap-1">

--- a/libs/tangle-shared-ui/src/components/TxConfirmationModal/TxConfirmationModal.tsx
+++ b/libs/tangle-shared-ui/src/components/TxConfirmationModal/TxConfirmationModal.tsx
@@ -314,7 +314,7 @@ const TxConfirmationModal: FC<Props> = ({
     }
 
     return null;
-  }, [tx?.details]);
+  }, [tx]);
 
   // Fetch token metadata for proper amount formatting
   const { data: tokenMetadatas } = useEvmAssetMetadatas(

--- a/libs/tangle-shared-ui/src/data/blueprints/useFakeBlueprintListing.ts
+++ b/libs/tangle-shared-ui/src/data/blueprints/useFakeBlueprintListing.ts
@@ -15,29 +15,38 @@ const generateBlueprints = () => {
   }, new Map<bigint, Blueprint>());
 };
 
+const EMPTY_BLUEPRINTS = new Map<bigint, Blueprint>();
+
 const useFakeBlueprintListing = (delayMs = 3000) => {
-  const [data, setData] = useState<Map<bigint, Blueprint>>(new Map());
-  const [isLoading, setIsLoading] = useState(true);
+  const [state, setState] = useState<{
+    delayMs: number;
+    data: Map<bigint, Blueprint>;
+    isLoading: boolean;
+  }>(() => ({
+    delayMs,
+    data: EMPTY_BLUEPRINTS,
+    isLoading: true,
+  }));
 
   useEffect(() => {
-    setIsLoading(true);
-    setData(new Map());
-
     const timer = setTimeout(() => {
-      setIsLoading(false);
-      setData(generateBlueprints());
+      setState({
+        delayMs,
+        data: generateBlueprints(),
+        isLoading: false,
+      });
     }, delayMs);
 
     return () => {
       clearTimeout(timer);
-      setIsLoading(false);
-      setData(new Map());
     };
   }, [delayMs]);
 
+  const isCurrentRequest = state.delayMs === delayMs;
+
   return {
-    blueprints: data,
-    isLoading,
+    blueprints: isCurrentRequest ? state.data : EMPTY_BLUEPRINTS,
+    isLoading: !isCurrentRequest || state.isLoading,
     error: null satisfies Error | null,
   };
 };

--- a/libs/tangle-shared-ui/src/data/blueprints/useFakeMonitoringBlueprints.ts
+++ b/libs/tangle-shared-ui/src/data/blueprints/useFakeMonitoringBlueprints.ts
@@ -61,30 +61,39 @@ const useFakeMonitoringBlueprints = (
   operatorAccountAddress?: string,
   delayMs = 1000,
 ) => {
-  const [data, setData] = useState<MonitoringBlueprint[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const requestKey = `${operatorAccountAddress ?? ''}:${delayMs}`;
+  const [state, setState] = useState<{
+    requestKey: string;
+    data: MonitoringBlueprint[];
+    isLoading: boolean;
+  }>(() => ({
+    requestKey,
+    data: [],
+    isLoading: Boolean(operatorAccountAddress),
+  }));
 
   useEffect(() => {
     if (!operatorAccountAddress) return;
 
-    setIsLoading(true);
-    setData([]);
-
     const timer = setTimeout(() => {
-      setIsLoading(false);
-      setData(generateBlueprints(operatorAccountAddress));
+      setState({
+        requestKey,
+        data: generateBlueprints(operatorAccountAddress),
+        isLoading: false,
+      });
     }, delayMs);
 
     return () => {
       clearTimeout(timer);
-      setIsLoading(false);
-      setData([]);
     };
-  }, [operatorAccountAddress, delayMs]);
+  }, [operatorAccountAddress, delayMs, requestKey]);
+
+  const isCurrentRequest = state.requestKey === requestKey;
 
   return {
-    blueprints: data,
-    isLoading,
+    blueprints: isCurrentRequest ? state.data : [],
+    isLoading:
+      Boolean(operatorAccountAddress) && (!isCurrentRequest || state.isLoading),
     error: null,
   };
 };

--- a/libs/tangle-shared-ui/src/data/graphql/useBlueprints.ts
+++ b/libs/tangle-shared-ui/src/data/graphql/useBlueprints.ts
@@ -4,7 +4,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { Address } from 'viem';
-import { useAccount, useChainId, usePublicClient } from 'wagmi';
+import { useChainId, usePublicClient } from 'wagmi';
 import {
   executeEnvioGraphQL,
   EnvioNetwork,
@@ -130,11 +130,12 @@ const toAppBlueprint = (bp: BlueprintWithMetadata): AppBlueprint => ({
   blueprintUi: bp.blueprintUi,
 });
 
+const BLUEPRINT_QUERY_CACHE_MS = 30 * 60_000;
+
 const useResolvedEnvioNetwork = (network?: EnvioNetwork) => {
   const chainId = useChainId();
-  const { isConnected } = useAccount();
   const networkChainId = useNetworkStore((store) => store.network2?.evmChainId);
-  const activeChainId = isConnected ? chainId : (networkChainId ?? chainId);
+  const activeChainId = networkChainId ?? chainId;
 
   return {
     activeChainId,
@@ -423,6 +424,8 @@ export const useBlueprints = (options?: {
     },
     enabled,
     staleTime: 60_000,
+    gcTime: BLUEPRINT_QUERY_CACHE_MS,
+    placeholderData: (previous) => previous,
   });
 };
 
@@ -492,6 +495,8 @@ export const useBlueprintsWithMetadata = (options?: {
     },
     enabled,
     staleTime: 300_000,
+    gcTime: BLUEPRINT_QUERY_CACHE_MS,
+    placeholderData: (previous) => previous,
   });
 };
 
@@ -597,6 +602,8 @@ export const useBlueprint = (
     },
     enabled: enabled && !!blueprintId,
     staleTime: 300_000,
+    gcTime: BLUEPRINT_QUERY_CACHE_MS,
+    placeholderData: (previous) => previous,
   });
 };
 
@@ -747,6 +754,8 @@ export const useBlueprintDetails = (
     },
     enabled: enabled && blueprintId !== undefined,
     staleTime: 60_000,
+    gcTime: BLUEPRINT_QUERY_CACHE_MS,
+    placeholderData: (previous) => previous,
   });
 
   return {

--- a/libs/tangle-shared-ui/src/data/staking/useErc20Balances.ts
+++ b/libs/tangle-shared-ui/src/data/staking/useErc20Balances.ts
@@ -1,34 +1,24 @@
 import { EvmAddress } from '@tangle-network/ui-components/types/address';
-import { isEqual } from 'lodash';
-import { useEffect, useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 import { erc20Abi } from 'viem';
 import { useReadContracts } from 'wagmi';
 import useAgnosticAccountInfo from '../../hooks/useAgnosticAccountInfo';
 
 const useErc20Balances = (assetAddressesArg: EvmAddress[]) => {
   const { evmAddress } = useAgnosticAccountInfo();
-  const assetAddressesRef = useRef(assetAddressesArg);
-
-  // Shallow compare the asset addresses.
-  useEffect(() => {
-    if (!isEqual(assetAddressesRef.current, assetAddressesArg)) {
-      assetAddressesRef.current = assetAddressesArg;
-    }
-  }, [assetAddressesArg]);
 
   const contracts = useMemo(() => {
     if (evmAddress === null) {
       return [];
     }
 
-    return assetAddressesRef.current.map((address) => ({
+    return assetAddressesArg.map((address) => ({
       address,
       abi: erc20Abi,
       functionName: 'balanceOf' as const,
       args: [evmAddress] as const,
     }));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [evmAddress, assetAddressesRef.current]);
+  }, [evmAddress, assetAddressesArg]);
 
   const { isLoading, ...rest } = useReadContracts({
     contracts: contracts,

--- a/libs/tangle-shared-ui/src/hooks/useAgnosticTx.ts
+++ b/libs/tangle-shared-ui/src/hooks/useAgnosticTx.ts
@@ -174,11 +174,15 @@ function useAgnosticTx<
     if (nextAgnosticStatus === null) {
       substrateReset();
       evmReset();
-      setAgnosticStatus(TxStatus.NOT_YET_INITIATED);
+      queueMicrotask(() => {
+        setAgnosticStatus(TxStatus.NOT_YET_INITIATED);
+      });
     }
     // Only update the transaction status when it changes.
     else if (nextAgnosticStatus !== agnosticStatus) {
-      setAgnosticStatus(nextAgnosticStatus);
+      queueMicrotask(() => {
+        setAgnosticStatus(nextAgnosticStatus);
+      });
     }
   }, [
     activeAccountAddress,

--- a/libs/tangle-shared-ui/src/hooks/useApi.ts
+++ b/libs/tangle-shared-ui/src/hooks/useApi.ts
@@ -70,7 +70,9 @@ const useApi = <T>(fetcher: ApiFetcher<T>, overrideRpcEndpoint?: string) => {
 
   // Refetch when the API changes or when the fetcher changes.
   useEffect(() => {
-    refetch();
+    queueMicrotask(() => {
+      refetch();
+    });
   }, [refetch]);
 
   return { result, error, refetch };

--- a/libs/tangle-shared-ui/src/hooks/useApiRx.ts
+++ b/libs/tangle-shared-ui/src/hooks/useApiRx.ts
@@ -65,14 +65,16 @@ const useApiRx = <T>(factory: ObservableFactory<T>) => {
       const factoryResult = factory(apiRx);
 
       if (factoryResult instanceof Error) {
-        setError(factoryResult);
-        setLoading(false);
+        queueMicrotask(() => {
+          setError(factoryResult);
+          setLoading(false);
+        });
 
         return;
       }
       // The factory is not yet ready to produce an observable.
       else if (factoryResult === null) {
-        reset();
+        queueMicrotask(reset);
 
         return;
       } else {
@@ -86,8 +88,10 @@ const useApiRx = <T>(factory: ObservableFactory<T>) => {
         newError,
       );
 
-      setError(newError);
-      setLoading(false);
+      queueMicrotask(() => {
+        setError(newError);
+        setLoading(false);
+      });
 
       return;
     }

--- a/libs/tangle-shared-ui/src/hooks/useInputAmount.ts
+++ b/libs/tangle-shared-ui/src/hooks/useInputAmount.ts
@@ -5,7 +5,7 @@ import {
   AmountFormatStyle,
   FormatOptions,
 } from '@tangle-network/ui-components';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import cleanNumericInputString from '../utils/cleanNumericInputString';
 import parseChainUnits, {
@@ -86,9 +86,18 @@ const useInputAmount = ({
 }: Options) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const [displayAmount, setDisplayAmount] = useState(
-    amount !== null ? formatBn(amount, decimals, INPUT_AMOUNT_FORMAT) : '',
-  );
+  const [displayState, setDisplayState] = useState(() => ({
+    amount,
+    decimals,
+    displayAmount:
+      amount !== null ? formatBn(amount, decimals, INPUT_AMOUNT_FORMAT) : '',
+  }));
+  const displayAmount =
+    displayState.amount === amount && displayState.decimals === decimals
+      ? displayState.displayAmount
+      : amount !== null
+        ? formatBn(amount, decimals, INPUT_AMOUNT_FORMAT)
+        : '';
 
   const handleChange = useCallback(
     (newAmountString: string) => {
@@ -99,7 +108,11 @@ const useInputAmount = ({
         return;
       }
 
-      setDisplayAmount(cleanAmountString);
+      setDisplayState({
+        amount,
+        decimals,
+        displayAmount: cleanAmountString,
+      });
 
       const amountOrError = safeParseInputAmount({
         amountString: cleanAmountString,
@@ -130,30 +143,24 @@ const useInputAmount = ({
       maxErrorMessage,
       min,
       minErrorMessage,
+      amount,
       setAmount,
     ],
   );
 
   const setDisplayAmount_ = useCallback(
     (amount: BN) => {
-      setDisplayAmount(
-        formatBn(amount, decimals, {
+      setDisplayState({
+        amount,
+        decimals,
+        displayAmount: formatBn(amount, decimals, {
           ...INPUT_AMOUNT_FORMAT,
           includeCommas: false,
         }),
-      );
+      });
     },
     [decimals],
   );
-
-  useEffect(() => {
-    // If the amount is null, then the display amount should always be empty.
-    // This handle the case where the amount is set to null after submitting a tx
-    // but the display amount is not updated
-    if (!amount) {
-      setDisplayAmount('');
-    }
-  }, [amount]);
 
   const trySetAmount = useCallback(
     (newAmount: BN): boolean => {

--- a/libs/tangle-shared-ui/src/hooks/useLocalStorage.ts
+++ b/libs/tangle-shared-ui/src/hooks/useLocalStorage.ts
@@ -107,7 +107,7 @@ const useLocalStorage = <Key extends LocalStorageKey>(key: Key) => {
 
   // Extract the value from local storage on mount.
   useEffect(() => {
-    refresh();
+    queueMicrotask(refresh);
   }, [refresh]);
 
   // Listen for changes to local storage. This is useful in case

--- a/libs/tangle-shared-ui/src/hooks/useViemPublicClient.ts
+++ b/libs/tangle-shared-ui/src/hooks/useViemPublicClient.ts
@@ -1,27 +1,21 @@
-import { useEffect, useState } from 'react';
-import { createPublicClient, http, type PublicClient } from 'viem';
+import { useMemo } from 'react';
+import { createPublicClient, http } from 'viem';
 
 import useEvmChain from './useEvmChain';
 
 const useViemPublicClient = () => {
-  const [publicClient, setPublicClient] = useState<PublicClient | null>(null);
   const evmChain = useEvmChain();
 
-  // Update the public client when the network changes.
-  useEffect(() => {
+  return useMemo(() => {
     if (evmChain === null) {
-      return;
+      return null;
     }
 
-    const newPublicClient = createPublicClient({
+    return createPublicClient({
       chain: evmChain,
       transport: http(),
     });
-
-    setPublicClient(newPublicClient);
   }, [evmChain]);
-
-  return publicClient;
 };
 
 export default useViemPublicClient;

--- a/libs/tangle-shared-ui/src/hooks/useViemWalletClient.ts
+++ b/libs/tangle-shared-ui/src/hooks/useViemWalletClient.ts
@@ -1,13 +1,12 @@
 import useNetworkStore from '../context/useNetworkStore';
 import useEvmChain from './useEvmChain';
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 import {
   createWalletClient,
   custom,
   EIP1193Provider,
   http,
   Transport,
-  WalletClient,
 } from 'viem';
 
 export enum WalletClientTransport {
@@ -30,14 +29,12 @@ export enum WalletClientTransport {
 }
 
 const useViemWalletClient = (transport = WalletClientTransport.HTTP_RPC) => {
-  const [walletClient, setWalletClient] = useState<WalletClient | null>(null);
   const network = useNetworkStore((store) => store.network2);
   const evmChain = useEvmChain();
 
-  // Update the wallet client when the network changes.
-  useEffect(() => {
+  return useMemo(() => {
     if (evmChain === null || network?.httpRpcEndpoints === undefined) {
-      return;
+      return null;
     }
 
     let transport_: Transport;
@@ -48,13 +45,17 @@ const useViemWalletClient = (transport = WalletClientTransport.HTTP_RPC) => {
 
         break;
       case WalletClientTransport.WINDOW: {
+        if (typeof window === 'undefined') {
+          return null;
+        }
+
         const ethereumProvider = window.ethereum as EIP1193Provider | undefined;
         if (ethereumProvider === undefined) {
           console.warn(
             'Could not create Viem wallet client due to Ethereum provider not found on window object.',
           );
 
-          return;
+          return null;
         }
 
         transport_ = custom(ethereumProvider);
@@ -63,15 +64,11 @@ const useViemWalletClient = (transport = WalletClientTransport.HTTP_RPC) => {
       }
     }
 
-    const newWalletClient = createWalletClient({
+    return createWalletClient({
       chain: evmChain,
       transport: transport_,
     });
-
-    setWalletClient(newWalletClient);
   }, [evmChain, network, transport]);
-
-  return walletClient;
 };
 
 export default useViemWalletClient;

--- a/libs/ui-components/src/components/FileUploads/FileUploadField.tsx
+++ b/libs/ui-components/src/components/FileUploads/FileUploadField.tsx
@@ -2,7 +2,7 @@
 
 import { InformationLine } from '@tangle-network/icons';
 import cx from 'classnames';
-import { FC, useCallback, useEffect, useState } from 'react';
+import { FC, useCallback, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 import { Typography } from '../../typography/Typography';
 import { Button } from '../buttons';
@@ -14,24 +14,23 @@ export const FileUploadField: FC<FileUploadFieldProps> = ({
   onUpload,
   value,
 }) => {
-  // State for the note value
-  const [note, setNote] = useState(value);
+  const [noteState, setNoteState] = useState(() => ({
+    propValue: value,
+    note: value,
+  }));
+  const note = noteState.propValue === value ? noteState.note : value;
 
   // State for uploading note
   const [isUploading, setIsUploading] = useState(false);
 
-  useEffect(() => {
-    setNote(value);
-  }, [value]);
-
   // Handle change event
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      const { value } = e.target;
-      setNote(value);
-      onChange?.(value);
+      const nextValue = e.target.value;
+      setNoteState({ propValue: value, note: nextValue });
+      onChange?.(nextValue);
     },
-    [onChange],
+    [onChange, value],
   );
 
   // Handle upload event

--- a/libs/ui-components/src/components/ListCard/TokenListItem.tsx
+++ b/libs/ui-components/src/components/ListCard/TokenListItem.tsx
@@ -7,7 +7,13 @@ import {
   ShieldedAssetIcon,
   TokenIcon,
 } from '@tangle-network/icons';
-import { ComponentProps, forwardRef, useMemo, useRef } from 'react';
+import {
+  ComponentProps,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
 import { PropsOf } from '../../types';
 import { Typography } from '../../typography';
 import { getRoundedAmountString } from '../../utils';
@@ -135,15 +141,17 @@ const TokenListItem = forwardRef<
     ref,
   ) => {
     const onAddTokenRef = useRef(onAddToken);
+    useEffect(() => {
+      onAddTokenRef.current = onAddToken;
+    }, [onAddToken]);
 
-    const handleTokenIconClick = useMemo(() => {
-      if (typeof onAddTokenRef.current === 'function') {
-        return (event: React.MouseEvent<HTMLButtonElement>) => {
-          event.stopPropagation();
-          onAddTokenRef.current?.(event);
-        };
-      }
-    }, []);
+    const handleTokenIconClick = useCallback(
+      (event: React.MouseEvent<HTMLButtonElement>) => {
+        event.stopPropagation();
+        onAddTokenRef.current?.(event);
+      },
+      [],
+    );
 
     return (
       <ListItem {...props} isDisabled={isDisabled} ref={ref}>
@@ -190,7 +198,7 @@ const TokenListItem = forwardRef<
           </p>
         </div>
 
-        {typeof handleTokenIconClick === 'function' && !isDisabled ? (
+        {typeof onAddToken === 'function' && !isDisabled ? (
           <AddToWalletButton onClick={handleTokenIconClick} />
         ) : isLoadingMetadata ? (
           <SkeletonLoader size="lg" className="w-14" />

--- a/libs/ui-components/src/components/Notification/NotificationProvider.tsx
+++ b/libs/ui-components/src/components/Notification/NotificationProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { SnackbarProvider } from 'notistack';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { NotificationItem } from './NotificationItem';
 import { NotificationStacked } from './NotificationStacked';
@@ -10,11 +10,11 @@ export const NotificationProvider: React.FC<{
   children?: React.ReactNode;
   maxStack?: number;
 }> = ({ children, maxStack = 3 }) => {
-  const [domRoot, setDomRoot] = useState<HTMLElement | undefined>(undefined);
-
-  useEffect(() => {
-    setDomRoot(document?.getElementById('notification-root') ?? undefined);
-  }, []);
+  const [domRoot] = useState<HTMLElement | undefined>(() =>
+    typeof document === 'undefined'
+      ? undefined
+      : (document.getElementById('notification-root') ?? undefined),
+  );
 
   return (
     <SnackbarProvider

--- a/libs/ui-components/src/components/SideBar/Item.tsx
+++ b/libs/ui-components/src/components/SideBar/Item.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { ArrowRightUp, ChevronDown, ChevronUp } from '@tangle-network/icons';
-import { FC, useEffect, useState } from 'react';
+import { FC, useMemo, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 
+import { useClientReady } from '../../hooks/useClientReady';
 import { Typography } from '../../typography/Typography';
 import isSideBarItemActive from '../../utils/isSideBarItemActive';
 import { Link } from '../Link';
@@ -27,34 +28,42 @@ const SideBarItem: FC<SideBarItemProps & SideBarExtraItemProps> = ({
   onClick,
   info,
 }) => {
-  const [isMounted, setIsMounted] = useState(false);
-  const [isDropdownOpen, setIsDropdownOpen] = useState(Boolean(isActive));
-  const [activeSubItem, setActiveSubItem] = useState<number>(() => {
-    const activeSubItemIndex = subItems.findIndex((subItem) =>
-      isSideBarItemActive(subItem.href, pathnameOrHash),
-    );
+  const isMounted = useClientReady();
+  const activeSubItemKey = useMemo(
+    () => `${pathnameOrHash}:${subItems.map(({ href }) => href).join('|')}`,
+    [pathnameOrHash, subItems],
+  );
+  const routeActiveSubItem = useMemo(
+    () =>
+      subItems.findIndex((subItem) =>
+        isSideBarItemActive(subItem.href, pathnameOrHash),
+      ),
+    [pathnameOrHash, subItems],
+  );
+  const [activeSubItemOverride, setActiveSubItemOverride] = useState<{
+    key: string;
+    index: number;
+  } | null>(null);
+  const activeSubItem =
+    activeSubItemOverride?.key === activeSubItemKey
+      ? activeSubItemOverride.index
+      : routeActiveSubItem;
+  const [dropdownState, setDropdownState] = useState(() => ({
+    isActive,
+    isOpen: Boolean(isActive),
+  }));
+  const isDropdownOpen =
+    dropdownState.isActive === isActive
+      ? dropdownState.isOpen
+      : Boolean(isActive);
 
-    return activeSubItemIndex;
-  });
+  const openDropdown = (isOpen: boolean) => {
+    setDropdownState({ isActive, isOpen });
+  };
 
-  useEffect(() => {
-    const idx = subItems.findIndex((subItem) =>
-      isSideBarItemActive(subItem.href, pathnameOrHash),
-    );
-
-    setActiveSubItem(idx);
-  }, [pathnameOrHash, subItems]);
-
-  // handle mounting to tackle `className` did not match between server and client
-  useEffect(() => {
-    setIsMounted(true);
-  }, [setIsMounted]);
-
-  useEffect(() => {
-    if (isActive) {
-      setIsDropdownOpen(true);
-    }
-  }, [isActive]);
+  const setSubItemActive = (index: number) => {
+    setActiveSubItemOverride({ key: activeSubItemKey, index });
+  };
 
   const setItemAsActiveAndToggleDropdown = () => {
     if (isDisabled) {
@@ -66,7 +75,7 @@ const SideBarItem: FC<SideBarItemProps & SideBarExtraItemProps> = ({
     }
 
     if (subItems.length > 0) {
-      setIsDropdownOpen(!isDropdownOpen);
+      openDropdown(!isDropdownOpen);
     }
   };
 
@@ -137,7 +146,7 @@ const SideBarItem: FC<SideBarItemProps & SideBarExtraItemProps> = ({
               {...subItemProps}
               isActive={activeSubItem === index && isActive}
               setItemIsActive={setIsActive}
-              setSubItemIsActive={() => setActiveSubItem(index)}
+              setSubItemIsActive={() => setSubItemActive(index)}
             />
           ))}
         </ul>

--- a/libs/ui-components/src/components/SideBar/SideBarItems.tsx
+++ b/libs/ui-components/src/components/SideBar/SideBarItems.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type FC, useEffect } from 'react';
+import { useMemo, useState, type FC } from 'react';
 import { twMerge } from 'tailwind-merge';
 import isSideBarItemActive from '../../utils/isSideBarItemActive';
 
@@ -15,37 +15,43 @@ export const SideBarItems: FC<SideBarItemsProps> = ({
   ActionButton,
   onItemClick,
 }) => {
-  const [activeItem, setActiveItem] = useState<number>(() => {
-    const activeItemIndex = items.findIndex((item) => {
-      const isActive =
-        item.subItems.length === 0
-          ? isSideBarItemActive(item.href, pathnameOrHash)
-          : isSideBarItemActive(
-              item.subItems.map((i) => i.href),
-              pathnameOrHash,
-            );
+  const activeItemKey = useMemo(
+    () =>
+      `${pathnameOrHash}:${items
+        .map(
+          (item) =>
+            `${item.href}:${item.subItems.map((i) => i.href).join(',')}`,
+        )
+        .join('|')}`,
+    [items, pathnameOrHash],
+  );
+  const routeActiveItem = useMemo(
+    () =>
+      items.findIndex((item) => {
+        const isActive =
+          item.subItems.length === 0
+            ? isSideBarItemActive(item.href, pathnameOrHash)
+            : isSideBarItemActive(
+                item.subItems.map((i) => i.href),
+                pathnameOrHash,
+              );
 
-      return isActive;
-    });
+        return isActive;
+      }),
+    [items, pathnameOrHash],
+  );
+  const [activeItemOverride, setActiveItemOverride] = useState<{
+    key: string;
+    index: number;
+  } | null>(null);
+  const activeItem =
+    activeItemOverride?.key === activeItemKey
+      ? activeItemOverride.index
+      : routeActiveItem;
 
-    return activeItemIndex;
-  });
-
-  useEffect(() => {
-    const idx = items.findIndex((item) => {
-      const isActive =
-        item.subItems.length === 0
-          ? isSideBarItemActive(item.href, pathnameOrHash)
-          : isSideBarItemActive(
-              item.subItems.map((i) => i.href),
-              pathnameOrHash,
-            );
-
-      return isActive;
-    });
-
-    setActiveItem(idx);
-  }, [items, pathnameOrHash]);
+  const setItemActive = (index: number) => {
+    setActiveItemOverride({ key: activeItemKey, index });
+  };
 
   return (
     <div className={twMerge('flex flex-col gap-2', className)}>
@@ -59,7 +65,7 @@ export const SideBarItems: FC<SideBarItemsProps> = ({
             {...itemProps}
             isExpanded={isExpanded}
             isActive={activeItem === idx}
-            setIsActive={() => setActiveItem(idx)}
+            setIsActive={() => setItemActive(idx)}
             onClick={onItemClick}
           />
         );

--- a/libs/ui-components/src/components/SlidingNumber/SlidingNumber.tsx
+++ b/libs/ui-components/src/components/SlidingNumber/SlidingNumber.tsx
@@ -7,6 +7,7 @@ import {
   useImperativeHandle,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 import useMeasure from 'react-use-measure';
 import { twMerge } from 'tailwind-merge';
@@ -98,7 +99,7 @@ const SlidingNumber = forwardRef<HTMLSpanElement, SlidingNumberProps>(
       return viewRef.current;
     });
 
-    const prevNumberRef = useRef<number>(0);
+    const [prevNumber, setPrevNumber] = useState(0);
 
     const effectiveNumber = useMemo(
       () => (startOnView && !inView ? 0 : Math.abs(Number(number))),
@@ -111,7 +112,7 @@ const SlidingNumber = forwardRef<HTMLSpanElement, SlidingNumberProps>(
     newIntStr =
       padStart && newIntStr.length === 1 ? '0' + newIntStr : newIntStr;
 
-    const prevStr = prevNumberRef.current.toString();
+    const prevStr = prevNumber.toString();
     let [prevIntStr = ''] = prevStr.split('.');
     const [, prevDecStr = ''] = prevStr.split('.');
     prevIntStr =
@@ -132,7 +133,18 @@ const SlidingNumber = forwardRef<HTMLSpanElement, SlidingNumberProps>(
 
     useEffect(() => {
       if (!startOnView || inView) {
-        prevNumberRef.current = effectiveNumber;
+        let cancelled = false;
+        queueMicrotask(() => {
+          if (!cancelled) {
+            setPrevNumber((current) =>
+              current === effectiveNumber ? current : effectiveNumber,
+            );
+          }
+        });
+
+        return () => {
+          cancelled = true;
+        };
       }
     }, [effectiveNumber, inView, startOnView]);
 

--- a/libs/ui-components/src/components/SocialChip/SocialChip.tsx
+++ b/libs/ui-components/src/components/SocialChip/SocialChip.tsx
@@ -24,8 +24,6 @@ const SocialChip: FC<SocialChipProps> = ({
   className,
   ...restProps
 }) => {
-  const Icon = getIconBySocialType(type);
-
   return (
     <a target="_blank" rel="noopener noreferrer" href={href}>
       <Chip
@@ -38,25 +36,33 @@ const SocialChip: FC<SocialChipProps> = ({
           className,
         )}
       >
-        <Icon className="fill-mono-200 dark:fill-mono-0" size="md" />
+        <SocialIcon type={type} />
       </Chip>
     </a>
   );
 };
 
-export default SocialChip;
-
-function getIconBySocialType(type: SocialType) {
+const SocialIcon: FC<{ type: SocialType }> = ({ type }) => {
   switch (type) {
     case 'discord':
-      return DiscordFill;
+      return (
+        <DiscordFill className="fill-mono-200 dark:fill-mono-0" size="md" />
+      );
     case 'github':
-      return GithubFill;
+      return (
+        <GithubFill className="fill-mono-200 dark:fill-mono-0" size="md" />
+      );
     case 'twitter':
-      return TwitterFill;
+      return (
+        <TwitterFill className="fill-mono-200 dark:fill-mono-0" size="md" />
+      );
     case 'website':
-      return GlobalLine;
+      return (
+        <GlobalLine className="fill-mono-200 dark:fill-mono-0" size="md" />
+      );
     case 'email':
-      return Mail;
+      return <Mail className="fill-mono-200 dark:fill-mono-0" size="md" />;
   }
-}
+};
+
+export default SocialChip;

--- a/libs/ui-components/src/components/TangleLogo/TangleLogo.tsx
+++ b/libs/ui-components/src/components/TangleLogo/TangleLogo.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { createIcon } from '@tangle-network/icons/create-icon';
-import { useMemo, useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { randNumber } from '@ngneat/falso';
 
+import { useClientReady } from '../../hooks/useClientReady';
 import { TangleLogoProps } from './types';
 
 const defaultTangleLogoSize = {
@@ -15,7 +16,7 @@ const defaultTangleLogoSize = {
 const TangleLogo: React.FC<TangleLogoProps> = (props) => {
   const { darkMode, size = 'md', ...restProps } = props;
 
-  const [isMounted, setIsMounted] = useState(false);
+  const isMounted = useClientReady();
 
   const { height, width } = useMemo(() => {
     switch (size) {
@@ -48,12 +49,7 @@ const TangleLogo: React.FC<TangleLogoProps> = (props) => {
 
   // non-unique ids problem with svg: https://stackoverflow.com/a/55846525
   // create id for each svg items in case there are multiple logos appear at the same time in html
-  const paintId = useMemo(() => randNumber().toString(), []);
-
-  // prevent hydration mismatch with paintId
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
+  const [paintId] = useState(() => randNumber().toString());
 
   if (!isMounted) {
     return null;

--- a/libs/ui-components/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/libs/ui-components/src/components/ThemeToggle/ThemeToggle.tsx
@@ -2,7 +2,8 @@
 
 import { MoonLine, SunLine } from '@tangle-network/icons';
 import cx from 'classnames';
-import { FC, useEffect, useState } from 'react';
+import { FC } from 'react';
+import { useClientReady } from '../../hooks/useClientReady';
 import { useDarkMode } from '../../hooks/useDarkMode';
 
 import { ThemeToggleProps } from './types';
@@ -17,13 +18,8 @@ import { ThemeToggleProps } from './types';
  */
 
 export const ThemeToggle: FC<ThemeToggleProps> = () => {
-  const [isMounted, setIsMounted] = useState(false);
+  const isMounted = useClientReady();
   const [isDarkMode, toggleThemeMode] = useDarkMode();
-
-  // useEffect only runs on the client, so now we can safely show the UI
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
 
   if (!isMounted) {
     return null;

--- a/libs/ui-components/src/components/TxProgressor/TxProgressor.tsx
+++ b/libs/ui-components/src/components/TxProgressor/TxProgressor.tsx
@@ -9,7 +9,7 @@ import {
   TokenIcon,
 } from '@tangle-network/icons';
 import { Decimal } from 'decimal.js';
-import { forwardRef } from 'react';
+import { forwardRef, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 import useTimeAgo from '../../hooks/useTimeAgo';
 import { PropsOf } from '../../types';
@@ -67,8 +67,9 @@ const getChipColor = (
 const TxProgressorHeader = forwardRef<
   React.ElementRef<'div'>,
   TxProgressorHeaderProps
->(({ className, children, name, createdAt = Date.now(), ...props }, ref) => {
-  const timeAgo = useTimeAgo({ date: createdAt });
+>(({ className, children, name, createdAt, ...props }, ref) => {
+  const [fallbackCreatedAt] = useState(() => Date.now());
+  const timeAgo = useTimeAgo({ date: createdAt ?? fallbackCreatedAt });
 
   return (
     <div

--- a/libs/ui-components/src/hooks/index.ts
+++ b/libs/ui-components/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { default as useBreakpointValue } from './useBreakpointValue';
+export * from './useClientReady';
 export * from './useCopyable';
 export * from './useDarkMode';
 export * from './useHiddenValue';

--- a/libs/ui-components/src/hooks/useClientReady.ts
+++ b/libs/ui-components/src/hooks/useClientReady.ts
@@ -1,0 +1,11 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+const subscribe = () => () => undefined;
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+export function useClientReady() {
+  return useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot);
+}

--- a/libs/ui-components/src/hooks/useCopyable.ts
+++ b/libs/ui-components/src/hooks/useCopyable.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import copyToClipboard from 'copy-to-clipboard';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 
 export type UseCopyableReturnType = {
   /**
@@ -22,8 +22,8 @@ export type UseCopyableReturnType = {
  * @param display The display time to reset time copy state in milliseconds (default 3000)
  */
 export const useCopyable = (display = 3000): UseCopyableReturnType => {
-  const ref = useRef<string>('');
   const [isCopied, setIsCopied] = useState(false);
+  const [copiedText, setCopiedText] = useState<string>();
   const timeoutRef_ = useRef<ReturnType<typeof setTimeout>>();
 
   const copy = (value: string) => {
@@ -31,7 +31,7 @@ export const useCopyable = (display = 3000): UseCopyableReturnType => {
       return;
     }
 
-    ref.current = value;
+    setCopiedText(value);
     copyToClipboard(value);
     setIsCopied(true);
 
@@ -52,6 +52,6 @@ export const useCopyable = (display = 3000): UseCopyableReturnType => {
   return {
     isCopied,
     copy,
-    copiedText: ref.current,
+    copiedText,
   };
 };

--- a/libs/ui-components/src/hooks/useMemorizedValue.ts
+++ b/libs/ui-components/src/hooks/useMemorizedValue.ts
@@ -22,13 +22,22 @@ export const useMemorizedValue = <T>(value: T): T => {
   const [memorizedValue, setMemorizedValue] = useState<T>(value);
 
   useEffect(() => {
-    setMemorizedValue((prev) => {
-      if (isEqual(prev, value)) {
-        return prev;
-      }
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
 
-      return value;
+      setMemorizedValue((prev) => {
+        if (isEqual(prev, value)) {
+          return prev;
+        }
+
+        return value;
+      });
     });
+
+    return () => {
+      cancelled = true;
+    };
   }, [value]);
 
   return memorizedValue;

--- a/libs/ui-components/src/hooks/useTimeAgo.ts
+++ b/libs/ui-components/src/hooks/useTimeAgo.ts
@@ -9,6 +9,7 @@ const DAY = HOUR * 24;
 const WEEK = DAY * 7;
 const MONTH = DAY * 30;
 const YEAR = DAY * 365;
+const defaultNow = Date.now;
 
 function dateParser(date: string | number | Date): Date {
   const parsed = new Date(date);
@@ -92,11 +93,11 @@ const useTimeAgo = (opts: TimeAgoOptions) => {
     live = true,
     maxPeriod = WEEK,
     minPeriod = 0,
-    now = () => Date.now(),
+    now = defaultNow,
     formatter = defaultFormatter,
   } = opts;
 
-  const [timeNow, setTimeNow] = useState(now());
+  const [timeNow, setTimeNow] = useState(() => now());
 
   useEffect(() => {
     const tick = (): 0 | NodeJS.Timeout => {

--- a/libs/ui-components/src/hooks/useWagmiHydration.ts
+++ b/libs/ui-components/src/hooks/useWagmiHydration.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 import { useConfig } from 'wagmi';
 import 'zustand/middleware';
 import type { Mutate, StoreApi } from 'zustand/vanilla';
@@ -14,29 +14,24 @@ import type { Mutate, StoreApi } from 'zustand/vanilla';
  * @see https://docs.pmnd.rs/zustand/integrations/persisting-store-data#how-can-i-check-if-my-store-has-been-hydrated
  */
 export default function useWagmiHydration() {
-  const [hydrated, setHydrated] = useState(false);
-
   const wagmiConfig = useConfig();
+  const store: Mutate<
+    StoreApi<unknown>,
+    [['zustand/persist', unknown]]
+  > = wagmiConfig._internal.store;
 
-  useEffect(() => {
-    const store: Mutate<
-      StoreApi<unknown>,
-      [['zustand/persist', unknown]]
-    > = wagmiConfig._internal.store;
+  return useSyncExternalStore(
+    (onStoreChange) => {
+      const unsubHydrate = store.persist.onHydrate(onStoreChange);
+      const unsubFinishHydration =
+        store.persist.onFinishHydration(onStoreChange);
 
-    const unsubHydrate = store.persist.onHydrate(() => setHydrated(false));
-
-    const unsubFinishHydration = store.persist.onFinishHydration(() =>
-      setHydrated(true),
-    );
-
-    setHydrated(store.persist.hasHydrated());
-
-    return () => {
-      unsubHydrate();
-      unsubFinishHydration();
-    };
-  }, [wagmiConfig._internal.store]);
-
-  return hydrated;
+      return () => {
+        unsubHydrate();
+        unsubFinishHydration();
+      };
+    },
+    () => store.persist.hasHydrated(),
+    () => false,
+  );
 }

--- a/libs/web3-api-provider/src/ext-provider/web3-accounts.ts
+++ b/libs/web3-api-provider/src/ext-provider/web3-accounts.ts
@@ -5,8 +5,8 @@ import {
   Account,
   AccountsAdapter,
   type PromiseOrT,
-} from '@tangle-network/abstract-api-provider/account';
-import getWagmiConfig from '@tangle-network/dapp-config/wagmi-config';
+} from '@tangle-network/abstract-api-provider';
+import { getWagmiConfig } from '@tangle-network/dapp-config';
 import type { Address, JsonRpcAccount } from 'viem';
 import type { Connector } from 'wagmi';
 import { getAccount } from 'wagmi/actions';

--- a/libs/web3-api-provider/src/webb-provider.ts
+++ b/libs/web3-api-provider/src/webb-provider.ts
@@ -5,14 +5,14 @@ import {
   WebbApiProvider,
   WebbProviderEvents,
 } from '@tangle-network/abstract-api-provider';
-import { ApiConfig } from '@tangle-network/dapp-config';
-import getWagmiConfig from '@tangle-network/dapp-config/wagmi-config';
-import { WebbError, WebbErrorCodes } from '@tangle-network/dapp-types';
-import { EventBus } from '@tangle-network/dapp-types/EventBus';
 import {
   ChainType,
+  EventBus,
+  WebbError,
+  WebbErrorCodes,
   calculateTypedChainId,
-} from '@tangle-network/dapp-types/TypedChainId';
+} from '@tangle-network/dapp-types';
+import { ApiConfig, getWagmiConfig } from '@tangle-network/dapp-config';
 import assert from 'assert';
 import values from 'lodash/values';
 import { BehaviorSubject } from 'rxjs';


### PR DESCRIPTION
Summary:
- Adds canonical Tangle Cloud status/money primitives and shared surfaces for status pills, copyable IDs, money rendering, and data tables.
- Updates blueprint catalog, operator directory, service details, and job history flows to use URL-state views, canonical status tones, and lossless bigint/money formatting.
- Clears the repo pre-push React Compiler lint baseline and fixes provider/config package boundaries so the full workspace build resolves internal packages through root exports instead of fragile subpath imports.

Validation:
- yarn concurrently "yarn run lint" "yarn run format:check"
- yarn run test
- yarn run build
- npx nx run-many -t typecheck -p icons,ui-components,tangle-dapp,tangle-cloud
- npx nx build tangle-cloud
- npx nx build tangle-dapp
- git merge-tree --write-tree origin/master HEAD
- Local Playwright smoke on /blueprints, /operators, /services/1 with no unexpected console errors and no horizontal overflow

Notes:
- Lint still reports existing warning-only React Compiler skips for TanStack Table / React Hook Form and the existing no-script-url warning in authoring.spec.ts.
- Build still reports existing large chunk and Rollup annotation warnings.