### PR TITLE
feat(tangle-cloud): restore Tangle dapp design system

### DIFF
--- a/.evolve/tangle-cloud-design-audit-2026-06-08.md
+++ b/.evolve/tangle-cloud-design-audit-2026-06-08.md
@@ -1,0 +1,57 @@
+# Tangle Cloud Design Audit - 2026-06-08
+
+Status: implemented and browser verified on `feat/tangle-cloud-tangle-dapp-system`.
+
+## Verdict
+
+The Blueprints page moved from glass-on-glass catalog cards to a list-first infrastructure console that matches the original Tangle dapp's operational hierarchy while keeping Cloud-specific density. The remaining surface is not a marketing hero; it is a service catalog for deployers, operators, and publishers.
+
+## Problems Addressed
+
+- Duplicate Blueprints title in top nav and page header.
+- Separate nav/title layer doing no unique work.
+- Blueprints catalog readability at roughly 6/10: same-background cards, weak hierarchy, small labels, hidden wallet address, italic controls, and decorative button dots.
+- Missing default blueprint visual identity for chain-only blueprints.
+- Local preview defaulting to Anvil and firing localhost RPC/indexer calls while the UI showed Base Sepolia.
+- Blueprint data refetching felt uncached after leaving and returning to the page.
+- Add-capacity/register flow could look blank or broken.
+
+## Product Direction
+
+- Use the original Tangle dapp design system selectively: wallet/network affordances, compact chrome, crisp borders, action hierarchy, and restrained Tangle color accents.
+- Keep Cloud as an infrastructure console: list/table first, cards only for repeated catalog/mobile/modals, no hero marketing treatment.
+- Make Blueprints read like inventory: capacity, trust, source, usage, and actions are first-order columns.
+
+## Changes Shipped
+
+- Removed the `/blueprints` top-nav breadcrumb title and let the page own the large `Blueprints` heading.
+- Kept wallet connection visible in the top-right shell and made the connected-address affordance visible.
+- Forced network/action controls to normal font style and removed button pseudo-dot artifacts.
+- Added default blueprint visuals for chain-only catalog rows/cards.
+- Added list-first catalog layout with metrics, availability filters, category/filter controls, grid/list toggle, pagination, and mobile cards.
+- Added React Query stale/cache behavior for blueprint queries.
+- Normalized Cloud's local-preview network to Base Sepolia unless `VITE_FORCE_LOCAL_CHAIN=true`.
+- Moved network normalization before indexer health checks and aligned audited-status reads with the selected Cloud network.
+- Made the local sandbox `Button` wrapper forward refs for Radix `asChild` compatibility.
+- Tightened the add-capacity drawer into a true right-side panel.
+- Stubbed `window.scrollTo` in shared Vitest setup to remove noisy route-test output.
+
+## Verification
+
+- `NX_DAEMON=false NX_SKIP_NX_CACHE=true yarn nx typecheck tangle-cloud`
+- `NX_DAEMON=false NX_SKIP_NX_CACHE=true yarn nx test tangle-cloud`
+- `NX_DAEMON=false NX_SKIP_NX_CACHE=true yarn nx build tangle-cloud`
+- Playwright screenshots and console checks:
+  - `/tmp/tangle-cloud-dapp-system-audit/blueprints-desktop-dark.png`
+  - `/tmp/tangle-cloud-dapp-system-audit/blueprints-desktop-light.png`
+  - `/tmp/tangle-cloud-dapp-system-audit/blueprints-mobile-dark.png`
+  - `/tmp/tangle-cloud-dapp-system-audit/instances-desktop-dark.png`
+  - `/tmp/tangle-cloud-dapp-system-audit/blueprints-add-capacity-flow.png`
+
+Final browser counters:
+
+- `local8545`: 0
+- `local8080`: 0
+- Radix ref warnings: 0
+- italic controls: 0
+- measured overflow: 0

--- a/apps/tangle-cloud/PRODUCT_BRIEF.md
+++ b/apps/tangle-cloud/PRODUCT_BRIEF.md
@@ -28,7 +28,7 @@ Primary actions: Connect wallet, switch network, create service, register operat
 
 Trust, risk, and compliance: Money, permissions, and protocol identity must be exact, copyable, and auditable. Destructive or irreversible actions need clear state, provenance, and confirmation. Embedded apps must expose origin, permissions, denied actions, and unavailable bridge methods. Empty/error/loading states must be truthful and actionable.
 
-Design posture: Dense infrastructure console with restrained blueprint identity accents. Use compact tables, split workspaces, tabs, ledgers, event timelines, thin borders, and low-chroma status colors. Cards belong mainly to catalog discovery, repeated items, and modals.
+Design posture: Dense infrastructure console with restrained blueprint identity accents. Use compact tables, split workspaces, tabs, ledgers, event timelines, thin borders, and low-chroma status colors. Cards belong mainly to catalog discovery, repeated items, and modals. Cloud should inherit the original Tangle dapp's wallet, network, chrome, and action hierarchy where it improves operator trust, but keep Cloud pages data-first rather than marketing-first.
 
 Non-goals: Do not reskin this as the AI trading app. Do not make a marketing landing page, decorative hero wall, app-store gallery, or purple/glow-heavy SaaS dashboard. Do not duplicate sidebar, topbar, breadcrumbs, page headers, tabs, and local nav unless each layer has a distinct job.
 
@@ -39,6 +39,7 @@ Evidence:
 - `src/pages/services/[id]/page.tsx` mixes service console, blueprint presentation, ACL, jobs, billing, and upgrade surfaces in one vertical stack.
 - `src/pages/blueprints/[id]/deploy/page.tsx` submits a request but sends users back to blueprint detail instead of request/service status.
 - Parallel audit reports on 2026-06-05 converged on app/workspace-first IA and infrastructure-console visual direction.
+- 2026-06-08 design-system pass restored Tangle dapp-style wallet/network affordances, removed the duplicate Blueprints nav title, converted the catalog to a list-first operator-capacity surface, added blueprint default visuals, and browser-verified desktop/mobile/light/dark render states.
 
 Open questions:
 

--- a/apps/tangle-cloud/src/app/providers.tsx
+++ b/apps/tangle-cloud/src/app/providers.tsx
@@ -3,11 +3,13 @@ import { ToastProvider } from '@tangle-network/sandbox-ui/primitives';
 import useLocalChainGuard from '@tangle-network/tangle-shared-ui/hooks/useLocalChainGuard';
 import useNetworkSync from '@tangle-network/tangle-shared-ui/hooks/useNetworkSync';
 import { IndexerStatusProvider } from '@tangle-network/tangle-shared-ui/context/IndexerStatusContext';
+import useNetworkStore from '@tangle-network/tangle-shared-ui/context/useNetworkStore';
 import { isLocalPreviewHost } from '@tangle-network/tangle-shared-ui/utils/localPreview';
 import { FC, type PropsWithChildren, useEffect, useState } from 'react';
 import { WagmiProvider } from 'wagmi';
 import {
   ANVIL_LOCAL_NETWORK,
+  BASE_SEPOLIA_NETWORK,
   TANGLE_CLOUD_NETWORKS,
 } from '../constants/networks';
 import { cloudWagmiConfig } from './cloudWagmiConfig';
@@ -15,11 +17,29 @@ import PaymentProviders from './PaymentProviders';
 
 // Component to sync network store with wagmi chain
 const NetworkSync: FC<PropsWithChildren> = ({ children }) => {
+  const forceLocalChain = import.meta.env.VITE_FORCE_LOCAL_CHAIN === 'true';
+  const selectedNetwork = useNetworkStore((store) => store.network2);
+  const setNetwork = useNetworkStore((store) => store.setNetwork);
+
+  const needsCloudNetworkReset =
+    !forceLocalChain &&
+    selectedNetwork?.evmChainId === ANVIL_LOCAL_NETWORK.evmChainId;
+
+  useEffect(() => {
+    if (needsCloudNetworkReset) {
+      setNetwork(BASE_SEPOLIA_NETWORK);
+    }
+  }, [needsCloudNetworkReset, setNetwork]);
+
   useNetworkSync(TANGLE_CLOUD_NETWORKS);
   useLocalChainGuard({
-    enabled: isLocalPreviewHost(),
+    enabled: forceLocalChain && isLocalPreviewHost(),
     targetChainId: ANVIL_LOCAL_NETWORK.evmChainId ?? 31337,
   });
+  if (needsCloudNetworkReset) {
+    return null;
+  }
+
   return children;
 };
 
@@ -59,14 +79,14 @@ const Providers: FC<PropsWithChildren> = ({ children }) => {
       reconnectOnMount={reconnectOnMount}
     >
       <QueryClientProvider client={queryClient}>
-        <IndexerStatusProvider>
-          <ToastProvider>
-            <ToastAccessibilityPatch />
-            <NetworkSync>
+        <NetworkSync>
+          <IndexerStatusProvider>
+            <ToastProvider>
+              <ToastAccessibilityPatch />
               <PaymentProviders>{children}</PaymentProviders>
-            </NetworkSync>
-          </ToastProvider>
-        </IndexerStatusProvider>
+            </ToastProvider>
+          </IndexerStatusProvider>
+        </NetworkSync>
       </QueryClientProvider>
     </WagmiProvider>
   );

--- a/apps/tangle-cloud/src/components/Header.tsx
+++ b/apps/tangle-cloud/src/components/Header.tsx
@@ -47,10 +47,6 @@ export default function Header({
   const pathname = useLocation().pathname;
   const trail = useMemo(() => getHeaderTrail(pathname), [pathname]);
   const topNavContent = useTopNavSlotContent();
-  const hasContextualConnect =
-    pathname.startsWith('/rewards') ||
-    pathname.startsWith('/earnings') ||
-    pathname.startsWith('/instances');
 
   return (
     <header
@@ -64,7 +60,8 @@ export default function Header({
        * ("Blueprints / Trading"); pages can override it with contextual
        * content (name + actions) via useTopNavSlot. */}
       <div className="ml-12 flex min-w-0 flex-1 items-center gap-2 sm:ml-0">
-        {topNavContent ?? <HeaderTrail items={trail} />}
+        {topNavContent ??
+          (trail.length > 0 ? <HeaderTrail items={trail} /> : null)}
       </div>
 
       <div className="flex shrink-0 items-center justify-end gap-2">
@@ -76,9 +73,10 @@ export default function Header({
 
         <ThemeToggle theme={theme} onThemeChange={onThemeChange} />
 
-        {!hasContextualConnect && (
-          <ConnectWalletButton className="tangle-cloud-wallet-action" />
-        )}
+        {/* Connection state lives in the chrome on every route — the header is
+         * the single owner of Connect Wallet. Pages never duplicate this; a
+         * disconnected page body renders a designed empty state instead. */}
+        <ConnectWalletButton className="tangle-cloud-wallet-action" />
       </div>
     </header>
   );
@@ -107,6 +105,7 @@ const getHeaderTrail = (pathname: string): TrailItem[] => {
     return [blueprints, { label: 'Service' }];
   if (pathname.startsWith('/blueprints/') && pathname !== '/blueprints')
     return [blueprints, { label: 'Details' }];
+  if (pathname === '/blueprints') return [];
   if (pathname.startsWith('/blueprints')) return [blueprints];
 
   if (pathname === '/operators/manage') return [operators, { label: 'Manage' }];
@@ -255,14 +254,15 @@ function CloudNetworkSelector({ networks }: { networks: Network[] }) {
     NetworkId | null | 'custom'
   >(null);
   const [customRpcEndpoint, setCustomRpcEndpoint] = useState('');
+  const evmChainId = network?.evmChainId;
 
   const isWrongEvmNetwork = useMemo(() => {
-    if (!isConnected || !network?.evmChainId) {
+    if (!isConnected || !evmChainId) {
       return false;
     }
 
-    return network.evmChainId !== chainId;
-  }, [chainId, isConnected, network?.evmChainId]);
+    return evmChainId !== chainId;
+  }, [chainId, evmChainId, isConnected]);
 
   const isLoading = isWalletConnecting || isSwitchingChain;
   const networkName = isLoading ? 'Connecting' : (network?.name ?? 'Network');
@@ -296,12 +296,12 @@ function CloudNetworkSelector({ networks }: { networks: Network[] }) {
   }, [customRpcEndpoint, setNetwork]);
 
   const switchToCorrectEvmChain = useCallback(() => {
-    if (!network?.evmChainId || !switchChain) {
+    if (!evmChainId || !switchChain) {
       return;
     }
 
-    switchChain({ chainId: network.evmChainId });
-  }, [network?.evmChainId, switchChain]);
+    switchChain({ chainId: evmChainId });
+  }, [evmChainId, switchChain]);
 
   return (
     <div className="flex items-center gap-2">
@@ -325,14 +325,16 @@ function CloudNetworkSelector({ networks }: { networks: Network[] }) {
             type="button"
             variant="outline"
             disabled={isLoading}
-            className="h-11 gap-2 border-border bg-muted/30 px-3 font-bold text-foreground hover:bg-muted"
+            className="h-11 gap-2 border-border bg-muted/30 px-3 font-sans font-medium not-italic text-foreground hover:bg-muted"
           >
             {isLoading ? (
               <Spinner size="lg" />
             ) : (
               <ChainIcon size="lg" className="shrink-0" name={networkName} />
             )}
-            <span className="hidden sm:inline">{networkName}</span>
+            <span className="hidden font-sans not-italic sm:inline">
+              {networkName}
+            </span>
           </Button>
         </DropdownMenuTrigger>
 
@@ -355,7 +357,9 @@ function CloudNetworkSelector({ networks }: { networks: Network[] }) {
                   ) : (
                     <ChainIcon size="lg" name={item.name} />
                   )}
-                  <span className="truncate font-semibold">{item.name}</span>
+                  <span className="truncate font-sans font-medium not-italic">
+                    {item.name}
+                  </span>
                 </span>
                 {isSelected && (
                   <StatusIndicator

--- a/apps/tangle-cloud/src/components/blueprints/BlueprintVisual.tsx
+++ b/apps/tangle-cloud/src/components/blueprints/BlueprintVisual.tsx
@@ -1,5 +1,6 @@
 import type { Blueprint } from '@tangle-network/tangle-shared-ui/types/blueprint';
-import { useEffect, useState, type CSSProperties } from 'react';
+import { useState, type CSSProperties } from 'react';
+import { twMerge } from 'tailwind-merge';
 import {
   formatBlueprintName,
   getGithubPreviewUrl,
@@ -22,24 +23,19 @@ export const BlueprintVisual = ({
   const imageUrl =
     getUsableMetadataImageUrl(blueprint.imgUrl) ??
     getGithubPreviewUrl(blueprint.githubUrl);
-  const [hasImageError, setHasImageError] = useState(false);
+  const [imageErrorUrl, setImageErrorUrl] = useState<string | null>(null);
   const displayName = formatBlueprintName(blueprint.name);
   const style = getBlueprintVisualStyle(`${displayName}:${category}`);
+  const hasImageError = imageErrorUrl === imageUrl;
   const resolvedImageUrl = imageUrl && !hasImageError ? imageUrl : null;
-
-  useEffect(() => {
-    setHasImageError(false);
-  }, [imageUrl]);
 
   return (
     <div
-      className={[
+      className={twMerge(
         'relative isolate overflow-hidden rounded-xl border border-border bg-muted/40 shadow-[var(--shadow-card)]',
         compact ? 'h-24' : 'h-44',
         className,
-      ]
-        .filter(Boolean)
-        .join(' ')}
+      )}
       style={style}
     >
       {resolvedImageUrl ? (
@@ -49,7 +45,7 @@ export const BlueprintVisual = ({
             alt=""
             className="absolute inset-0 h-full w-full object-cover opacity-80"
             loading="lazy"
-            onError={() => setHasImageError(true)}
+            onError={() => setImageErrorUrl(imageUrl)}
           />
           <div className="absolute inset-0 bg-gradient-to-br from-black/50 via-black/25 to-black/60" />
         </>

--- a/apps/tangle-cloud/src/components/chrome/CommandPalette.tsx
+++ b/apps/tangle-cloud/src/components/chrome/CommandPalette.tsx
@@ -153,8 +153,10 @@ const CommandPalette: FC<Props> = ({ open, onOpenChange, extra = [] }) => {
   // Reset on open / collapse on close so the next invocation starts fresh.
   useEffect(() => {
     if (open) {
-      setQuery('');
-      setActiveIndex(0);
+      queueMicrotask(() => {
+        setQuery('');
+        setActiveIndex(0);
+      });
       // Focus on next tick so the Dialog's autofocus doesn't steal it.
       const id = window.setTimeout(() => inputRef.current?.focus(), 10);
       return () => window.clearTimeout(id);
@@ -163,7 +165,9 @@ const CommandPalette: FC<Props> = ({ open, onOpenChange, extra = [] }) => {
   }, [open]);
 
   useEffect(() => {
-    setActiveIndex((i) => Math.min(i, Math.max(0, filtered.length - 1)));
+    queueMicrotask(() => {
+      setActiveIndex((i) => Math.min(i, Math.max(0, filtered.length - 1)));
+    });
   }, [filtered.length]);
 
   const onKeyDown = (e: React.KeyboardEvent) => {

--- a/apps/tangle-cloud/src/components/chrome/CopyableId.tsx
+++ b/apps/tangle-cloud/src/components/chrome/CopyableId.tsx
@@ -1,0 +1,103 @@
+import { useCallback, useState, type FC } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+type Props = {
+  /** The full value copied to the clipboard (id, hash, address). */
+  value: string | null | undefined;
+  /**
+   * Display text. Defaults to a middle-truncated form of `value` when it looks
+   * like a hash/address (long + hex), otherwise the raw value.
+   */
+  display?: string;
+  /** Middle-truncate hex-looking values to `head…tail`. Default true. */
+  truncate?: boolean;
+  className?: string;
+};
+
+function middleTruncate(value: string, head = 6, tail = 4): string {
+  if (value.length <= head + tail + 1) return value;
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
+/**
+ * Copyable identifier cell — mono, theme-aware, click-to-copy. The canonical
+ * way to render an id / tx hash / address inside a table or detail row so the
+ * operator can audit and copy the exact value (principle 2: copyable IDs). Long
+ * hex values are middle-truncated for scan density; the full value is always in
+ * `title` and on the clipboard.
+ */
+const CopyableId: FC<Props> = ({
+  value,
+  display,
+  truncate = true,
+  className,
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = useCallback(() => {
+    if (!value) return;
+    void navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    });
+  }, [value]);
+
+  if (!value) {
+    return <span className="text-muted-foreground">—</span>;
+  }
+
+  const looksHex = /^0x[0-9a-fA-F]{8,}$/.test(value);
+  const shown =
+    display ?? (truncate && looksHex ? middleTruncate(value) : value);
+
+  return (
+    <button
+      type="button"
+      onClick={onCopy}
+      title={copied ? 'Copied' : `Copy: ${value}`}
+      aria-label={`Copy ${value}`}
+      className={twMerge(
+        'group inline-flex max-w-full items-center gap-1 font-mono text-[13px] tabular-nums text-foreground transition-colors hover:text-[color:var(--border-accent-hover)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--border-accent-hover)]',
+        className,
+      )}
+    >
+      <span className="truncate">{shown}</span>
+      <span
+        aria-hidden
+        className="shrink-0 text-muted-foreground/60 transition-colors group-hover:text-[color:var(--border-accent-hover)]"
+      >
+        {copied ? (
+          <svg viewBox="0 0 16 16" fill="none" className="h-3 w-3" aria-hidden>
+            <path
+              d="M3.5 8.5l3 3 6-6.5"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        ) : (
+          <svg viewBox="0 0 16 16" fill="none" className="h-3 w-3" aria-hidden>
+            <rect
+              x="5.5"
+              y="5.5"
+              width="7"
+              height="7"
+              rx="1.2"
+              stroke="currentColor"
+              strokeWidth="1.2"
+            />
+            <path
+              d="M10.5 3.5H4.7c-.66 0-1.2.54-1.2 1.2v5.8"
+              stroke="currentColor"
+              strokeWidth="1.2"
+              strokeLinecap="round"
+            />
+          </svg>
+        )}
+      </span>
+    </button>
+  );
+};
+
+export default CopyableId;

--- a/apps/tangle-cloud/src/components/chrome/DataTable.tsx
+++ b/apps/tangle-cloud/src/components/chrome/DataTable.tsx
@@ -1,0 +1,177 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@tangle-network/sandbox-ui/primitives';
+import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { focus, typeRole } from '../../styles/chrome';
+
+export type DataColumn<T> = {
+  /** Column header. */
+  header: ReactNode;
+  /** Cell renderer for a row. */
+  render: (item: T, index: number) => ReactNode;
+  /**
+   * Alignment. Use `right` for amounts/numerics so columns line up on the
+   * decimal — the senior move for a ledger.
+   */
+  align?: 'left' | 'right' | 'center';
+  /** Render this column's cells as mono tabular numerics (IDs, hashes, amounts). */
+  mono?: boolean;
+  /** Width / sizing class for the `<th>`/`<td>` (e.g. `w-24`, `w-[1%]`). */
+  className?: string;
+  /** Header-cell class override. */
+  headerClassName?: string;
+  /** Fold this column on narrow viewports. */
+  hideBelow?: 'sm' | 'md' | 'lg' | 'xl';
+};
+
+type Props<T> = {
+  items: T[];
+  columns: DataColumn<T>[];
+  rowKey: (item: T, index: number) => string;
+  /** Make rows clickable (entire row is the target). */
+  onRowClick?: (item: T, index: number) => void;
+  /** Caption for screen readers. */
+  caption?: string;
+  /** Empty slot — pass an <EmptyState/> for the zero-row case. */
+  empty?: ReactNode;
+  className?: string;
+};
+
+const HIDE_CLASS: Record<
+  NonNullable<DataColumn<unknown>['hideBelow']>,
+  string
+> = {
+  sm: 'hidden sm:table-cell',
+  md: 'hidden md:table-cell',
+  lg: 'hidden lg:table-cell',
+  xl: 'hidden xl:table-cell',
+};
+
+const ALIGN_CLASS: Record<NonNullable<DataColumn<unknown>['align']>, string> = {
+  left: 'text-left',
+  right: 'text-right',
+  center: 'text-center',
+};
+
+/**
+ * Dense console table — the design-system instrument for in-page ledgers,
+ * job history, payout events, and any N-row homogeneous data inside a detail
+ * surface. Wraps the design-system `Table` family with the console defaults the
+ * brief mandates: mono tabular numerics, right-aligned amounts, copyable IDs
+ * (via the `mono` + `<CopyableId>` helpers), thin borders, row-as-target.
+ *
+ * Use this — NOT a hand-rolled `<table>` (the F4-svc bug) — whenever the data
+ * is tabular and lives inside a page. For top-level catalog/directory pages
+ * that need search + view-toggle, use `ResultList` instead.
+ *
+ *   <DataTable
+ *     items={jobs}
+ *     rowKey={(j) => j.id}
+ *     columns={[
+ *       { header: 'Job', render: (j) => <CopyableId value={j.id} />, mono: true },
+ *       { header: 'Amount', align: 'right', mono: true,
+ *         render: (j) => <Money value={j.amount} options={{ decimals, symbol }} /> },
+ *       { header: 'Status', render: (j) =>
+ *         <StatusPill tone={statusToneFor('job', j.status)}>{j.status}</StatusPill> },
+ *     ]}
+ *   />
+ */
+function DataTable<T>({
+  items,
+  columns,
+  rowKey,
+  onRowClick,
+  caption,
+  empty,
+  className,
+}: Props<T>) {
+  if (items.length === 0 && empty !== undefined) {
+    return empty;
+  }
+
+  return (
+    <div
+      className={twMerge(
+        'overflow-x-auto rounded-lg border border-border',
+        className,
+      )}
+    >
+      <Table>
+        {caption && <caption className="sr-only">{caption}</caption>}
+        <TableHeader>
+          <TableRow className="border-b border-border hover:bg-transparent">
+            {columns.map((col, i) => (
+              <TableHead
+                key={i}
+                className={twMerge(
+                  typeRole.label,
+                  'h-9 whitespace-nowrap px-4 align-middle',
+                  col.align && ALIGN_CLASS[col.align],
+                  col.hideBelow && HIDE_CLASS[col.hideBelow],
+                  col.headerClassName ?? col.className,
+                )}
+              >
+                {col.header}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {items.map((item, index) => {
+            const interactive = onRowClick !== undefined;
+            return (
+              <TableRow
+                key={rowKey(item, index)}
+                tabIndex={interactive ? 0 : undefined}
+                onClick={
+                  interactive ? () => onRowClick(item, index) : undefined
+                }
+                onKeyDown={
+                  interactive
+                    ? (e: ReactKeyboardEvent) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          onRowClick(item, index);
+                        }
+                      }
+                    : undefined
+                }
+                className={twMerge(
+                  'border-b border-border/60 last:border-b-0',
+                  interactive &&
+                    twMerge(
+                      'cursor-pointer transition-colors hover:bg-[color:var(--bg-hover)]/60',
+                      focus.ring,
+                    ),
+                )}
+              >
+                {columns.map((col, i) => (
+                  <TableCell
+                    key={i}
+                    className={twMerge(
+                      'px-4 py-2.5 align-middle text-sm',
+                      col.align && ALIGN_CLASS[col.align],
+                      col.mono && 'font-mono text-[13px] tabular-nums',
+                      col.hideBelow && HIDE_CLASS[col.hideBelow],
+                      col.className,
+                    )}
+                  >
+                    {col.render(item, index)}
+                  </TableCell>
+                ))}
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+export default DataTable;

--- a/apps/tangle-cloud/src/components/chrome/FilterTray.tsx
+++ b/apps/tangle-cloud/src/components/chrome/FilterTray.tsx
@@ -44,7 +44,7 @@ const FilterTray: FC<Props> = ({
         <button
           type="button"
           className={twMerge(
-            'inline-flex h-9 items-center gap-2 rounded-md border border-border bg-transparent px-3 text-sm font-medium text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
+            'inline-flex h-9 items-center gap-2 rounded-md border border-border bg-muted/30 px-3 font-sans text-sm font-medium text-foreground not-italic transition-colors hover:bg-[color:var(--bg-hover)]',
             focus.ring,
           )}
         >
@@ -79,7 +79,7 @@ const FilterTray: FC<Props> = ({
                 variant="ghost"
                 size="sm"
                 onClick={onClear}
-                className="h-7 px-2 text-xs"
+                className="h-7 px-2 font-sans text-xs not-italic"
               >
                 Clear all
               </Button>

--- a/apps/tangle-cloud/src/components/chrome/Money.tsx
+++ b/apps/tangle-cloud/src/components/chrome/Money.tsx
@@ -1,0 +1,127 @@
+import { useCallback, useState, type FC } from 'react';
+import { twMerge } from 'tailwind-merge';
+import {
+  formatMoney,
+  type FormatMoneyOptions,
+  type MoneyView,
+} from '../../styles/chrome';
+
+type Props = {
+  /** Exact on-chain value. The component derives a lossless view from it. */
+  value: bigint | null | undefined;
+  /** Formatting contract — decimals, symbol, compact display. */
+  options?: FormatMoneyOptions;
+  /** Pre-built view (when the caller already computed one). Overrides `value`. */
+  view?: MoneyView;
+  /**
+   * Show the copy-full-precision affordance. Default true. Disable in extremely
+   * dense rows where copy lives elsewhere; the full value is still in `title`.
+   */
+  copyable?: boolean;
+  /** Render the unit/symbol after the number. Default true. */
+  showSymbol?: boolean;
+  /** Right-align (the default for amounts in tables/ledgers). */
+  align?: 'left' | 'right';
+  className?: string;
+};
+
+/**
+ * Canonical money cell. Renders the compact display from a {@link MoneyView},
+ * carries the unit, exposes the full-precision value on hover (`title`) and one
+ * click away (copy). This is the ONLY way money should render on the console —
+ * it makes the on-chain bigint exact, copyable, and auditable, which the brief
+ * mandates and the old `parseFloat` formatter violated.
+ *
+ *   <Money value={escrow.balance} options={{ decimals, symbol: 'TNT' }} />
+ *
+ * Empty values render an em-dash (never a fake `0`).
+ */
+const Money: FC<Props> = ({
+  value,
+  options,
+  view,
+  copyable = true,
+  showSymbol = true,
+  align = 'right',
+  className,
+}) => {
+  const money = view ?? formatMoney(value, options);
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = useCallback(() => {
+    if (money.isEmpty) return;
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return;
+
+    void navigator.clipboard.writeText(money.full).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    });
+  }, [money.full, money.isEmpty]);
+
+  const fullLabel = money.isEmpty
+    ? 'No value'
+    : `${money.full}${money.symbol ? ` ${money.symbol}` : ''}`;
+
+  return (
+    <span
+      className={twMerge(
+        'inline-flex items-baseline gap-1 font-mono text-[13px] tabular-nums',
+        align === 'right' && 'justify-end',
+        className,
+      )}
+      title={fullLabel}
+    >
+      <span className="text-foreground">{money.display}</span>
+      {showSymbol && money.symbol && !money.isEmpty && (
+        <span className="text-[11px] text-muted-foreground">
+          {money.symbol}
+        </span>
+      )}
+      {copyable && !money.isEmpty && (
+        <button
+          type="button"
+          onClick={onCopy}
+          title={`Copy full precision: ${fullLabel}`}
+          aria-label={`Copy full precision value ${fullLabel}`}
+          className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded text-muted-foreground/70 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--border-accent-hover)]"
+        >
+          {copied ? <CheckGlyph /> : <CopyGlyph />}
+        </button>
+      )}
+    </span>
+  );
+};
+
+const CopyGlyph: FC = () => (
+  <svg viewBox="0 0 16 16" fill="none" className="h-3 w-3" aria-hidden>
+    <rect
+      x="5.5"
+      y="5.5"
+      width="7"
+      height="7"
+      rx="1.2"
+      stroke="currentColor"
+      strokeWidth="1.2"
+    />
+    <path
+      d="M10.5 3.5H4.7c-.66 0-1.2.54-1.2 1.2v5.8"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+const CheckGlyph: FC = () => (
+  <svg viewBox="0 0 16 16" fill="none" className="h-3 w-3" aria-hidden>
+    <path
+      d="M3.5 8.5l3 3 6-6.5"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default Money;

--- a/apps/tangle-cloud/src/components/chrome/PageMotion.tsx
+++ b/apps/tangle-cloud/src/components/chrome/PageMotion.tsx
@@ -34,7 +34,9 @@ const PageMotion: FC<Props> = ({ children, className }) => {
   const [entering, setEntering] = useState(false);
 
   useEffect(() => {
-    setEntering(true);
+    queueMicrotask(() => {
+      setEntering(true);
+    });
     // Two rAFs: one to commit the entering state, one to clear it after the
     // browser has had a chance to render the initial keyframe state. The
     // CSS animation handles the actual transition; the attribute is just a

--- a/apps/tangle-cloud/src/components/chrome/PageToolbar.tsx
+++ b/apps/tangle-cloud/src/components/chrome/PageToolbar.tsx
@@ -45,12 +45,12 @@ const PageToolbar: FC<Props> = ({
     <div
       className={twMerge(
         chromeHeight.toolbar,
-        'flex w-full items-center gap-3 border-b border-border bg-background',
-        sticky && 'sticky top-0 z-20',
+        'flex w-full flex-wrap items-center gap-2 rounded-lg border border-border bg-[color:var(--bg-card)] px-2 py-1.5 shadow-[var(--shadow-card)] sm:flex-nowrap sm:gap-3',
+        sticky && 'sticky top-16 z-20',
         className,
       )}
     >
-      <div className="relative flex min-w-0 flex-1 items-center">
+      <div className="relative flex min-w-[180px] flex-[1_1_260px] items-center">
         <Search
           className="pointer-events-none absolute left-3 h-4 w-4 fill-current text-muted-foreground"
           aria-hidden
@@ -62,8 +62,8 @@ const PageToolbar: FC<Props> = ({
           placeholder={search.placeholder}
           autoFocus={search.autoFocus}
           className={twMerge(
-            'h-9 w-full rounded-md border border-transparent bg-transparent pl-9 pr-3 text-sm leading-tight text-foreground placeholder:text-muted-foreground/70',
-            'hover:border-border',
+            'h-9 w-full rounded-md border border-transparent bg-transparent pl-9 pr-3 font-sans text-sm leading-tight text-foreground not-italic placeholder:text-muted-foreground/70',
+            'hover:border-border focus:border-[color:var(--border-accent-hover)]',
             focus.ring,
           )}
         />
@@ -95,7 +95,9 @@ const PageToolbar: FC<Props> = ({
       )}
 
       {trailing !== undefined && (
-        <div className="flex shrink-0 items-center gap-2">{trailing}</div>
+        <div className="flex flex-[1_1_100%] flex-wrap items-center justify-start gap-2 sm:flex-none sm:justify-end">
+          {trailing}
+        </div>
       )}
     </div>
   );

--- a/apps/tangle-cloud/src/components/chrome/ResultList.tsx
+++ b/apps/tangle-cloud/src/components/chrome/ResultList.tsx
@@ -53,12 +53,12 @@ function ResultList<T>({
   return (
     <div
       className={twMerge(
-        'overflow-hidden rounded-lg border border-border',
+        'overflow-hidden rounded-lg border border-border bg-[color:var(--bg-card)] shadow-[var(--shadow-card)]',
         className,
       )}
     >
       {/* Header */}
-      <div className="flex items-center border-b border-border bg-[color:var(--bg-card)]/40 px-4 py-2">
+      <div className="flex items-center border-b border-border bg-[color:var(--bg-elevated)]/80 px-4 py-2.5">
         {columns.map((col, i) => (
           <div
             key={i}
@@ -96,9 +96,9 @@ function ResultList<T>({
                   : undefined
               }
               className={twMerge(
-                'flex items-center border-b border-border/60 px-4 py-3 text-sm last:border-b-0',
+                'flex items-center border-b border-border/60 bg-[color:var(--bg-card)] px-4 py-3.5 text-sm last:border-b-0',
                 interactive &&
-                  'cursor-pointer transition-colors hover:bg-[color:var(--bg-hover)]/60',
+                  'cursor-pointer transition-colors hover:bg-[color:var(--bg-hover)]',
                 interactive && focus.ring,
               )}
             >

--- a/apps/tangle-cloud/src/components/chrome/StatusPill.tsx
+++ b/apps/tangle-cloud/src/components/chrome/StatusPill.tsx
@@ -1,38 +1,63 @@
 import type { FC, ReactNode } from 'react';
 import { twMerge } from 'tailwind-merge';
-import { statusPill, type StatusTone } from '../../styles/chrome';
+import { statusDot, statusPill, type StatusTone } from '../../styles/chrome';
 
 type Props = {
   tone?: StatusTone;
   children: ReactNode;
   className?: string;
-  /** Optional leading icon (sized 12px). */
+  /** Optional leading icon (sized 12px). Overrides the auto tone dot. */
   icon?: ReactNode;
+  /**
+   * Render a small leading tone dot when no `icon` is supplied. Default true.
+   * The dot reads the same hue as the pill border so the status is legible at a
+   * glance even before the label. `pending` tone pulses softly.
+   */
+  dot?: boolean;
 };
 
 /**
- * Outlined status pill — single tone per status, never filled. Use for
- * service state, audit state, capacity state, network state. **Not** for
- * decoration; pills should always reflect a model field the operator can act
- * on.
+ * Outlined status pill — single tone per status, never filled. The one
+ * canonical status badge for the whole console: service / instance / job /
+ * operator / payment state, audit state, capacity state.
+ *
+ * Pair with `statusToneFor(domain, status)` so a domain status maps to a tone
+ * in exactly one place:
+ *
+ *   <StatusPill tone={statusToneFor('service', 'Active')}>Active</StatusPill>
+ *
+ * **Not** for decoration; a pill should always reflect a model field the
+ * operator can act on.
  */
 const StatusPill: FC<Props> = ({
   tone = 'neutral',
   children,
   className,
   icon,
+  dot = true,
 }) => (
   <span
     className={twMerge(
-      'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold leading-none',
+      'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold leading-none',
       statusPill[tone],
       className,
     )}
   >
-    {icon !== undefined && (
+    {icon !== undefined ? (
       <span className="inline-flex h-3 w-3 items-center justify-center">
         {icon}
       </span>
+    ) : (
+      dot && (
+        <span
+          aria-hidden
+          className={twMerge(
+            'inline-block h-1.5 w-1.5 shrink-0 rounded-full',
+            statusDot[tone],
+            tone === 'pending' && 'animate-pulse',
+          )}
+        />
+      )
     )}
     {children}
   </span>

--- a/apps/tangle-cloud/src/components/chrome/TopNavSlot.tsx
+++ b/apps/tangle-cloud/src/components/chrome/TopNavSlot.tsx
@@ -2,9 +2,14 @@ import {
   createContext,
   useContext,
   useEffect,
-  useState,
+  useMemo,
   type ReactNode,
 } from 'react';
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { twMerge } from 'tailwind-merge';
+import StatusPill from './StatusPill';
+import type { StatusTone } from '../../styles/chrome';
 
 /**
  * Lets a page inject content (pills, contextual actions) into the global top
@@ -46,4 +51,86 @@ export function useTopNavSlot(node: ReactNode): void {
     ctx.setContent(node);
     return () => ctx.setContent(null);
   }, [ctx, node]);
+}
+
+/**
+ * Ergonomic publish API for detail pages: declare the entity identity (the
+ * section breadcrumb + the entity name), an optional status, and an optional
+ * primary action, and this builds the canonical top-nav row and publishes it.
+ *
+ * This is the single place that owns the breadcrumb + identity + status +
+ * action layout, so every detail page reads identically in the chrome without
+ * re-implementing truncation, the `ml-auto` action group, or the breadcrumb
+ * separator. A detail page adopts the contextual top nav with one call:
+ *
+ *   useTopNavEntity({
+ *     section: 'Instances',
+ *     sectionHref: PagePath.INSTANCES,
+ *     name: service.name,
+ *     status: { label: service.status, tone: statusToneFor('service', service.status) },
+ *     actions: <Button size="sm">Submit job</Button>,
+ *   });
+ *
+ * Principle map #8: global controls live in the chrome; the contextual top bar
+ * carries entity identity + the single primary action.
+ */
+export type TopNavEntity = {
+  /** Section root label, e.g. "Instances" / "Blueprints". */
+  section: string;
+  /** Section root href; the label links back to the section catalog. */
+  sectionHref: string;
+  /** The entity name (truncates). The leaf of the breadcrumb. */
+  name: ReactNode;
+  /**
+   * Optional status pill rendered next to the name — the one canonical badge,
+   * never a hand-rolled chip. Use `statusToneFor(domain, status)` for the tone.
+   */
+  status?: { label: ReactNode; tone: StatusTone };
+  /** Optional right-aligned primary action(s). Keep to one button on most pages. */
+  actions?: ReactNode;
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useTopNavEntity(entity: TopNavEntity | null): void {
+  const { section, sectionHref, name, status, actions } = entity ?? {};
+  const statusLabel = status?.label;
+  const statusTone = status?.tone;
+
+  const node = useMemo<ReactNode>(() => {
+    if (!entity) return null;
+    return (
+      <>
+        <nav
+          aria-label="Breadcrumb"
+          className="flex min-w-0 items-center gap-1.5 text-[13px]"
+        >
+          <Link
+            to={sectionHref ?? '#'}
+            className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {section}
+          </Link>
+          <span aria-hidden className="text-muted-foreground/40">
+            /
+          </span>
+          <span className="truncate font-semibold text-foreground">{name}</span>
+        </nav>
+        {statusTone !== undefined && (
+          <span className="hidden shrink-0 md:inline-flex">
+            <StatusPill tone={statusTone}>{statusLabel}</StatusPill>
+          </span>
+        )}
+        {actions !== undefined && (
+          <div className={twMerge('ml-auto flex shrink-0 items-center gap-2')}>
+            {actions}
+          </div>
+        )}
+      </>
+    );
+    // `entity` is included so a null->object transition re-publishes; the
+    // primitive fields drive the memo so a parent that rebuilds the object each
+    // render (without changing values) doesn't thrash the publish effect.
+  }, [entity, section, sectionHref, name, statusLabel, statusTone, actions]);
+
+  useTopNavSlot(node);
 }

--- a/apps/tangle-cloud/src/components/chrome/ViewToggle.tsx
+++ b/apps/tangle-cloud/src/components/chrome/ViewToggle.tsx
@@ -47,7 +47,7 @@ const ViewToggle: FC<Props> = ({ value, onChange, className }) => {
       role="radiogroup"
       aria-label="View"
       className={twMerge(
-        'inline-flex h-9 items-center rounded-md border border-border bg-transparent p-0.5',
+        'inline-flex h-9 items-center rounded-md border border-border bg-muted/30 p-0.5',
         className,
       )}
     >
@@ -79,7 +79,7 @@ const ViewButton: FC<{
       onClick={onClick}
       title={kind === 'grid' ? 'Grid view' : 'List view'}
       className={twMerge(
-        'inline-flex h-7 w-8 items-center justify-center rounded transition-colors',
+        'inline-flex h-7 w-8 items-center justify-center rounded font-sans not-italic transition-colors',
         active
           ? 'bg-[color:var(--bg-hover)] text-foreground'
           : 'text-muted-foreground hover:text-foreground',

--- a/apps/tangle-cloud/src/components/chrome/index.ts
+++ b/apps/tangle-cloud/src/components/chrome/index.ts
@@ -20,6 +20,11 @@
  *   </PageLayout>
  */
 
+export { default as CopyableId } from './CopyableId';
+
+export { default as DataTable } from './DataTable';
+export type { DataColumn } from './DataTable';
+
 export { default as EmptyState } from './EmptyState';
 export type { EmptyKind } from './EmptyState';
 
@@ -27,6 +32,8 @@ export { default as FilterTray } from './FilterTray';
 
 export { default as MetricStrip } from './MetricStrip';
 export type { Metric, MetricTone } from './MetricStrip';
+
+export { default as Money } from './Money';
 
 export { default as PageHeader } from './PageHeader';
 
@@ -41,3 +48,20 @@ export { default as StatusPill } from './StatusPill';
 
 export { default as ViewToggle } from './ViewToggle';
 export type { ResultView } from './ViewToggle';
+
+// Design-system contracts (tokens + helpers) — re-exported so surfaces have a
+// single import path for the whole chrome system. The status tone mapping and
+// the money formatter are the two canonical contracts every surface shares.
+export {
+  formatMoney,
+  statusDot,
+  statusPill,
+  statusToneFor,
+  typeRole,
+} from '../../styles/chrome';
+export type {
+  FormatMoneyOptions,
+  MoneyView,
+  StatusDomain,
+  StatusTone,
+} from '../../styles/chrome';

--- a/apps/tangle-cloud/src/components/sandbox/SandboxUi.tsx
+++ b/apps/tangle-cloud/src/components/sandbox/SandboxUi.tsx
@@ -33,7 +33,14 @@ import {
   TabsTrigger,
   Textarea,
 } from '@tangle-network/sandbox-ui/primitives';
-import type { ChangeEvent, ComponentProps, FC, ReactNode } from 'react';
+import {
+  forwardRef,
+  type ChangeEvent,
+  type ComponentProps,
+  type ElementRef,
+  type FC,
+  type ReactNode,
+} from 'react';
 
 // Re-export the canonical tangle-cloud Text from the dedicated module so we
 // preserve the existing import surface (`import { Text } from '...sandbox/SandboxUi'`)
@@ -149,42 +156,50 @@ export type ButtonProps = Omit<
   disabledTooltip?: string;
 };
 
-export const Button: FC<ButtonProps> = ({
-  variant,
-  size,
-  isDisabled,
-  isLoading,
-  isJustIcon,
-  isFullWidth,
-  leftIcon,
-  rightIcon,
-  loadingText: _loadingText,
-  disabledTooltip: _disabledTooltip,
-  disabled,
-  className = '',
-  children,
-  ...props
-}) => (
-  <SandboxButton
-    variant={
-      variant === 'utility'
-        ? 'outline'
-        : variant === 'primary'
-          ? 'default'
-          : variant
-    }
-    size={isJustIcon ? 'icon' : size}
-    disabled={disabled || isDisabled}
-    loading={isLoading}
-    className={[isFullWidth ? 'w-full' : '', className]
-      .filter(Boolean)
-      .join(' ')}
-    {...props}
-  >
-    {leftIcon}
-    {children}
-    {rightIcon}
-  </SandboxButton>
+export const Button = forwardRef<ElementRef<typeof SandboxButton>, ButtonProps>(
+  function Button(
+    {
+      variant,
+      size,
+      isDisabled,
+      isLoading,
+      isJustIcon,
+      isFullWidth,
+      leftIcon,
+      rightIcon,
+      loadingText: _loadingText,
+      disabledTooltip: _disabledTooltip,
+      disabled,
+      className = '',
+      children,
+      ...props
+    },
+    ref,
+  ) {
+    return (
+      <SandboxButton
+        ref={ref}
+        variant={
+          variant === 'utility'
+            ? 'outline'
+            : variant === 'primary'
+              ? 'default'
+              : variant
+        }
+        size={isJustIcon ? 'icon' : size}
+        disabled={disabled || isDisabled}
+        loading={isLoading}
+        className={[isFullWidth ? 'w-full' : '', className]
+          .filter(Boolean)
+          .join(' ')}
+        {...props}
+      >
+        {leftIcon}
+        {children}
+        {rightIcon}
+      </SandboxButton>
+    );
+  },
 );
 
 export type InputProps = Omit<

--- a/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
@@ -6,7 +6,16 @@ import {
   Skeleton,
 } from '../../components/sandbox/SandboxUi';
 import { formatBlueprintName } from '../../components/blueprints/blueprintVisualUtils';
-import { EmptyState, FilterTray, PageToolbar } from '../../components/chrome';
+import {
+  EmptyState,
+  FilterTray,
+  PageToolbar,
+  ResultList,
+  StatusPill,
+  ViewToggle,
+  statusToneFor,
+  type ResultView,
+} from '../../components/chrome';
 import {
   enumCodec,
   intCodec,
@@ -19,6 +28,7 @@ import type { Blueprint } from '@tangle-network/tangle-shared-ui/types/blueprint
 import {
   Dispatch,
   FC,
+  ReactNode,
   SetStateAction,
   useCallback,
   useDeferredValue,
@@ -35,33 +45,64 @@ import {
   fetchAttestations,
   fetchAuditorOnChain,
 } from '@tangle-network/tangle-shared-ui/data/blueprints/useBinaryVersions';
+import useNetworkStore from '@tangle-network/tangle-shared-ui/context/useNetworkStore';
 import {
   AttestationKind,
   type Auditor,
 } from '@tangle-network/tangle-shared-ui/blueprintApps/trustScore';
 import { auditorFallbackRegistry } from '../../auditors';
-import { Link } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 import { twMerge } from 'tailwind-merge';
 import { PagePath } from '../../types';
 import {
   dedupeBlueprintsByIdentity,
   type DedupedBlueprintRow,
 } from '../../blueprintApps/dedupe';
+import { BlueprintVisual } from '../../components/blueprints/BlueprintVisual';
 
 const PAGE_SIZE = 12;
 
-type AudienceFilter = 'all' | 'customers' | 'operators';
+type AvailabilityFilter = 'all' | 'deployable' | 'capacity';
 type ManifestFilter = 'all' | 'verified' | 'fallback';
 type AuditFilter = 'all' | 'audited';
+type FilterOption<T extends string> = {
+  value: T;
+  label: string;
+  description?: string;
+};
+type CatalogStat = {
+  label: string;
+  value: number;
+  detail: string;
+};
 
 type Props = {
   rowSelection?: RowSelectionState;
   onRowSelectionChange?: Dispatch<SetStateAction<RowSelectionState>>;
   onRegisterBlueprint?: (blueprint: Blueprint) => void;
+  toolbarAction?: ReactNode;
+  onRetry?: () => void;
 } & Omit<UseAllBlueprintsReturn, 'refetch'>;
 
 const pluralize = (label: string, count: number) =>
   count === 1 ? label : `${label}s`;
+
+const availabilityOptions: FilterOption<AvailabilityFilter>[] = [
+  { value: 'all', label: 'All' },
+  { value: 'deployable', label: 'Deployable' },
+  { value: 'capacity', label: 'Needs capacity' },
+];
+
+const sourceOptions: FilterOption<ManifestFilter>[] = [
+  { value: 'all', label: 'All sources' },
+  { value: 'verified', label: 'Pinned source' },
+  { value: 'fallback', label: 'Chain-only' },
+];
+
+const trustOptions: FilterOption<AuditFilter>[] = [
+  { value: 'all', label: 'All trust' },
+  { value: 'audited', label: 'Audited' },
+];
 
 /**
  * Title-case a single tag so the catalog renders consistent chips even if
@@ -171,6 +212,13 @@ const matchesSearch = (blueprint: Blueprint, query: string) => {
   return haystack.includes(query);
 };
 
+const getBlueprintDescription = (blueprint: Blueprint) =>
+  blueprint.description?.trim() ||
+  'Service blueprint ready for deployment once capacity is available.';
+
+const getModeCount = (row: DedupedBlueprintRow) =>
+  row.modes?.length ?? (row.aliases.length > 0 ? row.aliases.length + 1 : 1);
+
 /**
  * Multi-select category dropdown for the toolbar. Replaces the old
  * full-width segmented row — categories collapse into one pill with a
@@ -189,7 +237,7 @@ const CategoryFilterMenu: FC<{
         <button
           type="button"
           className={twMerge(
-            'inline-flex h-9 items-center gap-2 rounded-md border border-border bg-transparent px-3 text-sm font-medium text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
+            'inline-flex h-9 items-center gap-2 rounded-md border border-border bg-muted/30 px-3 font-sans text-sm font-medium text-foreground not-italic transition-colors hover:bg-[color:var(--bg-hover)]',
             focus.ring,
           )}
         >
@@ -221,7 +269,7 @@ const CategoryFilterMenu: FC<{
               <button
                 type="button"
                 onClick={onClear}
-                className="text-xs text-muted-foreground hover:text-foreground"
+                className="font-sans text-xs text-muted-foreground not-italic hover:text-foreground"
               >
                 Clear
               </button>
@@ -240,7 +288,7 @@ const CategoryFilterMenu: FC<{
                   type="button"
                   onClick={() => onToggle(category)}
                   className={twMerge(
-                    'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
+                    'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left font-sans text-sm text-foreground not-italic transition-colors hover:bg-[color:var(--bg-hover)]',
                     focus.ring,
                   )}
                 >
@@ -269,6 +317,106 @@ const CategoryFilterMenu: FC<{
   );
 };
 
+const BlueprintCatalogHeader: FC<{
+  matchCount: number;
+  totalCount: number;
+  stats: CatalogStat[];
+}> = ({ matchCount, totalCount, stats }) => (
+  <section className="border-b border-border pb-5">
+    <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+      <div className="max-w-3xl">
+        <h1 className={twMerge(typeRole.display, 'text-foreground')}>
+          Blueprints
+        </h1>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+          Live service catalog with capacity, source, and trust signals for the
+          selected network.
+        </p>
+        <div className="mt-3 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          <span className={typeRole.mono}>
+            {matchCount.toLocaleString()}
+            {matchCount !== totalCount && (
+              <span className="opacity-60">
+                {' / '}
+                {totalCount.toLocaleString()}
+              </span>
+            )}
+          </span>
+          <span>{pluralize('blueprint', matchCount)}</span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4 lg:min-w-[520px]">
+        {stats.map((stat) => (
+          <div key={stat.label} className="border-l border-border pl-3">
+            <div className="font-mono text-2xl leading-none tabular-nums text-foreground">
+              {stat.value.toLocaleString()}
+            </div>
+            <div className={twMerge(typeRole.label, 'mt-1')}>{stat.label}</div>
+            <div className="mt-1 text-xs leading-tight text-muted-foreground">
+              {stat.detail}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+function FilterSegment<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+  stacked = false,
+}: {
+  label: string;
+  options: FilterOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  stacked?: boolean;
+}) {
+  return (
+    <div className={twMerge(stacked ? 'space-y-2' : 'flex items-center gap-2')}>
+      {stacked && <span className={typeRole.label}>{label}</span>}
+      <div
+        role="radiogroup"
+        aria-label={label}
+        className={twMerge(
+          'inline-flex min-h-9 rounded-md border border-border bg-muted/30 p-0.5',
+          stacked && 'grid w-full grid-cols-1 gap-1 bg-transparent p-0',
+        )}
+      >
+        {options.map((option) => {
+          const active = option.value === value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => onChange(option.value)}
+              className={twMerge(
+                'inline-flex min-h-8 items-center justify-center rounded px-3 font-sans text-sm font-medium not-italic transition-colors',
+                active
+                  ? 'bg-[color:var(--bg-hover)] text-foreground shadow-[inset_0_0_0_1px_var(--border-accent)]'
+                  : 'text-muted-foreground hover:text-foreground',
+                stacked && 'justify-start border border-border bg-muted/20',
+                stacked &&
+                  active &&
+                  'border-[color:var(--border-accent-hover)]',
+                focus.ring,
+              )}
+            >
+              <span>{option.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 const BlueprintListing: FC<Props> = ({
   rowSelection,
   onRowSelectionChange,
@@ -276,13 +424,20 @@ const BlueprintListing: FC<Props> = ({
   isLoading,
   error,
   onRegisterBlueprint,
+  toolbarAction,
+  onRetry,
 }) => {
+  const navigate = useNavigate();
   // Filter state lives in the URL — refresh persists the view, deep-links are
   // shareable, the back button works. Defaults are omitted from the URL so a
   // bare /blueprints stays clean. `replace: true` (in `useUrlState`) means
   // every keystroke doesn't pollute the history stack.
   const [page, setPage] = useUrlState('page', intCodec(0));
   const [searchQuery, setSearchQuery] = useUrlState('q', stringCodec(''));
+  const [view, setView] = useUrlState<ResultView>(
+    'view',
+    enumCodec(['grid', 'list'] as const, 'list'),
+  );
   // Multi-select categories, comma-joined in the URL (empty = all). Single
   // dropdown in the toolbar replaces the old full-width category row.
   const [categoryParam, setCategoryParam] = useUrlState(
@@ -302,10 +457,11 @@ const BlueprintListing: FC<Props> = ({
     },
     [selectedCategories, setCategoryParam],
   );
-  const [audienceFilter, setAudienceFilter] = useUrlState<AudienceFilter>(
-    'avail',
-    enumCodec(['all', 'customers', 'operators'] as const, 'all'),
-  );
+  const [availabilityFilter, setAvailabilityFilter] =
+    useUrlState<AvailabilityFilter>(
+      'avail',
+      enumCodec(['all', 'deployable', 'capacity'] as const, 'all'),
+    );
   const [manifestFilter, setManifestFilter] = useUrlState<ManifestFilter>(
     'source',
     enumCodec(['all', 'verified', 'fallback'] as const, 'all'),
@@ -322,7 +478,8 @@ const BlueprintListing: FC<Props> = ({
     return Array.from(blueprints.values()).sort((a, b) => {
       if (a.isBoosted && !b.isBoosted) return -1;
       if (!a.isBoosted && b.isBoosted) return 1;
-      return Number(b.id - a.id);
+      if (a.id === b.id) return 0;
+      return a.id < b.id ? 1 : -1;
     });
   }, [blueprints]);
 
@@ -358,14 +515,14 @@ const BlueprintListing: FC<Props> = ({
       }
 
       if (
-        audienceFilter === 'customers' &&
+        availabilityFilter === 'deployable' &&
         (blueprint.operatorsCount ?? 0) <= 0
       ) {
         return false;
       }
 
       if (
-        audienceFilter === 'operators' &&
+        availabilityFilter === 'capacity' &&
         (blueprint.operatorsCount ?? 0) >= 3
       ) {
         return false;
@@ -389,19 +546,22 @@ const BlueprintListing: FC<Props> = ({
       return true;
     });
   }, [
-    audienceFilter,
+    availabilityFilter,
     auditFilter,
     auditedStatus,
     blueprintItems,
     deferredSearchQuery,
     manifestFilter,
-    categoryParam,
+    selectedCategories,
   ]);
 
+  // `useUrlState` returns a new setter each render; depending on it creates a
+  // page-reset loop. Filter values are the actual synchronization boundary.
   useEffect(() => {
     setPage(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    audienceFilter,
+    availabilityFilter,
     auditFilter,
     deferredSearchQuery,
     manifestFilter,
@@ -418,6 +578,47 @@ const BlueprintListing: FC<Props> = ({
     () => dedupeBlueprintsByIdentity(filteredBlueprints),
     [filteredBlueprints],
   );
+  const allDedupedRows = useMemo(
+    () => dedupeBlueprintsByIdentity(blueprintItems),
+    [blueprintItems],
+  );
+  const catalogStats = useMemo<CatalogStat[]>(() => {
+    let deployable = 0;
+    let capacityNeeded = 0;
+    let pinnedSource = 0;
+    let audited = 0;
+
+    for (const { blueprint } of allDedupedRows) {
+      const operatorCount = blueprint.operatorsCount ?? 0;
+      if (operatorCount > 0) deployable += 1;
+      if (operatorCount < 3) capacityNeeded += 1;
+      if (hasVerifiedManifest(blueprint)) pinnedSource += 1;
+      if (auditedStatus.get(blueprint.id.toString()) === true) audited += 1;
+    }
+
+    return [
+      {
+        label: 'Deployable',
+        value: deployable,
+        detail: 'ready now',
+      },
+      {
+        label: 'Need capacity',
+        value: capacityNeeded,
+        detail: 'below target',
+      },
+      {
+        label: 'Pinned',
+        value: pinnedSource,
+        detail: 'verified source',
+      },
+      {
+        label: 'Audited',
+        value: audited,
+        detail: 'trust signal',
+      },
+    ];
+  }, [allDedupedRows, auditedStatus]);
   const totalPages = Math.max(1, Math.ceil(dedupedRows.length / PAGE_SIZE));
   const safePage = Math.min(page, totalPages - 1);
   const visibleRows = dedupedRows.slice(
@@ -427,31 +628,144 @@ const BlueprintListing: FC<Props> = ({
   const hasActiveFilters =
     searchQuery.trim() !== '' ||
     selectedCategories.length > 0 ||
-    audienceFilter !== 'all' ||
+    availabilityFilter !== 'all' ||
     manifestFilter !== 'all' ||
     auditFilter !== 'all';
 
   const showSelection =
     typeof rowSelection !== 'undefined' &&
     typeof onRowSelectionChange === 'function';
+  const effectiveView = showSelection ? 'grid' : view;
 
-  if (isLoading) {
+  const listColumns = useMemo(
+    () => [
+      {
+        header: 'Blueprint',
+        className: 'min-w-0 flex-[2.4]',
+        render: (row: DedupedBlueprintRow) => (
+          <BlueprintIdentitySummary row={row} />
+        ),
+      },
+      {
+        header: 'Capacity',
+        className: 'w-40',
+        hideBelow: 'md' as const,
+        render: (row: DedupedBlueprintRow) => (
+          <BlueprintCapacityCell
+            operatorCount={row.blueprint.operatorsCount ?? 0}
+          />
+        ),
+      },
+      {
+        header: 'Trust',
+        className: 'w-28',
+        hideBelow: 'md' as const,
+        render: (row: DedupedBlueprintRow) => {
+          const audited =
+            auditedStatus.get(row.blueprint.id.toString()) ?? false;
+          return (
+            <StatusPill
+              tone={statusToneFor('audit', audited ? 'Audited' : 'Unaudited')}
+              dot={false}
+            >
+              {audited ? 'Audited' : 'Unaudited'}
+            </StatusPill>
+          );
+        },
+      },
+      {
+        header: 'Source',
+        className: 'w-32',
+        hideBelow: 'lg' as const,
+        render: (row: DedupedBlueprintRow) => {
+          const verified = hasVerifiedManifest(row.blueprint);
+          return (
+            <StatusPill
+              tone={verified ? 'success' : 'neutral'}
+              dot={false}
+              className="text-[12px]"
+            >
+              {verified ? 'Pinned' : 'Chain-only'}
+            </StatusPill>
+          );
+        },
+      },
+      {
+        header: 'Usage',
+        className: 'w-24 justify-end',
+        hideBelow: 'lg' as const,
+        render: (row: DedupedBlueprintRow) => (
+          <span className="font-mono text-[13px] tabular-nums text-muted-foreground">
+            {(row.blueprint.instancesCount ?? 0).toLocaleString()}
+          </span>
+        ),
+      },
+      {
+        header: 'Actions',
+        className: 'w-52 justify-end sm:w-56',
+        render: (row: DedupedBlueprintRow) => {
+          const { blueprint } = row;
+          const blueprintHref = `${PagePath.BLUEPRINTS}/${blueprint.id.toString()}`;
+          const hasOperators = (blueprint.operatorsCount ?? 0) > 0;
+
+          return (
+            <div className="flex w-full justify-end gap-2">
+              {hasOperators && (
+                <Link
+                  to={`${blueprintHref}/deploy`}
+                  onClick={(event) => event.stopPropagation()}
+                  className={catalogPrimaryActionClass}
+                >
+                  Deploy
+                </Link>
+              )}
+              <RegisterCapacityButton
+                blueprint={blueprint}
+                onRegister={onRegisterBlueprint}
+                isPrimary={!hasOperators}
+              />
+            </div>
+          );
+        },
+      },
+    ],
+    [auditedStatus, onRegisterBlueprint],
+  );
+
+  if (isLoading && blueprintItems.length === 0) {
     return (
-      <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
-        {Array.from({ length: 6 }).map((_, idx) => (
-          <Skeleton key={idx} className="h-[360px] rounded-lg" />
-        ))}
+      <div className="space-y-5">
+        <BlueprintCatalogHeader
+          matchCount={0}
+          totalCount={0}
+          stats={catalogStats}
+        />
+        <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, idx) => (
+            <Skeleton key={idx} className="h-[360px] rounded-lg" />
+          ))}
+        </div>
       </div>
     );
   }
 
-  if (error) {
+  if (error && blueprintItems.length === 0) {
     return (
       <Card variant="sandbox" className="border-destructive/20">
-        <CardContent className="flex min-h-40 items-center justify-center p-8 text-center">
-          <p className="max-w-2xl text-muted-foreground text-sm">
-            {error.message}
-          </p>
+        <CardContent className="flex min-h-40 flex-col items-center justify-center gap-3 p-8 text-center">
+          <div>
+            <p className="font-semibold text-foreground">
+              Unable to refresh blueprints
+            </p>
+            <p className="mt-1 max-w-2xl text-muted-foreground text-sm">
+              {error.message}
+            </p>
+          </div>
+          {onRetry !== undefined && (
+            <Button variant="outline" size="sm" onClick={onRetry}>
+              Retry
+            </Button>
+          )}
         </CardContent>
       </Card>
     );
@@ -462,41 +776,53 @@ const BlueprintListing: FC<Props> = ({
       <EmptyState
         kind="no-data"
         title="No blueprints on this network"
-        description="Register an operator, switch networks, or publish a blueprint to make it available for deployment."
+        description="Add capacity, switch networks, or publish a blueprint to make services available for deployment."
       />
     );
   }
 
-  // Count active non-default filters — drives the FilterTray's active badge
-  // so the operator sees at a glance how many constraints they have on.
-  const activeFilterCount =
-    (audienceFilter !== 'all' ? 1 : 0) +
-    (manifestFilter !== 'all' ? 1 : 0) +
-    (auditFilter !== 'all' ? 1 : 0);
+  const trayFilterCount =
+    (manifestFilter !== 'all' ? 1 : 0) + (auditFilter !== 'all' ? 1 : 0);
 
   const resetAllFilters = () => {
     setSearchQuery('');
     setCategoryParam('');
-    setAudienceFilter('all');
+    setAvailabilityFilter('all');
     setManifestFilter('all');
     setAuditFilter('all');
   };
 
   return (
     <div className="space-y-5">
+      <BlueprintCatalogHeader
+        matchCount={dedupedRows.length}
+        totalCount={allDedupedRows.length}
+        stats={catalogStats}
+      />
+
       <PageToolbar
         search={{
           value: searchQuery,
           onChange: setSearchQuery,
-          placeholder: 'Search blueprints, services, publishers, or IDs',
+          placeholder: 'Search name, publisher, tag, or #id',
         }}
+        filters={
+          <FilterSegment
+            label="Availability"
+            options={availabilityOptions}
+            value={availabilityFilter}
+            onChange={setAvailabilityFilter}
+          />
+        }
         count={{
           matches: dedupedRows.length,
-          total: blueprintItems.length,
+          total: allDedupedRows.length,
           noun: 'matches',
         }}
         trailing={
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            {toolbarAction}
+            {!showSelection && <ViewToggle value={view} onChange={setView} />}
             <CategoryFilterMenu
               categories={categories}
               selected={selectedCategories}
@@ -504,61 +830,35 @@ const BlueprintListing: FC<Props> = ({
               onClear={() => setCategoryParam('')}
             />
             <FilterTray
-              activeCount={activeFilterCount}
+              activeCount={trayFilterCount}
               onClear={resetAllFilters}
-              trayTitle="Catalog filters"
+              trayTitle="Source and trust"
             >
-              <label className="block space-y-1.5">
-                <span className={typeRole.label}>Availability</span>
-                <select
-                  value={audienceFilter}
-                  onChange={(event) =>
-                    setAudienceFilter(
-                      event.currentTarget.value as AudienceFilter,
-                    )
-                  }
-                  className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none hover:bg-[color:var(--bg-hover)] focus:border-[color:var(--border-accent-hover)]"
-                >
-                  <option value="all">All availability</option>
-                  <option value="customers">Has operators</option>
-                  <option value="operators">Needs capacity</option>
-                </select>
-              </label>
+              <FilterSegment
+                label="Source"
+                options={sourceOptions}
+                value={manifestFilter}
+                onChange={setManifestFilter}
+                stacked
+              />
 
-              <label className="block space-y-1.5">
-                <span className={typeRole.label}>Source</span>
-                <select
-                  value={manifestFilter}
-                  onChange={(event) =>
-                    setManifestFilter(
-                      event.currentTarget.value as ManifestFilter,
-                    )
-                  }
-                  className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none hover:bg-[color:var(--bg-hover)] focus:border-[color:var(--border-accent-hover)]"
-                >
-                  <option value="all">All sources</option>
-                  <option value="verified">Pinned source</option>
-                  <option value="fallback">Chain-only</option>
-                </select>
-              </label>
-
-              <label className="block space-y-1.5">
-                <span className={typeRole.label}>Trust</span>
-                <select
-                  value={auditFilter}
-                  onChange={(event) =>
-                    setAuditFilter(event.currentTarget.value as AuditFilter)
-                  }
-                  className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none hover:bg-[color:var(--bg-hover)] focus:border-[color:var(--border-accent-hover)]"
-                >
-                  <option value="all">All blueprints</option>
-                  <option value="audited">Audited only</option>
-                </select>
-              </label>
+              <FilterSegment
+                label="Trust"
+                options={trustOptions}
+                value={auditFilter}
+                onChange={setAuditFilter}
+                stacked
+              />
             </FilterTray>
           </div>
         }
       />
+
+      {error && (
+        <div className="rounded-lg border border-[color:var(--md3-warning,#f59e0b)]/35 bg-[color:var(--md3-warning,#f59e0b)]/10 px-4 py-3 text-sm text-[color:var(--surface-warning-text,var(--md3-warning,#f59e0b))]">
+          Showing cached blueprint data. Latest refresh failed: {error.message}
+        </div>
+      )}
 
       {dedupedRows.length === 0 ? (
         <EmptyState
@@ -570,6 +870,30 @@ const BlueprintListing: FC<Props> = ({
             )
           }
         />
+      ) : effectiveView === 'list' ? (
+        <>
+          <div className="space-y-3 md:hidden">
+            {visibleRows.map((row) => (
+              <MobileBlueprintRow
+                key={row.blueprint.id.toString()}
+                row={row}
+                isAudited={
+                  auditedStatus.get(row.blueprint.id.toString()) ?? false
+                }
+                onRegister={onRegisterBlueprint}
+              />
+            ))}
+          </div>
+          <ResultList
+            className="hidden md:block"
+            items={visibleRows}
+            columns={listColumns}
+            rowKey={(row) => row.blueprint.id.toString()}
+            onRowClick={(row) =>
+              navigate(`${PagePath.BLUEPRINTS}/${row.blueprint.id.toString()}`)
+            }
+          />
+        </>
       ) : (
         <div className="results-grid grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
           {visibleRows.map((row) => (
@@ -647,7 +971,9 @@ export default BlueprintListing;
  * the same react-query cache entry — no duplicate chain reads.
  */
 const useAuditedStatusMap = (blueprintIds: bigint[]): Map<string, boolean> => {
-  const chainId = useChainId();
+  const wagmiChainId = useChainId();
+  const networkChainId = useNetworkStore((store) => store.network2?.evmChainId);
+  const chainId = networkChainId ?? wagmiChainId;
   const publicClient = usePublicClient({ chainId });
   const fallback = useMemo(() => auditorFallbackRegistry(), []);
 
@@ -747,7 +1073,7 @@ const useAuditedStatusMap = (blueprintIds: bigint[]): Map<string, boolean> => {
         const nowSeconds = Math.floor(Date.now() / 1000);
         const hasAuditedAttestation = attestations.some((row) => {
           if (row.revoked) return false;
-          if (row.expiresAt !== 0n && Number(row.expiresAt) <= nowSeconds) {
+          if (row.expiresAt !== 0n && row.expiresAt <= BigInt(nowSeconds)) {
             return false;
           }
           if (row.kind === AttestationKind.SELF) return false;
@@ -773,27 +1099,175 @@ const useAuditedStatusMap = (blueprintIds: bigint[]): Map<string, boolean> => {
   return map;
 };
 
-/**
- * Catalog card — the operator/customer's primary scan surface.
- *
- * Hard rule: ONE fact per visual line, three lines of information total.
- *
- *   Line 1: title (large, primary read)
- *   Line 2: one-line description (truncated)
- *   Line 3: status — "Ready · N operators" OR "Needs operators"
- *
- * Everything else is hover-revealed (action buttons) or absent (publisher
- * address, category pill, deployment-modes pill, source-pinning pill,
- * three-cell metric grid, github link). The detail page is one click away
- * and surfaces those facts where they belong.
- *
- * Distinctive identity (so the wall doesn't look like a shadcn template
- * gallery): the blueprint id renders as a large mono "watermark" in the
- * top-right corner — like a tactical card chip number. Featured /
- * audited blueprints get a 2px accent stripe on the left border, not a
- * full perimeter glow. Visual identity comes from typography and
- * proportion, not from gradients.
- */
+const BlueprintIdentitySummary = ({ row }: { row: DedupedBlueprintRow }) => {
+  const { blueprint } = row;
+  const category = getBlueprintCategory(blueprint);
+  const modeCount = getModeCount(row);
+
+  return (
+    <div className="flex min-w-0 items-center gap-3">
+      <BlueprintVisual
+        blueprint={blueprint}
+        category={category}
+        compact
+        className="h-14 w-14 shrink-0 rounded-md"
+      />
+      <div className="min-w-0">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate font-display text-[15px] font-bold leading-tight text-foreground">
+            {formatBlueprintName(blueprint.name)}
+          </span>
+          <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+            #{blueprint.id.toString()}
+          </span>
+        </div>
+        <p className="mt-1 line-clamp-1 text-sm leading-snug text-muted-foreground">
+          {getBlueprintDescription(blueprint)}
+        </p>
+        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+          <BlueprintMetaChip>{category}</BlueprintMetaChip>
+          {modeCount > 1 && (
+            <BlueprintMetaChip>
+              {modeCount} {pluralize('mode', modeCount)}
+            </BlueprintMetaChip>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const BlueprintMetaChip = ({ children }: { children: ReactNode }) => (
+  <span className="rounded border border-border bg-muted/20 px-1.5 py-0.5 font-sans text-[11px] font-medium leading-none text-muted-foreground not-italic">
+    {children}
+  </span>
+);
+
+const BlueprintCapacityCell = ({
+  operatorCount,
+}: {
+  operatorCount: number;
+}) => {
+  const hasOperators = operatorCount > 0;
+
+  return (
+    <div className="flex min-w-0 flex-col items-start gap-1.5">
+      <BlueprintCapacitySignal operatorCount={operatorCount} />
+      <span className="font-mono text-[12px] tabular-nums text-muted-foreground">
+        {hasOperators
+          ? `${operatorCount.toLocaleString()} registered`
+          : '0 registered'}
+      </span>
+    </div>
+  );
+};
+
+const BlueprintCapacitySignal = ({
+  operatorCount,
+}: {
+  operatorCount: number;
+}) => {
+  const hasOperators = operatorCount > 0;
+
+  return (
+    <StatusPill
+      tone={statusToneFor(
+        'availability',
+        hasOperators ? 'Available' : 'Limited',
+      )}
+      dot={false}
+      className="text-[12px]"
+    >
+      {hasOperators ? 'Ready' : 'Needs capacity'}
+    </StatusPill>
+  );
+};
+
+const catalogActionClass =
+  'inline-flex min-h-8 flex-1 items-center justify-center rounded-md border border-border bg-muted/30 px-3 py-1.5 text-center font-sans text-xs font-semibold text-foreground not-italic transition-colors before:hidden after:hidden marker:hidden hover:bg-[color:var(--bg-hover)] whitespace-nowrap';
+
+const catalogPrimaryActionClass =
+  'inline-flex min-h-8 flex-1 items-center justify-center rounded-md bg-primary px-3 py-1.5 text-center font-sans text-xs font-semibold text-primary-foreground not-italic transition-colors before:hidden after:hidden marker:hidden hover:bg-primary/90 whitespace-nowrap';
+
+const MobileBlueprintRow = ({
+  row,
+  isAudited,
+  onRegister,
+}: {
+  row: DedupedBlueprintRow;
+  isAudited: boolean;
+  onRegister?: (blueprint: Blueprint) => void;
+}) => {
+  const { blueprint } = row;
+  const blueprintHref = `${PagePath.BLUEPRINTS}/${blueprint.id.toString()}`;
+  const operatorCount = blueprint.operatorsCount ?? 0;
+  const hasOperators = operatorCount > 0;
+  const description = getBlueprintDescription(blueprint);
+
+  return (
+    <article className="rounded-lg border border-border bg-[color:var(--bg-card)] p-3 shadow-[var(--shadow-card)]">
+      <Link
+        to={blueprintHref}
+        className={twMerge('flex min-w-0 gap-3', focus.ring)}
+      >
+        <BlueprintVisual
+          blueprint={blueprint}
+          category={getBlueprintCategory(blueprint)}
+          compact
+          className="h-14 w-14 shrink-0 rounded-md"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <h3 className="truncate font-display text-base font-bold leading-tight tracking-normal text-foreground">
+              {formatBlueprintName(blueprint.name)}
+            </h3>
+            <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+              #{blueprint.id.toString()}
+            </span>
+          </div>
+          <p className="mt-1 line-clamp-2 text-sm leading-snug text-muted-foreground">
+            {description}
+          </p>
+        </div>
+      </Link>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <BlueprintCapacitySignal operatorCount={operatorCount} />
+        <StatusPill
+          tone={statusToneFor('audit', isAudited ? 'Audited' : 'Unaudited')}
+          dot={false}
+          className="text-[12px]"
+        >
+          {isAudited ? 'Audited' : 'Unaudited'}
+        </StatusPill>
+        <StatusPill
+          tone={hasVerifiedManifest(blueprint) ? 'success' : 'neutral'}
+          dot={false}
+          className="text-[12px]"
+        >
+          {hasVerifiedManifest(blueprint) ? 'Pinned' : 'Chain-only'}
+        </StatusPill>
+      </div>
+
+      <div className="mt-3 flex gap-2">
+        {hasOperators && (
+          <Link
+            to={`${blueprintHref}/deploy`}
+            className={catalogPrimaryActionClass}
+          >
+            Deploy
+          </Link>
+        )}
+        <RegisterCapacityButton
+          blueprint={blueprint}
+          onRegister={onRegister}
+          isPrimary={!hasOperators}
+        />
+      </div>
+    </article>
+  );
+};
+
 const BlueprintCard = ({
   row,
   isSelectable,
@@ -810,37 +1284,37 @@ const BlueprintCard = ({
   onRegister?: (blueprint: Blueprint) => void;
 }) => {
   const { blueprint } = row;
-  const description =
-    blueprint.description?.trim() ||
-    'Service blueprint — deploy when operators are available.';
+  const description = getBlueprintDescription(blueprint);
   const blueprintHref = `${PagePath.BLUEPRINTS}/${blueprint.id.toString()}`;
   const operatorCount = blueprint.operatorsCount ?? 0;
   const hasOperators = operatorCount > 0;
   const isFeatured = blueprint.isBoosted === true || isAudited;
   const displayName = formatBlueprintName(blueprint.name);
+  const modeCount = getModeCount(row);
+  const sourcePinned = hasVerifiedManifest(blueprint);
   return (
     <div
       className={twMerge(
-        'group relative flex min-h-[180px] flex-col gap-3 rounded-lg border border-border bg-[color:var(--bg-card)] p-5 transition-all',
-        // Subtle hover: lift one pixel, tighten border accent. No gradient
-        // glow. The card already has enough visual weight from its content.
+        'group relative flex min-h-[260px] flex-col gap-3 rounded-lg border border-border bg-[color:var(--bg-card)] p-4 shadow-[var(--shadow-card)] transition-all',
         'hover:-translate-y-px hover:border-[color:var(--border-accent-hover)]',
         isFeatured && 'border-l-2 border-l-[color:var(--border-accent-hover)]',
         isSelected &&
           'border-[color:var(--border-accent-hover)] shadow-[0_0_0_1px_var(--border-accent-hover)]',
       )}
     >
-      {/* Whole-card link — keeps the deploy/register buttons interactive
-       * because they have z-20 and stopPropagation. Aria label on the
-       * link is the source of truth; the visible title is a styled span. */}
       <Link
         to={blueprintHref}
         className="absolute inset-0 z-10"
         aria-label={`Open ${blueprint.name}`}
       />
 
-      {/* Watermark ID — mono, low-contrast, top-right. The card's identity
-       * marker; not a UI element, not actionable. */}
+      <BlueprintVisual
+        blueprint={blueprint}
+        category={getBlueprintCategory(blueprint)}
+        compact
+        className="h-28 rounded-md"
+      />
+
       <span
         aria-hidden
         className="pointer-events-none absolute right-4 top-4 select-none font-mono text-xs tabular-nums text-foreground/15"
@@ -848,8 +1322,6 @@ const BlueprintCard = ({
         #{blueprint.id.toString().padStart(3, '0')}
       </span>
 
-      {/* Selection checkbox (drawer mode) — top-left so it never collides
-       * with the watermark or with the hover-revealed actions. */}
       {isSelectable && (
         <label
           className="absolute left-4 top-4 z-20 flex h-7 w-7 cursor-pointer items-center justify-center rounded border border-border bg-background/80 backdrop-blur transition-colors hover:bg-background"
@@ -865,49 +1337,37 @@ const BlueprintCard = ({
         </label>
       )}
 
-      {/* Header — name + 1-line description. */}
       <div className={twMerge('min-w-0', isSelectable && 'pl-8')}>
-        <h3 className="line-clamp-1 pr-12 font-display font-bold text-base leading-tight tracking-tight text-foreground">
+        <h3 className="line-clamp-1 pr-12 font-display font-bold text-base leading-tight tracking-normal text-foreground">
           {displayName}
         </h3>
-        <p className="mt-1 line-clamp-2 pr-12 text-xs leading-relaxed text-muted-foreground">
+        <p className="mt-1 line-clamp-2 pr-12 text-sm leading-snug text-muted-foreground">
           {description}
         </p>
       </div>
 
-      {/* Status row — one chip, mono operator count, audit/trust if present.
-       * Everything is bottom-anchored so cards align by their last line. */}
       <div className="mt-auto flex flex-wrap items-center gap-2 pt-2">
-        <span
-          className={twMerge(
-            'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider',
-            hasOperators
-              ? 'border-[color:var(--md3-tertiary,#10b981)]/40 bg-[color:var(--md3-tertiary,#10b981)]/8 text-[color:var(--md3-tertiary,#10b981)]'
-              : 'border-[color:var(--md3-warning,#f59e0b)]/40 bg-[color:var(--md3-warning,#f59e0b)]/8 text-[color:var(--md3-warning,#f59e0b)]',
-          )}
-        >
-          <span
-            aria-hidden
-            className={twMerge(
-              'h-1.5 w-1.5 rounded-full',
-              hasOperators
-                ? 'bg-[color:var(--md3-tertiary,#10b981)]'
-                : 'bg-[color:var(--md3-warning,#f59e0b)]',
-            )}
-          />
-          {hasOperators ? (
-            <>
-              <span className="font-mono tabular-nums">{operatorCount}</span>{' '}
-              {pluralize('operator', operatorCount)}
-            </>
-          ) : (
-            'Needs operators'
-          )}
-        </span>
+        <BlueprintCapacitySignal operatorCount={operatorCount} />
         {isAudited && (
-          <span className="inline-flex items-center gap-1 rounded-full border border-[color:var(--border-accent)] bg-transparent px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-foreground/80">
+          <StatusPill
+            tone={statusToneFor('audit', 'Audited')}
+            dot={false}
+            className="text-[12px]"
+          >
             Audited
-          </span>
+          </StatusPill>
+        )}
+        <StatusPill
+          tone={sourcePinned ? 'success' : 'neutral'}
+          dot={false}
+          className="text-[12px]"
+        >
+          {sourcePinned ? 'Pinned' : 'Chain-only'}
+        </StatusPill>
+        {modeCount > 1 && (
+          <BlueprintMetaChip>
+            {modeCount} {pluralize('mode', modeCount)}
+          </BlueprintMetaChip>
         )}
         {(blueprint.instancesCount ?? 0) > 0 && (
           <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
@@ -916,29 +1376,13 @@ const BlueprintCard = ({
         )}
       </div>
 
-      {/* Hover-revealed actions. Hidden by default — single click on the
-       * card opens the detail page; the actions are for power-users who
-       * want to jump straight to deploy/register without the detail step.
-       * `z-20` + `stopPropagation` keeps them clickable inside the overlay
-       * link.
-       *
-       * On non-hover devices (touch) the actions are always visible — the
-       * `group-hover:` selector only matches on pointer hover, so this is
-       * automatic. */}
-      <div
-        className={twMerge(
-          'actions relative z-20 mt-2 flex gap-2 opacity-0 transition-opacity',
-          'group-hover:opacity-100 group-focus-within:opacity-100',
-          // Always visible on touch — `pointer: coarse` means no hover layer.
-          '[@media(pointer:coarse)]:opacity-100',
-        )}
-      >
+      <div className={twMerge('actions relative z-20 mt-2 flex gap-2')}>
         {hasOperators ? (
           <>
             <Link
               to={`${blueprintHref}/deploy`}
               onClick={(e) => e.stopPropagation()}
-              className="flex-1 rounded-md bg-primary px-2 py-1.5 text-center text-xs font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+              className={catalogPrimaryActionClass}
             >
               Deploy
             </Link>
@@ -971,10 +1415,7 @@ const RegisterCapacityButton = ({
   <button
     type="button"
     className={twMerge(
-      'flex-1 rounded-md px-2 py-1.5 text-xs font-semibold transition-colors',
-      isPrimary
-        ? 'bg-primary text-primary-foreground hover:bg-primary/90'
-        : 'border border-border bg-transparent text-muted-foreground hover:bg-[color:var(--bg-hover)] hover:text-foreground',
+      isPrimary ? catalogPrimaryActionClass : catalogActionClass,
     )}
     onClick={(event) => {
       event.preventDefault();
@@ -982,6 +1423,6 @@ const RegisterCapacityButton = ({
       onRegister?.(blueprint);
     }}
   >
-    Register
+    Add capacity
   </button>
 );

--- a/apps/tangle-cloud/src/pages/blueprints/RegistrationDrawer/RegistrationDrawer.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/RegistrationDrawer/RegistrationDrawer.tsx
@@ -548,7 +548,7 @@ const RegistrationDrawer: FC<RegistrationDrawerProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="fixed right-0 left-auto top-0 z-[80] h-screen max-h-screen w-full max-w-xl translate-x-0 translate-y-0 rounded-none border-y-0 border-r-0 p-0 sm:max-w-xl">
+      <DialogContent className="fixed !left-auto !right-0 !top-0 z-[80] flex h-screen max-h-screen w-full max-w-xl !translate-x-0 !translate-y-0 flex-col overflow-hidden rounded-none border-y-0 border-r-0 p-0 sm:max-w-xl">
         <div className="shrink-0 flex items-center justify-between p-4 border-b border-border">
           <DialogTitle className="text-lg font-bold">
             Register as Operator
@@ -556,10 +556,6 @@ const RegistrationDrawer: FC<RegistrationDrawerProps> = ({
           <DialogDescription className="sr-only">
             Register an active operator for one or more selected blueprints.
           </DialogDescription>
-          <Button variant="ghost" size="icon" onClick={handleClose}>
-            <span aria-hidden>x</span>
-            <span className="sr-only">Close registration panel</span>
-          </Button>
         </div>
 
         {renderGatedContent()}

--- a/apps/tangle-cloud/src/pages/blueprints/[id]/deploy/page.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/[id]/deploy/page.tsx
@@ -440,8 +440,8 @@ const DeployPage: FC = () => {
 
   return (
     <RequireWallet
-      title="Connect wallet to create an instance"
-      description="Connect to choose operators, set permitted callers, and submit a service request transaction."
+      title={`Connect wallet to create ${blueprintResult.details.name}`}
+      description="Connect to choose operators, set permitted callers, and submit a service request transaction for this blueprint."
       eyebrow="Service instance"
       checks={['Operators', 'Payment', 'Request']}
     >

--- a/apps/tangle-cloud/src/pages/blueprints/page.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/page.tsx
@@ -10,28 +10,18 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router';
 import { twMerge } from 'tailwind-merge';
-import useRoleStore, { Role } from '../../stores/roleStore';
 import { PagePath } from '../../types';
 import pollWithBackoff from '../../utils/pollWithBackoff';
 import BlueprintListing from './BlueprintListing';
 import RegistrationDrawer from './RegistrationDrawer';
-import { PageHeader } from '../../components/chrome';
 
 const BLUEPRINT_DOCS_LINK =
   'https://docs.tangle.tools/developers/blueprints/introduction';
-
-const ROLE_TITLE = {
-  [Role.OPERATOR]: 'Blueprints',
-  [Role.DEPLOYER]: 'Blueprints',
-} satisfies Record<Role, string>;
-
-const HAS_BLUEPRINTS_TITLE = 'Blueprints';
 
 const pluralize = (label: string, count: number) =>
   count === 1 ? label : `${label}s`;
 
 const Page: FC = () => {
-  const role = useRoleStore((store) => store.role);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
@@ -69,10 +59,12 @@ const Page: FC = () => {
       return;
     }
 
-    handleRegisterBlueprint(blueprint);
-    const nextParams = new URLSearchParams(searchParams);
-    nextParams.delete('register');
-    setSearchParams(nextParams, { replace: true });
+    queueMicrotask(() => {
+      handleRegisterBlueprint(blueprint);
+      const nextParams = new URLSearchParams(searchParams);
+      nextParams.delete('register');
+      setSearchParams(nextParams, { replace: true });
+    });
   }, [
     blueprints,
     handleRegisterBlueprint,
@@ -154,43 +146,30 @@ const Page: FC = () => {
     });
   }, []);
 
-  const title = hasOwnedBlueprints ? HAS_BLUEPRINTS_TITLE : ROLE_TITLE[role];
-  // No subtitle on a catalog page — the visible content IS the subtitle.
-  // Adding "Find blueprints, create service instances, ..." steals 24px of
-  // vertical space for copy the operator already knows by being on this
-  // page. Catalog tier = title + toolbar + grid, nothing else above content.
-  // Catalog-wide stats (total, ready, needs-capacity, your-registrations)
-  // belong on the home dashboard, not above a search bar.
+  const toolbarAction = hasOwnedBlueprints ? (
+    <Button
+      asChild
+      variant="outline"
+      size="sm"
+      className="font-sans not-italic"
+    >
+      <Link to={PagePath.BLUEPRINTS_MANAGE}>Manage</Link>
+    </Button>
+  ) : (
+    <Button
+      variant="sandbox"
+      asChild
+      size="sm"
+      className="font-sans not-italic"
+    >
+      <a href={BLUEPRINT_DOCS_LINK} target="_blank" rel="noreferrer">
+        Publish
+      </a>
+    </Button>
+  );
 
   return (
     <div className="space-y-4">
-      <PageHeader
-        density="compact"
-        title={title}
-        action={
-          <>
-            {hasOwnedBlueprints && (
-              <Button asChild variant="ghost" size="sm">
-                <Link to={PagePath.OPERATORS}>Operators</Link>
-              </Button>
-            )}
-            <Button variant="sandbox" asChild size="sm">
-              <a
-                href={
-                  hasOwnedBlueprints
-                    ? PagePath.BLUEPRINTS_MANAGE
-                    : BLUEPRINT_DOCS_LINK
-                }
-                target={hasOwnedBlueprints ? undefined : '_blank'}
-                rel={hasOwnedBlueprints ? undefined : 'noreferrer'}
-              >
-                {hasOwnedBlueprints ? 'Manage blueprints' : 'Publish blueprint'}
-              </a>
-            </Button>
-          </>
-        }
-      />
-
       <BlueprintListing
         blueprints={blueprints}
         isLoading={isLoading}
@@ -198,6 +177,8 @@ const Page: FC = () => {
         rowSelection={isOperator ? rowSelection : undefined}
         onRowSelectionChange={isOperator ? setRowSelection : undefined}
         onRegisterBlueprint={handleRegisterBlueprint}
+        toolbarAction={toolbarAction}
+        onRetry={() => void refetch()}
       />
 
       <AnimatePresence>
@@ -228,8 +209,12 @@ const Page: FC = () => {
               </Button>
             </div>
 
-            <Button variant="sandbox" onClick={() => setIsDrawerOpen(true)}>
-              Register
+            <Button
+              variant="sandbox"
+              className="font-sans not-italic"
+              onClick={() => setIsDrawerOpen(true)}
+            >
+              Add capacity
             </Button>
           </motion.div>
         )}

--- a/apps/tangle-cloud/src/styles.css
+++ b/apps/tangle-cloud/src/styles.css
@@ -46,13 +46,16 @@ body {
 .tangle-cloud-shell[data-sandbox-theme='tangle'] {
   color-scheme: dark;
   /* prettier-ignore */
-  --bg-root: radial-gradient(ellipse 70% 48% at 18% 0%, rgba(99, 102, 241, 0.14), transparent), radial-gradient(ellipse 48% 36% at 82% 6%, rgba(20, 184, 166, 0.09), transparent), linear-gradient(180deg, #0a0a14 0%, #07070d 100%);
-  --bg-card: #1b1a2c;
-  --bg-elevated: #262448;
-  --bg-hover: rgba(129, 140, 248, 0.16);
+  --bg-root: radial-gradient(ellipse 60% 36% at 16% 0%, rgba(79, 70, 229, 0.1), transparent), radial-gradient(ellipse 44% 30% at 84% 4%, rgba(20, 184, 166, 0.08), transparent), linear-gradient(180deg, #090b10 0%, #07080c 100%);
+  --bg-card: #151922;
+  --bg-elevated: #202737;
+  --bg-hover: rgba(116, 126, 194, 0.18);
+  --text-primary: #dbe3f0;
+  --text-muted: #9aa7ba;
+  --text-secondary: #c3ccdc;
   --border-subtle: rgba(116, 126, 194, 0.12);
-  --border-default: rgba(128, 138, 213, 0.24);
-  --border-hover: rgba(151, 161, 245, 0.48);
+  --border-default: rgba(135, 146, 172, 0.26);
+  --border-hover: rgba(151, 161, 245, 0.46);
   --border-accent: rgba(129, 140, 248, 0.36);
   --border-accent-hover: rgba(129, 140, 248, 0.55);
   --accent-surface-soft: rgba(99, 102, 241, 0.12);
@@ -254,11 +257,6 @@ body {
   border: 1px solid var(--border-subtle);
   background: var(--bg-card);
   box-shadow: var(--shadow-card);
-}
-
-.results-grid {
-  content-visibility: auto;
-  contain-intrinsic-size: 800px;
 }
 
 /* Page-to-page transition triggered by PageMotion when react-router's

--- a/apps/tangle-cloud/src/styles/chrome.ts
+++ b/apps/tangle-cloud/src/styles/chrome.ts
@@ -23,10 +23,9 @@
 export const typeRole = {
   /** Page H1. One per page. */
   display:
-    'font-display font-extrabold text-3xl sm:text-4xl tracking-[-0.035em] leading-[1.05]',
+    'font-display font-extrabold text-3xl sm:text-4xl tracking-normal leading-[1.08]',
   /** Section heads, card titles. */
-  section:
-    'font-display font-semibold text-lg leading-tight tracking-[-0.012em]',
+  section: 'font-display font-semibold text-lg leading-tight tracking-normal',
   /** Default body copy. */
   body: 'text-sm leading-relaxed',
   /** Control labels, eyebrows. Always uppercase, always tracked. */
@@ -57,28 +56,175 @@ export const chromeHeight = {
   headerCompact: 'min-h-[60px] py-3',
   headerDefault: 'min-h-[80px] py-4',
   headerHero: 'min-h-[120px] py-6',
-  toolbar: 'h-11', // 44px
+  toolbar: 'min-h-11', // 44px minimum; wraps on narrow screens.
   metricStrip: 'min-h-[56px] py-3',
   tray: 'w-[420px]',
 } as const;
 
 // ── Status palette ───────────────────────────────────────────────────────────
-// Three status tones. Outlined pills only — `border-{color} bg-{color}/8` —
-// never filled. One color per status. Used at boundaries (state of a service,
-// audit state, capacity state). Never decorative.
+// Six status tones, one per *meaning*. Outlined pills only —
+// `border-{color} bg-{color}/8` — never filled. One color per status. Used at
+// boundaries (state of a service/instance/job/operator/payment, audit state,
+// capacity state). Never decorative.
+//
+// The tone enum is closed on purpose: surfaces map a domain status to one of
+// these six and the pill renders identically everywhere. A status can never
+// silently collapse to a default (the bug F1-svc: a Chip color map that only
+// knew green/red, so blue/purple/yellow all rendered the same neutral pill).
+//
+// Tone meanings:
+//   neutral  — inert / unknown / placeholder (default; no signal)
+//   info     — informational, in the accent family (e.g. Fixed membership,
+//              EventDriven pricing, an in-band state worth surfacing)
+//   success  — healthy / active / live / approved / billable / audited
+//   warning  — needs attention / pending action / degraded / stale / not-yet
+//   danger   — failed / rejected / slashed / terminated / disputed
+//   pending  — in-flight / provisioning / indexing / awaiting confirmation
+//              (rendered with a soft pulsing dot by StatusPill)
 
-export type StatusTone = 'neutral' | 'success' | 'warning' | 'danger' | 'info';
+export type StatusTone =
+  | 'neutral'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'pending';
 
 export const statusPill: Record<StatusTone, string> = {
   neutral: 'border border-border bg-transparent text-muted-foreground',
+  info: 'border border-[color:var(--border-accent)] bg-[var(--accent-surface-soft)] text-foreground',
   success:
     'border border-[color:var(--md3-tertiary,#10b981)]/40 bg-[color:var(--md3-tertiary,#10b981)]/8 text-[color:var(--md3-tertiary,#10b981)]',
   warning:
     'border border-[color:var(--md3-warning,#f59e0b)]/40 bg-[color:var(--md3-warning,#f59e0b)]/8 text-[color:var(--md3-warning,#f59e0b)]',
   danger:
     'border border-[color:var(--md3-error,#ef4444)]/40 bg-[color:var(--md3-error,#ef4444)]/8 text-[color:var(--md3-error,#ef4444)]',
-  info: 'border border-[color:var(--border-accent)] bg-[var(--accent-surface-soft)] text-foreground',
+  pending:
+    'border border-[color:var(--border-accent)] bg-[var(--accent-surface-soft)] text-[color:var(--border-accent-hover)]',
 } as const;
+
+// The leading dot color for each tone — kept in sync with `statusPill` so the
+// StatusPill auto-dot and any tone-aware indicator read the same hue.
+export const statusDot: Record<StatusTone, string> = {
+  neutral: 'bg-muted-foreground/40',
+  info: 'bg-[color:var(--border-accent-hover)]',
+  success: 'bg-[color:var(--md3-tertiary,#10b981)]',
+  warning: 'bg-[color:var(--md3-warning,#f59e0b)]',
+  danger: 'bg-[color:var(--md3-error,#ef4444)]',
+  pending: 'bg-[color:var(--border-accent-hover)]',
+} as const;
+
+// ── Canonical domain → tone mapping ──────────────────────────────────────────
+// `statusToneFor(domain, status)` is the single place the app decides which
+// tone a given domain status earns. Surfaces NEVER hand-roll
+// `color === 'green' ? 'success' : …`; they call this. Adding a new status
+// value is a one-line edit here, not a sweep across N files.
+//
+// Each domain maps its *string* status label (the value surfaces already have
+// in hand — enum label, indexer field, derived flag) to a tone. Unknown values
+// fall through to `neutral`, which is the honest default: no fake signal.
+
+export type StatusDomain =
+  | 'service' // service lifecycle: Pending | Active | Terminated
+  | 'instance' // instance / request approval: Pending | Approved | Rejected | Active | Terminated
+  | 'job' // job execution: Submitted | Running | Completed | Failed
+  | 'operator' // operator state: Active | Inactive | Leaving | Slashed
+  | 'payment' // payment / pricing model: PayOnce | Subscription | EventDriven
+  | 'membership' // membership model: Fixed | Dynamic
+  | 'audit' // audit / attestation: Audited | Unaudited | Pending
+  | 'availability' // capacity: Available | Limited | Unavailable
+  | 'billing'; // subscription billability: Billable | NotBillable | Due | Paid
+
+const TONE_BY_DOMAIN: Record<StatusDomain, Record<string, StatusTone>> = {
+  service: {
+    pending: 'pending',
+    active: 'success',
+    terminated: 'danger',
+  },
+  instance: {
+    pending: 'pending',
+    approved: 'success',
+    active: 'success',
+    rejected: 'danger',
+    terminated: 'danger',
+    indexing: 'pending',
+    submitted: 'pending',
+  },
+  job: {
+    submitted: 'pending',
+    pending: 'pending',
+    running: 'pending',
+    completed: 'success',
+    succeeded: 'success',
+    failed: 'danger',
+    errored: 'danger',
+  },
+  operator: {
+    active: 'success',
+    online: 'success',
+    inactive: 'neutral',
+    offline: 'warning',
+    leaving: 'warning',
+    exiting: 'warning',
+    slashed: 'danger',
+    disabled: 'danger',
+  },
+  payment: {
+    // Distinct tones so PayOnce / Subscription / EventDriven are never
+    // visually identical (the F1-svc collapse). These are *informational*
+    // category badges, not health signals — kept in the accent/neutral family.
+    payonce: 'info',
+    subscription: 'success',
+    eventdriven: 'warning',
+  },
+  membership: {
+    // Fixed vs Dynamic must be distinguishable.
+    fixed: 'info',
+    dynamic: 'success',
+  },
+  audit: {
+    audited: 'success',
+    verified: 'success',
+    unaudited: 'neutral',
+    pending: 'pending',
+    failed: 'danger',
+  },
+  availability: {
+    available: 'success',
+    limited: 'warning',
+    degraded: 'warning',
+    unavailable: 'danger',
+  },
+  billing: {
+    billable: 'success',
+    due: 'warning',
+    notbillable: 'neutral',
+    notyet: 'warning',
+    paid: 'success',
+  },
+} as const;
+
+/**
+ * Map a domain status to its canonical {@link StatusTone}. Pass the status as a
+ * string (enum label, indexer field, or a derived label) plus the domain so the
+ * same word can mean different things in different contexts (an `active`
+ * service and an `active` operator both read success, but `pending` is a
+ * `pending` tone for a service yet there is no such status for membership).
+ *
+ * Returns `neutral` for any unknown status — the honest default. Matching is
+ * case/space/dash-insensitive so `'PayOnce'`, `'pay_once'`, and `'pay once'`
+ * all resolve.
+ */
+export function statusToneFor(
+  domain: StatusDomain,
+  status: string | number | null | undefined,
+): StatusTone {
+  if (status === null || status === undefined) return 'neutral';
+  const key = String(status)
+    .toLowerCase()
+    .replace(/[\s_-]+/g, '');
+  return TONE_BY_DOMAIN[domain][key] ?? 'neutral';
+}
 
 // ── Surface roles ────────────────────────────────────────────────────────────
 // Eight roles. Bound to brand tokens. Anything not in this list is a bug.
@@ -99,3 +245,150 @@ export const surface = {
 export const focus = {
   ring: 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--border-accent-hover)] focus-visible:ring-offset-2 focus-visible:ring-offset-background',
 } as const;
+
+// ── Money contract ───────────────────────────────────────────────────────────
+// On a money/permissions console the value on screen MUST be the exact on-chain
+// bigint, never a lossy float. The bug this kills (F1-acct, F5-svc): bigints
+// pushed through `Number(formatUnits(...)).toLocaleString({maxFractionDigits:4})`
+// — which silently truncates precision and drops the unit, so an auditor can
+// neither trust nor copy the number.
+//
+// `formatMoney` is a *view* over the exact bigint: it returns a compact display
+// string for the cell, the full-precision decimal string for the copy
+// affordance, and the unit. The `<Money>` chrome component renders this view
+// with a copy-full-precision button. Surfaces format money ONE way: through
+// this contract.
+
+export type MoneyView = {
+  /** Compact, human display — e.g. `1,234.56` or `1.2M`. Lossy by design; the
+   *  cell stays scannable. Never the source of truth. */
+  display: string;
+  /** Full-precision decimal string — every significant digit the bigint holds.
+   *  This is what the copy affordance writes to the clipboard. */
+  full: string;
+  /** The raw on-chain integer as a string (wei-equivalent), for power users /
+   *  debugging. */
+  raw: string;
+  /** Token symbol / unit. Provenance always travels with the number. */
+  symbol: string;
+  /** Decimals used to scale `raw` → `full`. */
+  decimals: number;
+  /** True when the source value was missing — render an em-dash, not `0`. */
+  isEmpty: boolean;
+};
+
+export type FormatMoneyOptions = {
+  /** Token decimals. Default 18. */
+  decimals?: number;
+  /** Token symbol / unit. Default `''` (caller should always pass one). */
+  symbol?: string;
+  /** Significant fraction digits in the *compact display* only — `full` is
+   *  always complete. Default 4. */
+  displayDecimals?: number;
+  /** Collapse large magnitudes to K/M/B in the compact display. Default true. */
+  compact?: boolean;
+};
+
+const EM_DASH = '—';
+
+function trimTrailingZeros(decimalStr: string): string {
+  if (!decimalStr.includes('.')) return decimalStr;
+  return decimalStr.replace(/\.?0+$/, '');
+}
+
+/**
+ * Build a {@link MoneyView} from an exact on-chain bigint. Lossless: `full` is
+ * derived by integer-only division of the raw value, never by `Number()`.
+ *
+ *   formatMoney(1234567890000000000n, { decimals: 18, symbol: 'TNT' })
+ *   // → { display: '1.2346', full: '1.23456789', raw: '1234567890000000000',
+ *   //     symbol: 'TNT', decimals: 18, isEmpty: false }
+ */
+export function formatMoney(
+  value: bigint | null | undefined,
+  options: FormatMoneyOptions = {},
+): MoneyView {
+  const {
+    decimals = 18,
+    symbol = '',
+    displayDecimals = 4,
+    compact = true,
+  } = options;
+
+  if (value === null || value === undefined) {
+    return {
+      display: EM_DASH,
+      full: EM_DASH,
+      raw: '',
+      symbol,
+      decimals,
+      isEmpty: true,
+    };
+  }
+
+  const negative = value < 0n;
+  const abs = negative ? -value : value;
+  const base = 10n ** BigInt(decimals);
+  const whole = abs / base;
+  const fraction = abs % base;
+
+  // Lossless full-precision decimal string from integer arithmetic.
+  const fractionStr =
+    decimals > 0
+      ? fraction.toString().padStart(decimals, '0').replace(/0+$/, '')
+      : '';
+  const full =
+    (negative ? '-' : '') +
+    (fractionStr.length > 0
+      ? `${whole.toString()}.${fractionStr}`
+      : whole.toString());
+
+  // Compact display. We round the fractional part to `displayDecimals` for the
+  // cell only; the source of truth stays in `full`.
+  const wholeNum = whole; // bigint, may exceed Number range
+  let display: string;
+  if (compact && wholeNum >= 1_000_000n) {
+    const units: Array<[bigint, string]> = [
+      [1_000_000_000_000n, 'T'],
+      [1_000_000_000n, 'B'],
+      [1_000_000n, 'M'],
+    ];
+    const [unitBase, suffix] = units.find(([u]) => wholeNum >= u) ?? [
+      1_000_000n,
+      'M',
+    ];
+    // One decimal of the compacted magnitude, integer-only.
+    const scaled = (wholeNum * 10n) / unitBase;
+    const head = scaled / 10n;
+    const tenth = scaled % 10n;
+    display =
+      (negative ? '-' : '') +
+      (tenth > 0n
+        ? `${head.toString()}.${tenth.toString()}`
+        : head.toString()) +
+      suffix;
+  } else {
+    // wholeNum is < 1e6 here, safe to render with group separators.
+    const wholeDisplay = Number(wholeNum).toLocaleString('en-US');
+    const roundedFraction =
+      displayDecimals > 0 && fractionStr.length > 0
+        ? `.${trimTrailingZeros(
+            fraction
+              .toString()
+              .padStart(decimals, '0')
+              .slice(0, displayDecimals),
+          ).replace(/^\./, '')}`.replace(/\.$/, '')
+        : '';
+    const fracClean = roundedFraction === '.' ? '' : roundedFraction;
+    display = (negative ? '-' : '') + wholeDisplay + fracClean;
+  }
+
+  return {
+    display: display === '' ? '0' : display,
+    full,
+    raw: value.toString(),
+    symbol,
+    decimals,
+    isEmpty: false,
+  };
+}

--- a/libs/tangle-shared-ui/src/components/ConnectWalletButton/WalletDropdown.tsx
+++ b/libs/tangle-shared-ui/src/components/ConnectWalletButton/WalletDropdown.tsx
@@ -70,7 +70,7 @@ const WalletDropdown: FC<WalletDropdownProps> = ({
             variant="body1"
             fw="bold"
             component="p"
-            className="truncate dark:text-mono-0 sr-only sm:not-sr-only"
+            className="max-w-[96px] truncate font-mono text-sm text-inherit"
           >
             {shortenHex(accountAddress)}
           </Typography>

--- a/libs/tangle-shared-ui/src/context/IndexerStatusContext.tsx
+++ b/libs/tangle-shared-ui/src/context/IndexerStatusContext.tsx
@@ -21,6 +21,7 @@ import {
   getEnvioNetworkFromChainId,
   type EnvioNetwork,
 } from '../utils/executeEnvioGraphQL';
+import useNetworkStore from './useNetworkStore';
 
 // Data source type
 export type DataSource = 'graphql' | 'onchain' | 'unavailable';
@@ -48,7 +49,9 @@ const IndexerStatusContext = createContext<IndexerStatus | null>(null);
  * Should be placed high in the component tree, after WagmiProvider.
  */
 export const IndexerStatusProvider: FC<PropsWithChildren> = ({ children }) => {
-  const chainId = useChainId();
+  const wagmiChainId = useChainId();
+  const networkChainId = useNetworkStore((store) => store.network2?.evmChainId);
+  const chainId = networkChainId ?? wagmiChainId;
   const network = getEnvioNetworkFromChainId(chainId);
 
   // Use the shared health check hook
@@ -147,7 +150,9 @@ export const useIsGraphQLEnabled = (): {
  * Useful for hooks that may be used outside the provider.
  */
 export const useIndexerStatusStandalone = () => {
-  const chainId = useChainId();
+  const wagmiChainId = useChainId();
+  const networkChainId = useNetworkStore((store) => store.network2?.evmChainId);
+  const chainId = networkChainId ?? wagmiChainId;
   const { data: isHealthy, isLoading: isCheckingHealth } =
     useEnvioHealthCheckByChainId(chainId);
 

--- a/libs/tangle-shared-ui/src/data/graphql/useBlueprints.ts
+++ b/libs/tangle-shared-ui/src/data/graphql/useBlueprints.ts
@@ -4,7 +4,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { Address } from 'viem';
-import { useAccount, useChainId, usePublicClient } from 'wagmi';
+import { useChainId, usePublicClient } from 'wagmi';
 import {
   executeEnvioGraphQL,
   EnvioNetwork,
@@ -130,11 +130,12 @@ const toAppBlueprint = (bp: BlueprintWithMetadata): AppBlueprint => ({
   blueprintUi: bp.blueprintUi,
 });
 
+const BLUEPRINT_QUERY_CACHE_MS = 30 * 60_000;
+
 const useResolvedEnvioNetwork = (network?: EnvioNetwork) => {
   const chainId = useChainId();
-  const { isConnected } = useAccount();
   const networkChainId = useNetworkStore((store) => store.network2?.evmChainId);
-  const activeChainId = isConnected ? chainId : (networkChainId ?? chainId);
+  const activeChainId = networkChainId ?? chainId;
 
   return {
     activeChainId,
@@ -423,6 +424,8 @@ export const useBlueprints = (options?: {
     },
     enabled,
     staleTime: 60_000,
+    gcTime: BLUEPRINT_QUERY_CACHE_MS,
+    placeholderData: (previous) => previous,
   });
 };
 
@@ -492,6 +495,8 @@ export const useBlueprintsWithMetadata = (options?: {
     },
     enabled,
     staleTime: 300_000,
+    gcTime: BLUEPRINT_QUERY_CACHE_MS,
+    placeholderData: (previous) => previous,
   });
 };
 
@@ -597,6 +602,8 @@ export const useBlueprint = (
     },
     enabled: enabled && !!blueprintId,
     staleTime: 300_000,
+    gcTime: BLUEPRINT_QUERY_CACHE_MS,
+    placeholderData: (previous) => previous,
   });
 };
 
@@ -747,6 +754,8 @@ export const useBlueprintDetails = (
     },
     enabled: enabled && blueprintId !== undefined,
     staleTime: 60_000,
+    gcTime: BLUEPRINT_QUERY_CACHE_MS,
+    placeholderData: (previous) => previous,
   });
 
   return {

--- a/libs/tangle-shared-ui/src/utils/setupTest.ts
+++ b/libs/tangle-shared-ui/src/utils/setupTest.ts
@@ -37,6 +37,12 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
+Object.defineProperty(window, 'scrollTo', {
+  configurable: true,
+  writable: true,
+  value: vi.fn(),
+});
+
 process.on('unhandledRejection', (reason) => {
   console.log('FAILED TO HANDLE PROMISE REJECTION');
   console.log('REASON', reason);


### PR DESCRIPTION
## Summary

- Restores the original Tangle dapp chrome/action hierarchy in Tangle Cloud: visible wallet/network controls, no duplicate Blueprints top-nav title, normal button typography, and no action-dot artifacts.
- Rebuilds the Blueprints page as a list-first infrastructure catalog with default blueprint visuals, capacity/trust/source/usage columns, mobile cards, and tighter add-capacity drawer behavior.
- Hardens Cloud network/data behavior by normalizing local-preview default state to Base Sepolia, aligning audited-status and indexer-health reads with the selected network, and adding blueprint query cache retention.
- Adds a product-brief note and dated design-audit trace for the design decision and browser verification artifacts.

## Verification

- `NX_DAEMON=false NX_SKIP_NX_CACHE=true yarn nx typecheck tangle-cloud`
- `NX_DAEMON=false NX_SKIP_NX_CACHE=true yarn nx test tangle-cloud`
- `NX_DAEMON=false NX_SKIP_NX_CACHE=true yarn nx build tangle-cloud`
- `git merge-tree --write-tree origin/develop HEAD`
- Pre-push hook: full repo lint/test/build completed successfully
- Playwright browser audit screenshots in `/tmp/tangle-cloud-dapp-system-audit/`: desktop dark/light, mobile dark, instances, add-capacity drawer

Browser counters after fixes: `local8545=0`, `local8080=0`, Radix ref warnings `0`, italic controls `0`, measured overflow `0`.
