### PR TITLE
feat(tangle-cloud): restore shared blueprint gallery

### DIFF
--- a/apps/tangle-cloud/src/main.tsx
+++ b/apps/tangle-cloud/src/main.tsx
@@ -1,10 +1,5 @@
-import '@fontsource/geist-sans/400.css';
-import '@fontsource/geist-sans/500.css';
-import '@fontsource/geist-sans/600.css';
-import '@fontsource/geist-sans/700.css';
-import '@fontsource/geist-sans/800.css';
-import '@fontsource/geist-mono/400.css';
-import '@fontsource/geist-mono/500.css';
+import '@tangle-network/ui-components/tailwind.css';
+import '@tangle-network/ui-components/css/typography-fonts.css';
 import { StrictMode } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import * as ReactDOM from 'react-dom/client';

--- a/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/BlueprintListing.tsx
@@ -1,79 +1,25 @@
 import type { RowSelectionState } from '@tanstack/table-core';
-import {
-  Button,
-  Card,
-  CardContent,
-  Skeleton,
-} from '../../components/sandbox/SandboxUi';
-import { formatBlueprintName } from '../../components/blueprints/blueprintVisualUtils';
-import {
-  EmptyState,
-  FilterTray,
-  ResultList,
-  StatusPill,
-  ViewToggle,
-  statusToneFor,
-  type ResultView,
-} from '../../components/chrome';
-import {
-  enumCodec,
-  intCodec,
-  stringCodec,
-  useUrlState,
-} from '../../components/chrome/useUrlState';
-import { focus, typeRole } from '../../styles/chrome';
+import BlueprintGallery from '@tangle-network/tangle-shared-ui/components/blueprints/BlueprintGallery';
+import type { BlueprintItemProps } from '@tangle-network/tangle-shared-ui/components/blueprints/BlueprintGallery/types';
 import type { UseAllBlueprintsReturn } from '@tangle-network/tangle-shared-ui/data/graphql';
 import type { Blueprint } from '@tangle-network/tangle-shared-ui/types/blueprint';
+import { Button, Typography } from '@tangle-network/ui-components';
 import {
-  Dispatch,
-  FC,
-  ReactNode,
-  SetStateAction,
-  useCallback,
-  useDeferredValue,
-  useEffect,
+  type Dispatch,
+  type FC,
+  type ReactNode,
+  type SetStateAction,
   useMemo,
 } from 'react';
-import * as Popover from '@radix-ui/react-popover';
-import { useQueries } from '@tanstack/react-query';
-import { useChainId, usePublicClient } from 'wagmi';
-import type { Address } from 'viem';
-import { getContractsByChainId } from '@tangle-network/dapp-config/contracts';
-import BinaryUpgradeABI from '@tangle-network/tangle-shared-ui/abi/tangleBinaryUpgrade';
-import {
-  fetchAttestations,
-  fetchAuditorOnChain,
-} from '@tangle-network/tangle-shared-ui/data/blueprints/useBinaryVersions';
-import useNetworkStore from '@tangle-network/tangle-shared-ui/context/useNetworkStore';
-import {
-  AttestationKind,
-  type Auditor,
-} from '@tangle-network/tangle-shared-ui/blueprintApps/trustScore';
-import { auditorFallbackRegistry } from '../../auditors';
-import { Link, useNavigate } from 'react-router';
+import { useNavigate } from 'react-router';
 import { twMerge } from 'tailwind-merge';
-import { PagePath } from '../../types';
 import {
   dedupeBlueprintsByIdentity,
   type DedupedBlueprintRow,
 } from '../../blueprintApps/dedupe';
 import { BlueprintVisual } from '../../components/blueprints/BlueprintVisual';
-
-const PAGE_SIZE = 12;
-
-type AvailabilityFilter = 'all' | 'deployable' | 'capacity';
-type ManifestFilter = 'all' | 'verified' | 'fallback';
-type AuditFilter = 'all' | 'audited';
-type FilterOption<T extends string> = {
-  value: T;
-  label: string;
-  description?: string;
-};
-type CatalogStat = {
-  label: string;
-  value: number;
-  detail: string;
-};
+import { formatBlueprintName } from '../../components/blueprints/blueprintVisualUtils';
+import { PagePath } from '../../types';
 
 type Props = {
   rowSelection?: RowSelectionState;
@@ -86,57 +32,25 @@ type Props = {
 const pluralize = (label: string, count: number) =>
   count === 1 ? label : `${label}s`;
 
-const availabilityOptions: FilterOption<AvailabilityFilter>[] = [
-  { value: 'all', label: 'All' },
-  { value: 'deployable', label: 'Deployable' },
-  { value: 'capacity', label: 'Needs capacity' },
-];
-
-const sourceOptions: FilterOption<ManifestFilter>[] = [
-  { value: 'all', label: 'All sources' },
-  { value: 'verified', label: 'Pinned source' },
-  { value: 'fallback', label: 'Chain-only' },
-];
-
-const trustOptions: FilterOption<AuditFilter>[] = [
-  { value: 'all', label: 'All trust' },
-  { value: 'audited', label: 'Audited' },
-];
-
-/**
- * Title-case a single tag so the catalog renders consistent chips even if
- * the publisher's on-chain string is lowercase or mixed-case ("inference"
- * vs "Inference" vs "INFERENCE" all render as "Inference").
- */
 const normalizeTag = (raw: string): string => {
   const t = raw.trim();
   if (t.length === 0) return '';
-  // Preserve all-caps acronyms (TEE, LLM, RAG, ZK, AI, MEV).
   if (/^[A-Z]{2,5}$/.test(t)) return t;
+
   return t
     .split(/[\s-]+/)
     .filter(Boolean)
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(' ');
 };
 
-/**
- * Resolve a blueprint's category in three tiers, in order:
- *
- *   1. `blueprintUi.tags[0]` — publisher-declared, on-chain, authoritative.
- *      Multi-tag blueprints surface the first as the primary chip.
- *   2. `blueprint.category` — chain-derived, present on older metadata.
- *   3. Keyword inference from name + description — last resort.
- *
- * The keyword fallback is a fingerprint, not a taxonomy. It's narrow on
- * purpose: misclassifying a blueprint into the wrong bucket is worse than
- * dropping it into "Other" and asking the publisher to declare tags.
- */
 const getBlueprintCategory = (blueprint: Blueprint): string => {
-  const declaredTags = blueprint.blueprintUi?.tags ?? [];
-  for (const raw of declaredTags) {
-    const normalized = normalizeTag(raw);
-    if (normalized.length > 0) return normalized;
+  const declaredTag = blueprint.blueprintUi?.tags
+    ?.map(normalizeTag)
+    .find(Boolean);
+
+  if (declaredTag) {
+    return declaredTag;
   }
 
   const explicitCategory = blueprint.category?.trim();
@@ -152,15 +66,19 @@ const getBlueprintCategory = (blueprint: Blueprint): string => {
   ) {
     return 'Data';
   }
+
   if (/\b(agent|sandbox|automation|bot)\b/.test(searchable)) {
     return 'Agents';
   }
+
   if (/\b(trading|market|strategy|portfolio)\b/.test(searchable)) {
     return 'Trading';
   }
+
   if (/\b(training|train|fine[- ]?tune|checkpoint)\b/.test(searchable)) {
     return 'Training';
   }
+
   if (
     /\b(ai|llm|inference|model|image|video|voice|avatar|modal|gpu)\b/.test(
       searchable,
@@ -172,317 +90,53 @@ const getBlueprintCategory = (blueprint: Blueprint): string => {
   return 'Other';
 };
 
-/**
- * Full tag set for a blueprint — all publisher-declared tags + the primary
- * category (so search/filter still matches on the inferred bucket when the
- * publisher didn't declare it explicitly).
- */
-const getBlueprintTags = (blueprint: Blueprint): readonly string[] => {
-  const declared = (blueprint.blueprintUi?.tags ?? [])
-    .map(normalizeTag)
-    .filter((t) => t.length > 0);
-  if (declared.length > 0) return declared;
-  return [getBlueprintCategory(blueprint)];
-};
-
-const hasVerifiedManifest = (blueprint: Blueprint) =>
-  blueprint.metadataVerification?.status === 'verified';
-
-const matchesSearch = (blueprint: Blueprint, query: string) => {
-  if (query === '') {
-    return true;
-  }
-
-  const haystack = [
-    blueprint.name,
-    blueprint.description,
-    blueprint.author,
-    blueprint.category,
-    // Match against every declared tag, not just the primary category —
-    // a search for "tee" should hit a blueprint tagged ["Inference", "TEE"]
-    // even though its primary chip says Inference.
-    ...getBlueprintTags(blueprint),
-    blueprint.id.toString(),
-  ]
-    .filter(Boolean)
-    .join(' ')
-    .toLowerCase();
-
-  return haystack.includes(query);
-};
-
-const getBlueprintDescription = (blueprint: Blueprint) =>
-  blueprint.description?.trim() ||
-  'Service blueprint ready for deployment once capacity is available.';
-
 const getModeCount = (row: DedupedBlueprintRow) =>
   row.modes?.length ?? (row.aliases.length > 0 ? row.aliases.length + 1 : 1);
 
-/**
- * Multi-select category dropdown for the toolbar. Replaces the old
- * full-width segmented row — categories collapse into one pill with a
- * checkbox list, so search + categories + filters fit a single toolbar row.
- */
-const CategoryFilterMenu: FC<{
-  categories: { category: string; count: number }[];
-  selected: string[];
-  onToggle: (category: string) => void;
-  onClear: () => void;
-}> = ({ categories, selected, onToggle, onClear }) => {
-  const count = selected.length;
-  return (
-    <Popover.Root>
-      <Popover.Trigger asChild>
-        <button
-          type="button"
-          className={twMerge(
-            'inline-flex h-9 items-center gap-2 rounded-md border border-border bg-muted/30 px-3 font-sans text-sm font-medium text-foreground not-italic transition-colors hover:bg-[color:var(--bg-hover)]',
-            focus.ring,
-          )}
-        >
-          <span>Categories</span>
-          {count > 0 && (
-            <span
-              className={twMerge(
-                typeRole.mono,
-                'flex h-5 min-w-[20px] items-center justify-center rounded-full bg-[color:var(--border-accent)] px-1.5 text-[11px] text-foreground',
-              )}
-            >
-              {count}
-            </span>
-          )}
-        </button>
-      </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Content
-          align="end"
-          sideOffset={8}
-          className={twMerge(
-            'z-50 max-h-[60vh] w-64 overflow-y-auto rounded-lg border border-border bg-[color:var(--bg-card)] p-2 shadow-[var(--shadow-dropdown)]',
-            'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-          )}
-        >
-          <div className="mb-1 flex items-center justify-between px-2 py-1">
-            <span className={typeRole.label}>Categories</span>
-            {count > 0 && (
-              <button
-                type="button"
-                onClick={onClear}
-                className="font-sans text-xs text-muted-foreground not-italic hover:text-foreground"
-              >
-                Clear
-              </button>
-            )}
-          </div>
-          {categories.length === 0 ? (
-            <p className="px-2 py-3 text-sm text-muted-foreground">
-              No categories
-            </p>
-          ) : (
-            categories.map(({ category, count: c }) => {
-              const checked = selected.includes(category);
-              return (
-                <button
-                  key={category}
-                  type="button"
-                  onClick={() => onToggle(category)}
-                  className={twMerge(
-                    'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left font-sans text-sm text-foreground not-italic transition-colors hover:bg-[color:var(--bg-hover)]',
-                    focus.ring,
-                  )}
-                >
-                  <span className="flex items-center gap-2">
-                    <span
-                      className={twMerge(
-                        'flex h-4 w-4 items-center justify-center rounded border border-border text-[10px] leading-none',
-                        checked &&
-                          'border-[color:var(--border-accent-hover)] bg-[color:var(--border-accent)]',
-                      )}
-                    >
-                      {checked ? '✓' : ''}
-                    </span>
-                    {category}
-                  </span>
-                  <span className="font-mono text-[10px] text-muted-foreground">
-                    {c}
-                  </span>
-                </button>
-              );
-            })
-          )}
-        </Popover.Content>
-      </Popover.Portal>
-    </Popover.Root>
-  );
+const toGalleryItem = (
+  row: DedupedBlueprintRow,
+  onView: (blueprint: Blueprint) => void,
+  onDeploy: (blueprint: Blueprint) => void,
+  onRegister?: (blueprint: Blueprint) => void,
+): BlueprintItemProps => {
+  const { blueprint } = row;
+  const category = getBlueprintCategory(blueprint);
+  const modeCount = getModeCount(row);
+
+  return {
+    id: blueprint.id,
+    name: formatBlueprintName(blueprint.name),
+    author:
+      modeCount > 1
+        ? `${blueprint.author} · ${modeCount} ${pluralize('mode', modeCount)}`
+        : blueprint.author,
+    imgUrl: blueprint.imgUrl,
+    description: blueprint.description,
+    instancesCount: blueprint.instancesCount,
+    operatorsCount: blueprint.operatorsCount,
+    stakersCount: blueprint.stakersCount,
+    tvl: blueprint.tvl,
+    isBoosted: blueprint.isBoosted,
+    category,
+    onClick: () => onView(blueprint),
+    renderImage: () => (
+      <BlueprintVisual
+        blueprint={blueprint}
+        category={category}
+        compact
+        className="h-[72px] w-[72px] shrink-0 rounded-full"
+      />
+    ),
+    action: (
+      <BlueprintActions
+        blueprint={blueprint}
+        onView={onView}
+        onDeploy={onDeploy}
+        onRegister={onRegister}
+      />
+    ),
+  };
 };
-
-const BlueprintCatalogHeader: FC<{
-  matchCount: number;
-  totalCount: number;
-  stats: CatalogStat[];
-  searchQuery: string;
-  onSearchChange: (value: string) => void;
-  availabilityFilter: AvailabilityFilter;
-  onAvailabilityChange: (value: AvailabilityFilter) => void;
-  categories: { category: string; count: number }[];
-  selectedCategories: string[];
-  onCategoryToggle: (category: string) => void;
-  onClearCategories: () => void;
-  toolbarAction?: ReactNode;
-  showSelection: boolean;
-  view: ResultView;
-  onViewChange: (value: ResultView) => void;
-  filterTray: ReactNode;
-}> = ({
-  matchCount,
-  totalCount,
-  stats,
-  searchQuery,
-  onSearchChange,
-  availabilityFilter,
-  onAvailabilityChange,
-  categories,
-  selectedCategories,
-  onCategoryToggle,
-  onClearCategories,
-  toolbarAction,
-  showSelection,
-  view,
-  onViewChange,
-  filterTray,
-}) => (
-  <section className="overflow-hidden rounded-xl border border-border bg-[color:var(--bg-card)] shadow-[var(--shadow-card)]">
-    <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_minmax(360px,520px)]">
-      <div className="border-b border-border p-5 sm:p-6 lg:border-b-0 lg:border-r">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className={twMerge(typeRole.label, 'text-foreground/70')}>
-            Service catalog
-          </span>
-          <span className="rounded-full border border-[color:var(--border-accent)] bg-[var(--accent-surface-soft)] px-2 py-0.5 font-mono text-[11px] text-foreground">
-            {matchCount.toLocaleString()}
-            {matchCount !== totalCount && (
-              <span className="text-muted-foreground">
-                /{totalCount.toLocaleString()}
-              </span>
-            )}{' '}
-            {pluralize('blueprint', matchCount)}
-          </span>
-        </div>
-        <h1 className={twMerge(typeRole.display, 'mt-3 text-foreground')}>
-          Blueprints
-        </h1>
-        <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
-          Pick deployable services, find capacity gaps, and inspect trust
-          signals without leaving the catalog.
-        </p>
-      </div>
-
-      <div className="grid grid-cols-2 border-b border-border lg:border-b-0">
-        {stats.map((stat) => (
-          <div
-            key={stat.label}
-            className="min-h-[96px] border-b border-r border-border p-4 last:border-r-0 odd:last:border-r md:min-h-[112px]"
-          >
-            <div className="font-mono text-3xl leading-none tabular-nums text-foreground">
-              {stat.value.toLocaleString()}
-            </div>
-            <div className={twMerge(typeRole.label, 'mt-2')}>{stat.label}</div>
-            <div className="mt-1 text-xs leading-tight text-muted-foreground">
-              {stat.detail}
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-
-    <div className="flex flex-col gap-3 bg-[color:var(--bg-elevated)]/35 p-3 lg:flex-row lg:items-center">
-      <label className="relative min-w-0 flex-1">
-        <span className="sr-only">Search blueprints</span>
-        <input
-          value={searchQuery}
-          onChange={(event) => onSearchChange(event.target.value)}
-          placeholder="Search name, publisher, tag, or #id"
-          className={twMerge(
-            'h-11 w-full rounded-lg border border-border bg-[color:var(--bg-card)] px-4 font-sans text-sm text-foreground outline-none placeholder:text-muted-foreground/70',
-            focus.ring,
-          )}
-        />
-      </label>
-
-      <div className="flex flex-wrap items-center gap-2">
-        <FilterSegment
-          label="Availability"
-          options={availabilityOptions}
-          value={availabilityFilter}
-          onChange={onAvailabilityChange}
-        />
-        <CategoryFilterMenu
-          categories={categories}
-          selected={selectedCategories}
-          onToggle={onCategoryToggle}
-          onClear={onClearCategories}
-        />
-        {filterTray}
-        {!showSelection && <ViewToggle value={view} onChange={onViewChange} />}
-        {toolbarAction}
-      </div>
-    </div>
-  </section>
-);
-
-function FilterSegment<T extends string>({
-  label,
-  options,
-  value,
-  onChange,
-  stacked = false,
-}: {
-  label: string;
-  options: FilterOption<T>[];
-  value: T;
-  onChange: (value: T) => void;
-  stacked?: boolean;
-}) {
-  return (
-    <div className={twMerge(stacked ? 'space-y-2' : 'flex items-center gap-2')}>
-      {stacked && <span className={typeRole.label}>{label}</span>}
-      <div
-        role="radiogroup"
-        aria-label={label}
-        className={twMerge(
-          'inline-flex min-h-9 rounded-md border border-border bg-muted/30 p-0.5',
-          stacked && 'grid w-full grid-cols-1 gap-1 bg-transparent p-0',
-        )}
-      >
-        {options.map((option) => {
-          const active = option.value === value;
-          return (
-            <button
-              key={option.value}
-              type="button"
-              role="radio"
-              aria-checked={active}
-              onClick={() => onChange(option.value)}
-              className={twMerge(
-                'inline-flex min-h-8 items-center justify-center rounded px-3 font-sans text-sm font-medium not-italic transition-colors',
-                active
-                  ? 'bg-[color:var(--bg-hover)] text-foreground shadow-[inset_0_0_0_1px_var(--border-accent)]'
-                  : 'text-muted-foreground hover:text-foreground',
-                stacked && 'justify-start border border-border bg-muted/20',
-                stacked &&
-                  active &&
-                  'border-[color:var(--border-accent-hover)]',
-                focus.ring,
-              )}
-            >
-              <span>{option.label}</span>
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
 
 const BlueprintListing: FC<Props> = ({
   rowSelection,
@@ -495,522 +149,81 @@ const BlueprintListing: FC<Props> = ({
   onRetry,
 }) => {
   const navigate = useNavigate();
-  // Filter state lives in the URL — refresh persists the view, deep-links are
-  // shareable, the back button works. Defaults are omitted from the URL so a
-  // bare /blueprints stays clean. `replace: true` (in `useUrlState`) means
-  // every keystroke doesn't pollute the history stack.
-  const [page, setPage] = useUrlState('page', intCodec(0));
-  const [searchQuery, setSearchQuery] = useUrlState('q', stringCodec(''));
-  const [view, setView] = useUrlState<ResultView>(
-    'view',
-    enumCodec(['grid', 'list'] as const, 'grid'),
-  );
-  // Multi-select categories, comma-joined in the URL (empty = all). Single
-  // dropdown in the toolbar replaces the old full-width category row.
-  const [categoryParam, setCategoryParam] = useUrlState(
-    'category',
-    stringCodec(''),
-  );
-  const selectedCategories = useMemo(
-    () => (categoryParam ? categoryParam.split(',').filter(Boolean) : []),
-    [categoryParam],
-  );
-  const toggleCategory = useCallback(
-    (category: string) => {
-      const next = selectedCategories.includes(category)
-        ? selectedCategories.filter((c) => c !== category)
-        : [...selectedCategories, category];
-      setCategoryParam(next.join(','));
-    },
-    [selectedCategories, setCategoryParam],
-  );
-  const [availabilityFilter, setAvailabilityFilter] =
-    useUrlState<AvailabilityFilter>(
-      'avail',
-      enumCodec(['all', 'deployable', 'capacity'] as const, 'all'),
-    );
-  const [manifestFilter, setManifestFilter] = useUrlState<ManifestFilter>(
-    'source',
-    enumCodec(['all', 'verified', 'fallback'] as const, 'all'),
-  );
-  const [auditFilter, setAuditFilter] = useUrlState<AuditFilter>(
-    'trust',
-    enumCodec(['all', 'audited'] as const, 'all'),
-  );
-  const deferredSearchQuery = useDeferredValue(
-    searchQuery.trim().toLowerCase(),
-  );
 
-  const blueprintItems = useMemo(() => {
-    return Array.from(blueprints.values()).sort((a, b) => {
+  const rows = useMemo(() => {
+    const sorted = Array.from(blueprints.values()).sort((a, b) => {
       if (a.isBoosted && !b.isBoosted) return -1;
       if (!a.isBoosted && b.isBoosted) return 1;
       if (a.id === b.id) return 0;
       return a.id < b.id ? 1 : -1;
     });
+
+    return dedupeBlueprintsByIdentity(sorted);
   }, [blueprints]);
 
-  // Audited-status map keyed by blueprintId string. We pre-fetch in parallel
-  // so the "Audited only" toggle can filter before pagination — otherwise
-  // we'd render the wrong page count when toggling.
-  const auditedStatus = useAuditedStatusMap(blueprintItems.map((b) => b.id));
-
-  const categories = useMemo(() => {
-    const counts = new Map<string, number>();
-
-    for (const blueprint of blueprintItems) {
-      const category = getBlueprintCategory(blueprint);
-      counts.set(category, (counts.get(category) ?? 0) + 1);
-    }
-
-    return Array.from(counts.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([category, count]) => ({ category, count }));
-  }, [blueprintItems]);
-
-  const filteredBlueprints = useMemo(() => {
-    return blueprintItems.filter((blueprint) => {
-      if (!matchesSearch(blueprint, deferredSearchQuery)) {
-        return false;
-      }
-
-      if (
-        selectedCategories.length > 0 &&
-        !selectedCategories.includes(getBlueprintCategory(blueprint))
-      ) {
-        return false;
-      }
-
-      if (
-        availabilityFilter === 'deployable' &&
-        (blueprint.operatorsCount ?? 0) <= 0
-      ) {
-        return false;
-      }
-
-      if (
-        availabilityFilter === 'capacity' &&
-        (blueprint.operatorsCount ?? 0) >= 3
-      ) {
-        return false;
-      }
-
-      if (manifestFilter === 'verified' && !hasVerifiedManifest(blueprint)) {
-        return false;
-      }
-
-      if (manifestFilter === 'fallback' && hasVerifiedManifest(blueprint)) {
-        return false;
-      }
-
-      if (
-        auditFilter === 'audited' &&
-        !auditedStatus.get(blueprint.id.toString())
-      ) {
-        return false;
-      }
-
-      return true;
-    });
-  }, [
-    availabilityFilter,
-    auditFilter,
-    auditedStatus,
-    blueprintItems,
-    deferredSearchQuery,
-    manifestFilter,
-    selectedCategories,
-  ]);
-
-  // `useUrlState` returns a new setter each render; depending on it creates a
-  // page-reset loop. Filter values are the actual synchronization boundary.
-  useEffect(() => {
-    setPage(0);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    availabilityFilter,
-    auditFilter,
-    deferredSearchQuery,
-    manifestFilter,
-    categoryParam,
-  ]);
-
-  // Collapse the catalog by metadata identity (publisher.namespace,
-  // requestedSlug) AFTER filtering. Running dedupe before filter would
-  // mean a filter like "audited only" couldn't surface a sibling mode
-  // when the canonical one isn't audited. After filter, the dedupe runs
-  // on the survivor set — same set of cards the operator was about to
-  // see, just collapsed into one per identity.
-  const dedupedRows = useMemo(
-    () => dedupeBlueprintsByIdentity(filteredBlueprints),
-    [filteredBlueprints],
-  );
-  const allDedupedRows = useMemo(
-    () => dedupeBlueprintsByIdentity(blueprintItems),
-    [blueprintItems],
-  );
-  const catalogStats = useMemo<CatalogStat[]>(() => {
-    let deployable = 0;
-    let capacityNeeded = 0;
-    let pinnedSource = 0;
-    let audited = 0;
-
-    for (const { blueprint } of allDedupedRows) {
-      const operatorCount = blueprint.operatorsCount ?? 0;
-      if (operatorCount > 0) deployable += 1;
-      if (operatorCount < 3) capacityNeeded += 1;
-      if (hasVerifiedManifest(blueprint)) pinnedSource += 1;
-      if (auditedStatus.get(blueprint.id.toString()) === true) audited += 1;
-    }
-
-    return [
-      {
-        label: 'Deployable',
-        value: deployable,
-        detail: 'ready now',
-      },
-      {
-        label: 'Need capacity',
-        value: capacityNeeded,
-        detail: 'below target',
-      },
-      {
-        label: 'Pinned',
-        value: pinnedSource,
-        detail: 'verified source',
-      },
-      {
-        label: 'Audited',
-        value: audited,
-        detail: 'trust signal',
-      },
-    ];
-  }, [allDedupedRows, auditedStatus]);
-  const totalPages = Math.max(1, Math.ceil(dedupedRows.length / PAGE_SIZE));
-  const safePage = Math.min(page, totalPages - 1);
-  const visibleRows = dedupedRows.slice(
-    safePage * PAGE_SIZE,
-    safePage * PAGE_SIZE + PAGE_SIZE,
-  );
-  const hasActiveFilters =
-    searchQuery.trim() !== '' ||
-    selectedCategories.length > 0 ||
-    availabilityFilter !== 'all' ||
-    manifestFilter !== 'all' ||
-    auditFilter !== 'all';
-
-  const showSelection =
-    typeof rowSelection !== 'undefined' &&
-    typeof onRowSelectionChange === 'function';
-  const effectiveView = showSelection ? 'grid' : view;
-
-  const listColumns = useMemo(
-    () => [
-      {
-        header: 'Blueprint',
-        className: 'min-w-0 flex-[2.4]',
-        render: (row: DedupedBlueprintRow) => (
-          <BlueprintIdentitySummary row={row} />
+  const galleryItems = useMemo(
+    () =>
+      rows.map((row) =>
+        toGalleryItem(
+          row,
+          (blueprint) => navigate(`${PagePath.BLUEPRINTS}/${blueprint.id}`),
+          (blueprint) =>
+            navigate(`${PagePath.BLUEPRINTS}/${blueprint.id}/deploy`),
+          onRegisterBlueprint,
         ),
-      },
-      {
-        header: 'Capacity',
-        className: 'w-40',
-        hideBelow: 'md' as const,
-        render: (row: DedupedBlueprintRow) => (
-          <BlueprintCapacityCell
-            operatorCount={row.blueprint.operatorsCount ?? 0}
-          />
-        ),
-      },
-      {
-        header: 'Trust',
-        className: 'w-28',
-        hideBelow: 'md' as const,
-        render: (row: DedupedBlueprintRow) => {
-          const audited =
-            auditedStatus.get(row.blueprint.id.toString()) ?? false;
-          return (
-            <StatusPill
-              tone={statusToneFor('audit', audited ? 'Audited' : 'Unaudited')}
-              dot={false}
-            >
-              {audited ? 'Audited' : 'Unaudited'}
-            </StatusPill>
-          );
-        },
-      },
-      {
-        header: 'Source',
-        className: 'w-32',
-        hideBelow: 'lg' as const,
-        render: (row: DedupedBlueprintRow) => {
-          const verified = hasVerifiedManifest(row.blueprint);
-          return (
-            <StatusPill
-              tone={verified ? 'success' : 'neutral'}
-              dot={false}
-              className="text-[12px]"
-            >
-              {verified ? 'Pinned' : 'Chain-only'}
-            </StatusPill>
-          );
-        },
-      },
-      {
-        header: 'Usage',
-        className: 'w-24 justify-end',
-        hideBelow: 'lg' as const,
-        render: (row: DedupedBlueprintRow) => (
-          <span className="font-mono text-[13px] tabular-nums text-muted-foreground">
-            {(row.blueprint.instancesCount ?? 0).toLocaleString()}
-          </span>
-        ),
-      },
-      {
-        header: 'Actions',
-        className: 'w-52 justify-end sm:w-56',
-        render: (row: DedupedBlueprintRow) => {
-          const { blueprint } = row;
-          const blueprintHref = `${PagePath.BLUEPRINTS}/${blueprint.id.toString()}`;
-          const hasOperators = (blueprint.operatorsCount ?? 0) > 0;
-
-          return (
-            <div className="flex w-full justify-end gap-2">
-              {hasOperators && (
-                <Link
-                  to={`${blueprintHref}/deploy`}
-                  onClick={(event) => event.stopPropagation()}
-                  className={catalogPrimaryActionClass}
-                >
-                  Deploy
-                </Link>
-              )}
-              <RegisterCapacityButton
-                blueprint={blueprint}
-                onRegister={onRegisterBlueprint}
-                isPrimary={!hasOperators}
-              />
-            </div>
-          );
-        },
-      },
-    ],
-    [auditedStatus, onRegisterBlueprint],
+      ),
+    [navigate, onRegisterBlueprint, rows],
   );
 
-  if (isLoading && blueprintItems.length === 0) {
-    return (
-      <div className="space-y-5">
-        <BlueprintCatalogHeader
-          matchCount={0}
-          totalCount={0}
-          stats={catalogStats}
-          searchQuery={searchQuery}
-          onSearchChange={setSearchQuery}
-          availabilityFilter={availabilityFilter}
-          onAvailabilityChange={setAvailabilityFilter}
-          categories={categories}
-          selectedCategories={selectedCategories}
-          onCategoryToggle={toggleCategory}
-          onClearCategories={() => setCategoryParam('')}
-          toolbarAction={toolbarAction}
-          showSelection={showSelection}
-          view={view}
-          onViewChange={setView}
-          filterTray={null}
-        />
-        <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
-          {Array.from({ length: 6 }).map((_, idx) => (
-            <Skeleton key={idx} className="h-[360px] rounded-lg" />
-          ))}
-        </div>
-      </div>
-    );
-  }
-
-  if (error && blueprintItems.length === 0) {
-    return (
-      <Card variant="sandbox" className="border-destructive/20">
-        <CardContent className="flex min-h-40 flex-col items-center justify-center gap-3 p-8 text-center">
-          <div>
-            <p className="font-semibold text-foreground">
-              Unable to refresh blueprints
-            </p>
-            <p className="mt-1 max-w-2xl text-muted-foreground text-sm">
-              {error.message}
-            </p>
-          </div>
-          {onRetry !== undefined && (
-            <Button variant="outline" size="sm" onClick={onRetry}>
-              Retry
-            </Button>
-          )}
-        </CardContent>
-      </Card>
-    );
-  }
-
-  if (blueprintItems.length === 0) {
-    return (
-      <EmptyState
-        kind="no-data"
-        title="No blueprints on this network"
-        description="Add capacity, switch networks, or publish a blueprint to make services available for deployment."
-      />
-    );
-  }
-
-  const trayFilterCount =
-    (manifestFilter !== 'all' ? 1 : 0) + (auditFilter !== 'all' ? 1 : 0);
-
-  const resetAllFilters = () => {
-    setSearchQuery('');
-    setCategoryParam('');
-    setAvailabilityFilter('all');
-    setManifestFilter('all');
-    setAuditFilter('all');
-  };
+  const hasCachedData = rows.length > 0;
 
   return (
     <div className="space-y-5">
-      <BlueprintCatalogHeader
-        matchCount={dedupedRows.length}
-        totalCount={allDedupedRows.length}
-        stats={catalogStats}
-        searchQuery={searchQuery}
-        onSearchChange={setSearchQuery}
-        availabilityFilter={availabilityFilter}
-        onAvailabilityChange={setAvailabilityFilter}
-        categories={categories}
-        selectedCategories={selectedCategories}
-        onCategoryToggle={toggleCategory}
-        onClearCategories={() => setCategoryParam('')}
-        toolbarAction={toolbarAction}
-        showSelection={showSelection}
-        view={view}
-        onViewChange={setView}
-        filterTray={
-          <FilterTray
-            activeCount={trayFilterCount}
-            onClear={resetAllFilters}
-            trayTitle="Source and trust"
+      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div>
+          <Typography variant="h1" className="text-mono-200 dark:text-mono-0">
+            Blueprints
+          </Typography>
+
+          <Typography
+            variant="body1"
+            className="mt-2 max-w-2xl text-mono-120 dark:text-mono-80"
           >
-            <FilterSegment
-              label="Source"
-              options={sourceOptions}
-              value={manifestFilter}
-              onChange={setManifestFilter}
-              stacked
-            />
-
-            <FilterSegment
-              label="Trust"
-              options={trustOptions}
-              value={auditFilter}
-              onChange={setAuditFilter}
-              stacked
-            />
-          </FilterTray>
-        }
-      />
-
-      {error && (
-        <div className="rounded-lg border border-[color:var(--md3-warning,#f59e0b)]/35 bg-[color:var(--md3-warning,#f59e0b)]/10 px-4 py-3 text-sm text-[color:var(--surface-warning-text,var(--md3-warning,#f59e0b))]">
-          Showing cached blueprint data. Latest refresh failed: {error.message}
+            {rows.length.toLocaleString()} deployable service{' '}
+            {pluralize('blueprint', rows.length)}
+          </Typography>
         </div>
-      )}
 
-      {dedupedRows.length === 0 ? (
-        <EmptyState
-          kind="no-match"
-          description="Try a broader category, remove the source filter, or search by the blueprint name, publisher, or protocol ID."
-          primary={
-            hasActiveFilters && (
-              <Button onClick={resetAllFilters}>Clear all filters</Button>
-            )
-          }
-        />
-      ) : effectiveView === 'list' ? (
-        <>
-          <div className="space-y-3 md:hidden">
-            {visibleRows.map((row) => (
-              <MobileBlueprintRow
-                key={row.blueprint.id.toString()}
-                row={row}
-                isAudited={
-                  auditedStatus.get(row.blueprint.id.toString()) ?? false
-                }
-                onRegister={onRegisterBlueprint}
-              />
-            ))}
+        {toolbarAction !== undefined && (
+          <div className="flex shrink-0 justify-start md:justify-end">
+            {toolbarAction}
           </div>
-          <ResultList
-            className="hidden md:block"
-            items={visibleRows}
-            columns={listColumns}
-            rowKey={(row) => row.blueprint.id.toString()}
-            onRowClick={(row) =>
-              navigate(`${PagePath.BLUEPRINTS}/${row.blueprint.id.toString()}`)
-            }
-          />
-        </>
-      ) : (
-        <div className="results-grid grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {visibleRows.map((row) => (
-            <BlueprintCard
-              key={row.blueprint.id.toString()}
-              row={row}
-              isSelectable={showSelection}
-              isSelected={rowSelection?.[row.blueprint.id.toString()] === true}
-              isAudited={
-                auditedStatus.get(row.blueprint.id.toString()) ?? false
-              }
-              onSelectionChange={(isSelected) => {
-                onRowSelectionChange?.((previous) => ({
-                  ...previous,
-                  [row.blueprint.id.toString()]: isSelected,
-                }));
-              }}
-              onRegister={onRegisterBlueprint}
-            />
-          ))}
+        )}
+      </div>
+
+      {error && hasCachedData && (
+        <div className="rounded-xl border border-yellow-50/40 bg-yellow-10/20 px-4 py-3 text-sm font-medium text-yellow-90 dark:border-yellow-70/40 dark:bg-yellow-120/30 dark:text-yellow-30">
+          Showing cached blueprints. Latest refresh failed: {error.message}
+          {onRetry !== undefined && (
+            <Button
+              variant="link"
+              size="sm"
+              className="ml-3 inline-flex p-0"
+              onClick={onRetry}
+            >
+              Retry
+            </Button>
+          )}
         </div>
       )}
 
-      <div className="flex flex-col gap-3 border-border border-t pt-4 text-muted-foreground text-sm sm:flex-row sm:items-center sm:justify-between">
-        <span>
-          Showing {dedupedRows.length === 0 ? 0 : safePage * PAGE_SIZE + 1}-
-          {Math.min((safePage + 1) * PAGE_SIZE, dedupedRows.length)} of{' '}
-          {dedupedRows.length} {pluralize('blueprint', dedupedRows.length)}
-        </span>
-
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={safePage === 0}
-            onClick={() => setPage((current) => Math.max(0, current - 1))}
-          >
-            Previous
-          </Button>
-
-          <span className="px-2 font-mono text-muted-foreground text-xs">
-            {safePage + 1}/{totalPages}
-          </span>
-
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={safePage >= totalPages - 1}
-            onClick={() =>
-              setPage((current) => Math.min(totalPages - 1, current + 1))
-            }
-          >
-            Next
-          </Button>
-        </div>
-      </div>
+      <BlueprintGallery
+        blueprints={galleryItems}
+        isLoading={isLoading && !hasCachedData}
+        error={hasCachedData ? null : error}
+        rowSelection={rowSelection}
+        onRowSelectionChange={onRowSelectionChange}
+      />
     </div>
   );
 };
@@ -1019,492 +232,49 @@ BlueprintListing.displayName = 'BlueprintListing';
 
 export default BlueprintListing;
 
-/**
- * Per-blueprint audited-status fetcher. For each id, reads the active
- * version + that version's attestation list, then determines whether at
- * least one non-revoked, non-expired, non-SELF attestation came from a
- * known active auditor.
- *
- * Returns a Map<idString, boolean> so the parent filter can stay synchronous.
- *
- * Each query is keyed identically to `useBlueprintTrust` in
- * `BlueprintTrustChip.tsx`, so the card chip + the listing filter share
- * the same react-query cache entry — no duplicate chain reads.
- */
-const useAuditedStatusMap = (blueprintIds: bigint[]): Map<string, boolean> => {
-  const wagmiChainId = useChainId();
-  const networkChainId = useNetworkStore((store) => store.network2?.evmChainId);
-  const chainId = networkChainId ?? wagmiChainId;
-  const publicClient = usePublicClient({ chainId });
-  const fallback = useMemo(() => auditorFallbackRegistry(), []);
-
-  const queries = useQueries({
-    queries: blueprintIds.map((blueprintId) => ({
-      queryKey: ['tangle', 'blueprint-trust', chainId, blueprintId.toString()],
-      queryFn: async (): Promise<{
-        score: number;
-        hasCriticalFinding: boolean;
-        hasAuditedAttestation: boolean;
-        attestationCount: number;
-      }> => {
-        if (!publicClient) {
-          return {
-            score: 0,
-            hasCriticalFinding: false,
-            hasAuditedAttestation: false,
-            attestationCount: 0,
-          };
-        }
-        let tangle: Address;
-        try {
-          tangle = getContractsByChainId(chainId).tangle as Address;
-        } catch {
-          return {
-            score: 0,
-            hasCriticalFinding: false,
-            hasAuditedAttestation: false,
-            attestationCount: 0,
-          };
-        }
-        const [count, activeId] = await Promise.all([
-          publicClient.readContract({
-            address: tangle,
-            abi: BinaryUpgradeABI,
-            functionName: 'getBinaryVersionCount',
-            args: [blueprintId],
-          }) as Promise<bigint>,
-          publicClient.readContract({
-            address: tangle,
-            abi: BinaryUpgradeABI,
-            functionName: 'getActiveBinaryVersionId',
-            args: [blueprintId],
-          }) as Promise<bigint>,
-        ]);
-        if (count === 0n) {
-          return {
-            score: 0,
-            hasCriticalFinding: false,
-            hasAuditedAttestation: false,
-            attestationCount: 0,
-          };
-        }
-        const attestations = await fetchAttestations(
-          publicClient,
-          chainId,
-          blueprintId,
-          BigInt(activeId),
-        );
-        if (attestations.length === 0) {
-          return {
-            score: 0,
-            hasCriticalFinding: false,
-            hasAuditedAttestation: false,
-            attestationCount: 0,
-          };
-        }
-        const uniqueAttesters = Array.from(
-          new Set(attestations.map((a) => a.attester.toLowerCase())),
-        ) as Address[];
-        const auditors = await Promise.all(
-          uniqueAttesters.map(async (address): Promise<Auditor | null> => {
-            const onChain = await fetchAuditorOnChain(
-              publicClient,
-              chainId,
-              address,
-            );
-            if (onChain !== null && onChain.active) return onChain;
-            const entry = fallback[address];
-            if (entry) {
-              return {
-                name: entry.name,
-                metadataUri: entry.metadataUri,
-                weight: entry.weight,
-                tier: entry.tier,
-                active: entry.active,
-                admittedAt: 0n,
-              };
-            }
-            return onChain;
-          }),
-        );
-        const auditorMap = new Map<string, Auditor | null>();
-        uniqueAttesters.forEach((address, idx) => {
-          auditorMap.set(address, auditors[idx] ?? null);
-        });
-        const nowSeconds = Math.floor(Date.now() / 1000);
-        const hasAuditedAttestation = attestations.some((row) => {
-          if (row.revoked) return false;
-          if (row.expiresAt !== 0n && row.expiresAt <= BigInt(nowSeconds)) {
-            return false;
-          }
-          if (row.kind === AttestationKind.SELF) return false;
-          const auditor = auditorMap.get(row.attester.toLowerCase());
-          return auditor !== null && auditor !== undefined && auditor.active;
-        });
-        return {
-          score: 0,
-          hasCriticalFinding: false,
-          hasAuditedAttestation,
-          attestationCount: attestations.length,
-        };
-      },
-      enabled: publicClient !== undefined,
-      staleTime: 60_000,
-    })),
-  });
-
-  const map = new Map<string, boolean>();
-  blueprintIds.forEach((id, idx) => {
-    map.set(id.toString(), queries[idx]?.data?.hasAuditedAttestation ?? false);
-  });
-  return map;
-};
-
-const BlueprintIdentitySummary = ({ row }: { row: DedupedBlueprintRow }) => {
-  const { blueprint } = row;
-  const category = getBlueprintCategory(blueprint);
-  const modeCount = getModeCount(row);
-
-  return (
-    <div className="flex min-w-0 items-center gap-4">
-      <BlueprintVisual
-        blueprint={blueprint}
-        category={category}
-        compact
-        className="h-16 w-16 shrink-0 rounded-lg"
-      />
-      <div className="min-w-0">
-        <div className="flex min-w-0 items-center gap-2">
-          <span className="truncate font-display text-base font-bold leading-tight text-foreground">
-            {formatBlueprintName(blueprint.name)}
-          </span>
-          <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
-            #{blueprint.id.toString()}
-          </span>
-        </div>
-        <p className="mt-1 line-clamp-1 text-sm leading-snug text-muted-foreground">
-          {getBlueprintDescription(blueprint)}
-        </p>
-        <div className="mt-2 flex flex-wrap items-center gap-1.5">
-          <BlueprintMetaChip>{category}</BlueprintMetaChip>
-          {modeCount > 1 && (
-            <BlueprintMetaChip>
-              {modeCount} {pluralize('mode', modeCount)}
-            </BlueprintMetaChip>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-};
-
-const BlueprintMetaChip = ({ children }: { children: ReactNode }) => (
-  <span className="rounded-md border border-border bg-[color:var(--bg-elevated)] px-2 py-1 font-sans text-xs font-medium leading-none text-muted-foreground not-italic">
-    {children}
-  </span>
-);
-
-const BlueprintCapacityCell = ({
-  operatorCount,
-}: {
-  operatorCount: number;
-}) => {
-  const hasOperators = operatorCount > 0;
-
-  return (
-    <div className="flex min-w-0 flex-col items-start gap-1.5">
-      <BlueprintCapacitySignal operatorCount={operatorCount} />
-      <span className="font-mono text-[12px] tabular-nums text-muted-foreground">
-        {hasOperators
-          ? `${operatorCount.toLocaleString()} registered`
-          : '0 registered'}
-      </span>
-    </div>
-  );
-};
-
-const BlueprintCapacitySignal = ({
-  operatorCount,
-}: {
-  operatorCount: number;
-}) => {
-  const hasOperators = operatorCount > 0;
-
-  return (
-    <StatusPill
-      tone={statusToneFor(
-        'availability',
-        hasOperators ? 'Available' : 'Limited',
-      )}
-      dot={false}
-      className="px-2.5 py-1 text-xs"
-    >
-      {hasOperators ? 'Ready' : 'Needs capacity'}
-    </StatusPill>
-  );
-};
-
-const catalogActionClass =
-  'inline-flex min-h-8 flex-1 items-center justify-center rounded-md border border-border bg-muted/30 px-3 py-1.5 text-center font-sans text-xs font-semibold text-foreground not-italic transition-colors before:hidden after:hidden marker:hidden hover:bg-[color:var(--bg-hover)] whitespace-nowrap';
-
-const catalogPrimaryActionClass =
-  'inline-flex min-h-8 flex-1 items-center justify-center rounded-md bg-primary px-3 py-1.5 text-center font-sans text-xs font-semibold text-primary-foreground not-italic transition-colors before:hidden after:hidden marker:hidden hover:bg-primary/90 whitespace-nowrap';
-
-const MobileBlueprintRow = ({
-  row,
-  isAudited,
-  onRegister,
-}: {
-  row: DedupedBlueprintRow;
-  isAudited: boolean;
-  onRegister?: (blueprint: Blueprint) => void;
-}) => {
-  const { blueprint } = row;
-  const blueprintHref = `${PagePath.BLUEPRINTS}/${blueprint.id.toString()}`;
-  const operatorCount = blueprint.operatorsCount ?? 0;
-  const hasOperators = operatorCount > 0;
-  const description = getBlueprintDescription(blueprint);
-
-  return (
-    <article className="rounded-xl border border-border bg-[color:var(--bg-card)] p-4 shadow-[var(--shadow-card)]">
-      <Link
-        to={blueprintHref}
-        className={twMerge('flex min-w-0 gap-3', focus.ring)}
-      >
-        <BlueprintVisual
-          blueprint={blueprint}
-          category={getBlueprintCategory(blueprint)}
-          compact
-          className="h-16 w-16 shrink-0 rounded-lg"
-        />
-        <div className="min-w-0 flex-1">
-          <div className="flex min-w-0 items-center gap-2">
-            <h3 className="truncate font-display text-base font-bold leading-tight tracking-normal text-foreground">
-              {formatBlueprintName(blueprint.name)}
-            </h3>
-            <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
-              #{blueprint.id.toString()}
-            </span>
-          </div>
-          <p className="mt-1 line-clamp-2 text-sm leading-snug text-muted-foreground">
-            {description}
-          </p>
-        </div>
-      </Link>
-
-      <div className="mt-3 flex flex-wrap items-center gap-2">
-        <BlueprintCapacitySignal operatorCount={operatorCount} />
-        <StatusPill
-          tone={statusToneFor('audit', isAudited ? 'Audited' : 'Unaudited')}
-          dot={false}
-          className="text-[12px]"
-        >
-          {isAudited ? 'Audited' : 'Unaudited'}
-        </StatusPill>
-        <StatusPill
-          tone={hasVerifiedManifest(blueprint) ? 'success' : 'neutral'}
-          dot={false}
-          className="text-[12px]"
-        >
-          {hasVerifiedManifest(blueprint) ? 'Pinned' : 'Chain-only'}
-        </StatusPill>
-      </div>
-
-      <div className="mt-3 flex gap-2">
-        {hasOperators && (
-          <Link
-            to={`${blueprintHref}/deploy`}
-            className={catalogPrimaryActionClass}
-          >
-            Deploy
-          </Link>
-        )}
-        <RegisterCapacityButton
-          blueprint={blueprint}
-          onRegister={onRegister}
-          isPrimary={!hasOperators}
-        />
-      </div>
-    </article>
-  );
-};
-
-const BlueprintCard = ({
-  row,
-  isSelectable,
-  isSelected,
-  isAudited,
-  onSelectionChange,
-  onRegister,
-}: {
-  row: DedupedBlueprintRow;
-  isSelectable: boolean;
-  isSelected: boolean;
-  isAudited: boolean;
-  onSelectionChange: (isSelected: boolean) => void;
-  onRegister?: (blueprint: Blueprint) => void;
-}) => {
-  const { blueprint } = row;
-  const description = getBlueprintDescription(blueprint);
-  const blueprintHref = `${PagePath.BLUEPRINTS}/${blueprint.id.toString()}`;
-  const operatorCount = blueprint.operatorsCount ?? 0;
-  const hasOperators = operatorCount > 0;
-  const isFeatured = blueprint.isBoosted === true || isAudited;
-  const displayName = formatBlueprintName(blueprint.name);
-  const modeCount = getModeCount(row);
-  const sourcePinned = hasVerifiedManifest(blueprint);
-  const category = getBlueprintCategory(blueprint);
-  return (
-    <div
-      className={twMerge(
-        'group relative grid min-h-[260px] grid-cols-[88px_minmax(0,1fr)] gap-3 overflow-hidden rounded-xl border border-border bg-[color:var(--bg-card)] p-3 shadow-[var(--shadow-card)] transition-all sm:grid-cols-[112px_minmax(0,1fr)] sm:gap-4 sm:p-4',
-        'hover:-translate-y-px hover:border-[color:var(--border-accent-hover)] hover:shadow-[var(--shadow-hover)]',
-        isFeatured && 'ring-1 ring-[color:var(--border-accent)]',
-        isSelected &&
-          'border-[color:var(--border-accent-hover)] shadow-[0_0_0_1px_var(--border-accent-hover)]',
-      )}
-    >
-      <Link
-        to={blueprintHref}
-        className="absolute inset-0 z-10"
-        aria-label={`Open ${blueprint.name}`}
-      />
-
-      <BlueprintVisual
-        blueprint={blueprint}
-        category={category}
-        className="h-full min-h-[190px] rounded-lg sm:min-h-[196px]"
-      />
-
-      <span
-        aria-hidden
-        className="pointer-events-none absolute right-4 top-4 select-none font-mono text-xs tabular-nums text-foreground/15"
-      >
-        #{blueprint.id.toString().padStart(3, '0')}
-      </span>
-
-      {isSelectable && (
-        <label
-          className="absolute left-4 top-4 z-20 flex h-7 w-7 cursor-pointer items-center justify-center rounded border border-border bg-background/80 backdrop-blur transition-colors hover:bg-background"
-          onClick={(event) => event.stopPropagation()}
-        >
-          <span className="sr-only">Select {blueprint.name}</span>
-          <input
-            type="checkbox"
-            checked={isSelected}
-            onChange={(event) => onSelectionChange(event.target.checked)}
-            className="h-3.5 w-3.5 accent-[var(--border-accent-hover)]"
-          />
-        </label>
-      )}
-
-      <div className={twMerge('flex min-w-0 flex-col', isSelectable && 'pl-8')}>
-        <div className="min-w-0 pr-10">
-          <div className="mb-2 flex flex-wrap items-center gap-1.5">
-            <BlueprintMetaChip>{category}</BlueprintMetaChip>
-            {modeCount > 1 && (
-              <BlueprintMetaChip>
-                {modeCount} {pluralize('mode', modeCount)}
-              </BlueprintMetaChip>
-            )}
-          </div>
-          <h3 className="line-clamp-2 font-display text-lg font-bold leading-tight tracking-normal text-foreground">
-            {displayName}
-          </h3>
-          <p className="mt-2 line-clamp-3 text-sm leading-5 text-muted-foreground">
-            {description}
-          </p>
-        </div>
-
-        <div className="mt-4 grid grid-cols-3 gap-2">
-          <div className="rounded-lg border border-border bg-[color:var(--bg-elevated)]/45 p-2">
-            <div className="font-mono text-base font-semibold tabular-nums text-foreground">
-              {operatorCount.toLocaleString()}
-            </div>
-            <div className={twMerge(typeRole.label, 'mt-1')}>Ops</div>
-          </div>
-          <div className="rounded-lg border border-border bg-[color:var(--bg-elevated)]/45 p-2">
-            <div className="font-mono text-base font-semibold tabular-nums text-foreground">
-              {(blueprint.instancesCount ?? 0).toLocaleString()}
-            </div>
-            <div className={twMerge(typeRole.label, 'mt-1')}>Use</div>
-          </div>
-          <div className="rounded-lg border border-border bg-[color:var(--bg-elevated)]/45 p-2">
-            <div className="font-mono text-base font-semibold tabular-nums text-foreground">
-              {sourcePinned ? 'Yes' : 'No'}
-            </div>
-            <div className={twMerge(typeRole.label, 'mt-1')}>Source</div>
-          </div>
-        </div>
-
-        <div className="mt-3 flex flex-wrap items-center gap-2">
-          <BlueprintCapacitySignal operatorCount={operatorCount} />
-          <StatusPill
-            tone={statusToneFor('audit', isAudited ? 'Audited' : 'Unaudited')}
-            dot={false}
-            className="px-2.5 py-1 text-xs"
-          >
-            {isAudited ? 'Audited' : 'Unaudited'}
-          </StatusPill>
-          <StatusPill
-            tone={sourcePinned ? 'success' : 'neutral'}
-            dot={false}
-            className="px-2.5 py-1 text-xs"
-          >
-            {sourcePinned ? 'Pinned source' : 'Chain-only'}
-          </StatusPill>
-        </div>
-
-        <div
-          className={twMerge('actions relative z-20 mt-auto flex gap-2 pt-4')}
-        >
-          {hasOperators ? (
-            <>
-              <Link
-                to={`${blueprintHref}/deploy`}
-                onClick={(e) => e.stopPropagation()}
-                className={catalogPrimaryActionClass}
-              >
-                Deploy
-              </Link>
-              <RegisterCapacityButton
-                blueprint={blueprint}
-                onRegister={onRegister}
-              />
-            </>
-          ) : (
-            <RegisterCapacityButton
-              blueprint={blueprint}
-              onRegister={onRegister}
-              isPrimary
-            />
-          )}
-        </div>
-      </div>
-    </div>
-  );
-};
-
-const RegisterCapacityButton = ({
-  blueprint,
-  onRegister,
-  isPrimary = false,
-}: {
+const BlueprintActions: FC<{
   blueprint: Blueprint;
+  onView: (blueprint: Blueprint) => void;
+  onDeploy: (blueprint: Blueprint) => void;
   onRegister?: (blueprint: Blueprint) => void;
-  isPrimary?: boolean;
-}) => (
-  <button
-    type="button"
-    className={twMerge(
-      isPrimary ? catalogPrimaryActionClass : catalogActionClass,
-    )}
-    onClick={(event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      onRegister?.(blueprint);
-    }}
-  >
-    Add capacity
-  </button>
-);
+}> = ({ blueprint, onView, onDeploy, onRegister }) => {
+  const hasOperators = (blueprint.operatorsCount ?? 0) > 0;
+
+  return (
+    <>
+      <Button
+        variant="secondary"
+        size="sm"
+        className="min-w-0 flex-1 px-3"
+        onClick={() => onView(blueprint)}
+      >
+        View
+      </Button>
+
+      {hasOperators && (
+        <Button
+          variant="primary"
+          size="sm"
+          className="min-w-0 flex-1 px-3"
+          onClick={() => onDeploy(blueprint)}
+        >
+          Deploy
+        </Button>
+      )}
+
+      {onRegister !== undefined && (
+        <Button
+          variant={hasOperators ? 'utility' : 'primary'}
+          size="sm"
+          className={twMerge(
+            'min-w-0 flex-1 px-3',
+            hasOperators && 'uppercase',
+          )}
+          onClick={() => onRegister(blueprint)}
+        >
+          Add capacity
+        </Button>
+      )}
+    </>
+  );
+};

--- a/apps/tangle-cloud/src/pages/blueprints/page.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/page.tsx
@@ -1,14 +1,14 @@
 import { RowSelectionState } from '@tanstack/table-core';
-import { Button } from '@tangle-network/sandbox-ui/primitives';
 import {
   useAllBlueprints,
   useBlueprintsByOwner,
 } from '@tangle-network/tangle-shared-ui/data/graphql';
 import useOperatorInfo from '@tangle-network/tangle-shared-ui/hooks/useOperatorInfo';
 import type { Blueprint } from '@tangle-network/tangle-shared-ui/types/blueprint';
+import { Button } from '@tangle-network/ui-components';
 import { AnimatePresence, motion } from 'framer-motion';
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
-import { Link, useSearchParams } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 import { twMerge } from 'tailwind-merge';
 import { PagePath } from '../../types';
 import pollWithBackoff from '../../utils/pollWithBackoff';
@@ -25,6 +25,7 @@ const Page: FC = () => {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
   const { blueprints, isLoading, error, refetch } = useAllBlueprints();
   const { data: ownedBlueprints } = useBlueprintsByOwner();
 
@@ -148,23 +149,24 @@ const Page: FC = () => {
 
   const toolbarAction = hasOwnedBlueprints ? (
     <Button
-      asChild
-      variant="outline"
+      variant="secondary"
       size="sm"
-      className="font-sans not-italic"
+      className="px-5"
+      onClick={() => navigate(PagePath.BLUEPRINTS_MANAGE)}
     >
-      <Link to={PagePath.BLUEPRINTS_MANAGE}>Manage</Link>
+      Manage
     </Button>
   ) : (
     <Button
-      variant="sandbox"
-      asChild
+      as="a"
+      variant="primary"
       size="sm"
-      className="font-sans not-italic"
+      className="px-5"
+      href={BLUEPRINT_DOCS_LINK}
+      target="_blank"
+      rel="noreferrer"
     >
-      <a href={BLUEPRINT_DOCS_LINK} target="_blank" rel="noreferrer">
-        Publish
-      </a>
+      Publish
     </Button>
   );
 
@@ -201,7 +203,7 @@ const Page: FC = () => {
               </p>
 
               <Button
-                variant="ghost"
+                variant="link"
                 size="sm"
                 onClick={() => setRowSelection({})}
               >
@@ -209,11 +211,7 @@ const Page: FC = () => {
               </Button>
             </div>
 
-            <Button
-              variant="sandbox"
-              className="font-sans not-italic"
-              onClick={() => setIsDrawerOpen(true)}
-            >
+            <Button variant="primary" onClick={() => setIsDrawerOpen(true)}>
               Add capacity
             </Button>
           </motion.div>

--- a/apps/tangle-cloud/src/styles.css
+++ b/apps/tangle-cloud/src/styles.css
@@ -1,17 +1,17 @@
 /* Tangle Cloud styles. Tokens (--md3-*, --hsl-*, --bg-*, --text-*, --border-*,
  * --btn-*, --shadow-*, [data-sandbox-theme='vault'] light overrides) come from
  * @tangle-network/brand via the sandbox-ui vendor CSS preloaded in index.html.
- * This file adds Geist typeface, tangle/vault theme deltas, and cloud-only
- * component classes. `!important` is reserved for fights against legacy
- * ui-components @layer base rules ('*:not(code) Satoshi', 'h1..h6 text-mono-*')
- * that arrive in the bundle BEFORE cloud styles. */
+ * This file adds tangle/vault theme deltas and cloud-only component classes.
+ * `!important` is reserved for fights against legacy ui-components @layer base
+ * rules ('*:not(code) Satoshi', 'h1..h6 text-mono-*') that arrive in the bundle
+ * BEFORE cloud styles. */
 @import '@tangle-network/brand/styles/tokens.css';
 
 :root,
 [data-sandbox-ui] {
-  --font-sans: 'Geist Sans', ui-sans-serif, system-ui, sans-serif;
-  --font-display: 'Geist Sans', ui-sans-serif, system-ui, sans-serif;
-  --font-mono: 'Geist Mono', ui-monospace, SFMono-Regular, monospace;
+  --font-sans: 'Satoshi', ui-sans-serif, system-ui, sans-serif;
+  --font-display: 'Satoshi', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'Cousine', ui-monospace, SFMono-Regular, monospace;
 }
 
 html,
@@ -29,14 +29,7 @@ body {
   font-family: var(--font-sans);
 }
 
-/* Override ui-components' .bg-tangle wallpaper with the brand radial gradient. */
-.tangle-cloud-shell.bg-tangle,
-[data-sandbox-ui].bg-tangle {
-  background: var(--bg-root);
-  background-attachment: initial;
-}
 .tangle-cloud-shell {
-  background: var(--bg-root);
   color: var(--text-primary);
 }
 
@@ -93,13 +86,30 @@ body {
  * fires when a requested weight is missing from a fallback font) doesn't
  * sneak in slanted glyphs on body text. Italic is a deliberate emphasis
  * marker in this app and shows up only via explicit `.italic` class. */
-.tangle-cloud-shell :where(h1, h2, h3, h4, h5, h6, p, label, li, td, th, button, a, span) {
+.tangle-cloud-shell
+  :where(h1, h2, h3, h4, h5, h6, p, label, li, td, th, button, a, span) {
   color: inherit;
 }
 .tangle-cloud-shell
   :where(
-    h1, h2, h3, h4, h5, h6, p, span, a, button, label, li, td, th,
-    input, select, textarea, div
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p,
+    span,
+    a,
+    button,
+    label,
+    li,
+    td,
+    th,
+    input,
+    select,
+    textarea,
+    div
   ):not(.italic) {
   /* `!important` + form controls: the previous rule (no !important, no
    * inputs/selects) let slanted fallback glyphs through on the search bar
@@ -215,9 +225,15 @@ body {
  * those alone so my centering math doesn't drag the drawer back to center.
  */
 @media (min-width: 1024px) {
-  [role='dialog'][data-state='open']:not([class*='left-auto']):not([class*='right-auto']):not([class*='translate-x-0']),
-  [role='dialog'][data-state='closed']:not([class*='left-auto']):not([class*='right-auto']):not([class*='translate-x-0']) {
-    --tw-translate-x: calc(-50% + var(--cloud-sidebar-width, 16rem) / 2) !important;
+  [role='dialog'][data-state='open']:not([class*='left-auto']):not(
+      [class*='right-auto']
+    ):not([class*='translate-x-0']),
+  [role='dialog'][data-state='closed']:not([class*='left-auto']):not(
+      [class*='right-auto']
+    ):not([class*='translate-x-0']) {
+    --tw-translate-x: calc(
+      -50% + var(--cloud-sidebar-width, 16rem) / 2
+    ) !important;
   }
 }
 

--- a/libs/tangle-shared-ui/src/components/blueprints/BlueprintGallery/BlueprintItem.tsx
+++ b/libs/tangle-shared-ui/src/components/blueprints/BlueprintGallery/BlueprintItem.tsx
@@ -19,11 +19,14 @@ const BlueprintItem: FC<Omit<BlueprintItemProps, 'id'>> = ({
   operatorsCount,
   isBoosted,
   renderImage,
+  action,
+  onClick,
   isSelected,
   onSelectedChange,
 }) => {
   return (
     <div
+      onClick={onClick}
       className={twMerge(
         'h-[364px] overflow-hidden rounded-xl flex flex-col cursor-pointer group',
         'border border-mono-0 dark:border-mono-170',
@@ -50,7 +53,7 @@ const BlueprintItem: FC<Omit<BlueprintItemProps, 'id'>> = ({
       >
         <div className="space-y-3">
           <div className="flex items-center gap-2 py-2 border-b border-mono-60 dark:border-mono-170">
-            {imgUrl && renderImage(imgUrl)}
+            {renderImage(imgUrl ?? '')}
 
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2">
@@ -135,6 +138,15 @@ const BlueprintItem: FC<Omit<BlueprintItemProps, 'id'>> = ({
             </Typography>
           </div> */}
         </div>
+
+        {action !== undefined && (
+          <div
+            className="relative z-10 flex w-full gap-2 pt-3"
+            onClick={(event) => event.stopPropagation()}
+          >
+            {action}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/libs/tangle-shared-ui/src/components/blueprints/BlueprintGallery/types.ts
+++ b/libs/tangle-shared-ui/src/components/blueprints/BlueprintGallery/types.ts
@@ -1,5 +1,10 @@
 import type { RowSelectionState } from '@tanstack/table-core';
-import type { Dispatch, PropsWithChildren, SetStateAction } from 'react';
+import type {
+  Dispatch,
+  PropsWithChildren,
+  ReactNode,
+  SetStateAction,
+} from 'react';
 
 export type BlueprintItemProps = {
   id: bigint;
@@ -13,7 +18,9 @@ export type BlueprintItemProps = {
   tvl?: string | null;
   isBoosted?: boolean;
   category: string | null;
-  renderImage: (imageUrl: string) => React.ReactNode;
+  renderImage: (imageUrl: string) => ReactNode;
+  action?: ReactNode;
+  onClick?: () => void;
   isSelected?: boolean;
   onSelectedChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };


### PR DESCRIPTION
## Summary
- replaces the bespoke Blueprints catalog/dashboard surface with the existing shared `BlueprintGallery` from `tangle-shared-ui`
- keeps Cloud-specific behavior as a thin adapter: deduped blueprint modes, generated/default visuals, card view routing, deploy, and add-capacity registration
- restores Tangle dapp visual fundamentals in Cloud: shared `ui-components` CSS import, Satoshi/Cousine fonts, shared `bg-tangle` background, and shared buttons
- extends `BlueprintGallery` narrowly with optional card action and click hooks instead of duplicating a second gallery system

## Why
The previous redesign still looked unlike the original Tangle dapp because it introduced a new command-panel/card system, Geist fonts, and a Cloud-specific background override. This moves Blueprints back onto the existing Tangle UI surface and deletes the large one-off listing implementation.

## Verification
- `NX_DAEMON=false NX_SKIP_NX_CACHE=true yarn nx typecheck tangle-cloud`
- `NX_DAEMON=false NX_SKIP_NX_CACHE=true yarn nx test tangle-cloud`
- `NX_DAEMON=false NX_SKIP_NX_CACHE=true yarn nx build tangle-cloud`
- `git diff --check`
- local Playwright screenshots:
  - `/tmp/tangle-cloud-blueprints-shared-gallery-desktop-v2.png`
  - `/tmp/tangle-cloud-blueprints-shared-gallery-mobile-v2.png`

Browser checks confirmed 12 cards, shared pagination, Satoshi font, shared Tangle background image, no command-panel residue, no italic buttons, and no horizontal overflow.