### PR TITLE
feat(tangle-cloud): unify app shell with tangle dapp

### DIFF
--- a/apps/tangle-cloud/src/components/Header.tsx
+++ b/apps/tangle-cloud/src/components/Header.tsx
@@ -24,11 +24,9 @@ import {
   DropdownMenuTrigger,
 } from '@tangle-network/sandbox-ui/primitives';
 import { ComponentProps, useCallback, useMemo, useState } from 'react';
-import { Link, useLocation } from 'react-router';
 import { twMerge } from 'tailwind-merge';
 import { useAccount, useChainId, useSwitchChain } from 'wagmi';
 import TxHistoryDrawer from './TxHistoryDrawer';
-import { useTopNavSlotContent } from './chrome/TopNavSlot';
 import {
   Network,
   NetworkId,
@@ -44,26 +42,14 @@ export default function Header({
   theme: 'dark' | 'light';
   onThemeChange: (theme: 'dark' | 'light') => void;
 }) {
-  const pathname = useLocation().pathname;
-  const trail = useMemo(() => getHeaderTrail(pathname), [pathname]);
-  const topNavContent = useTopNavSlotContent();
-
   return (
     <header
       className={twMerge(
-        'tangle-cloud-topbar fixed top-0 right-0 left-0 z-40 flex h-14 items-center justify-between gap-4 border-b border-border bg-[var(--bg-elevated)] px-4 font-sans text-[13px] tracking-tight lg:left-16 lg:px-8',
+        'flex items-center justify-end gap-2 font-sans text-[13px] tracking-tight',
         className,
       )}
       {...props}
     >
-      {/* Topbar left slot: the route breadcrumb trail by default
-       * ("Blueprints / Trading"); pages can override it with contextual
-       * content (name + actions) via useTopNavSlot. */}
-      <div className="ml-12 flex min-w-0 flex-1 items-center gap-2 sm:ml-0">
-        {topNavContent ??
-          (trail.length > 0 ? <HeaderTrail items={trail} /> : null)}
-      </div>
-
       <div className="flex shrink-0 items-center justify-end gap-2">
         <TxHistoryDrawer />
 
@@ -79,88 +65,6 @@ export default function Header({
         <ConnectWalletButton className="tangle-cloud-wallet-action" />
       </div>
     </header>
-  );
-}
-
-type TrailItem = { label: string; href?: string };
-
-/**
- * Breadcrumb trail for the top nav ("Blueprints / Trading"). The leading
- * "Cloud" is dropped — the whole app is Cloud and the sidebar already names
- * the section. Non-leaf section roots link back (e.g. Blueprints → catalog).
- * Blueprint *detail* pages override this via useTopNavSlot with the real name.
- */
-const getHeaderTrail = (pathname: string): TrailItem[] => {
-  const blueprints: TrailItem = { label: 'Blueprints', href: '/blueprints' };
-  const operators: TrailItem = { label: 'Operators', href: '/operators' };
-  const instances: TrailItem = { label: 'Instances', href: '/instances' };
-
-  if (pathname === '/blueprints/create')
-    return [blueprints, { label: 'Create' }];
-  if (pathname === '/blueprints/manage')
-    return [blueprints, { label: 'Manage' }];
-  if (pathname.startsWith('/blueprints/') && pathname.endsWith('/deploy'))
-    return [blueprints, { label: 'Instance checkout' }];
-  if (pathname.startsWith('/blueprints/') && pathname.includes('/services/'))
-    return [blueprints, { label: 'Service' }];
-  if (pathname.startsWith('/blueprints/') && pathname !== '/blueprints')
-    return [blueprints, { label: 'Details' }];
-  if (pathname === '/blueprints') return [];
-  if (pathname.startsWith('/blueprints')) return [blueprints];
-
-  if (pathname === '/operators/manage') return [operators, { label: 'Manage' }];
-  if (pathname.startsWith('/operators')) return [operators];
-  if (pathname === '/payments/credits')
-    return [{ label: 'Payments' }, { label: 'Credits' }];
-  if (pathname === '/payments/pool')
-    return [{ label: 'Payments' }, { label: 'Shielded pool' }];
-  if (pathname.startsWith('/rewards')) return [{ label: 'Rewards' }];
-  if (pathname.startsWith('/earnings')) return [{ label: 'Earnings' }];
-  if (pathname.startsWith('/services/'))
-    return [instances, { label: 'Service' }];
-  if (pathname.startsWith('/instances')) return [instances];
-
-  return [{ label: 'Tangle Cloud' }];
-};
-
-/** Renders a breadcrumb trail; non-leaf items with an href are links. */
-function HeaderTrail({ items }: { items: TrailItem[] }) {
-  return (
-    <nav
-      aria-label="Breadcrumb"
-      className="flex min-w-0 items-center gap-1.5 text-[13px]"
-    >
-      {items.map((item, i) => {
-        const isLeaf = i === items.length - 1;
-        return (
-          <span key={i} className="flex min-w-0 items-center gap-1.5">
-            {i > 0 && (
-              <span aria-hidden className="text-muted-foreground/40">
-                /
-              </span>
-            )}
-            {item.href && !isLeaf ? (
-              <Link
-                to={item.href}
-                className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
-              >
-                {item.label}
-              </Link>
-            ) : (
-              <span
-                className={twMerge(
-                  isLeaf
-                    ? 'truncate font-semibold text-foreground'
-                    : 'shrink-0 text-muted-foreground',
-                )}
-              >
-                {item.label}
-              </span>
-            )}
-          </span>
-        );
-      })}
-    </nav>
   );
 }
 

--- a/apps/tangle-cloud/src/components/Header.tsx
+++ b/apps/tangle-cloud/src/components/Header.tsx
@@ -8,9 +8,7 @@ import createCustomNetwork from '@tangle-network/tangle-shared-ui/utils/createCu
 import {
   Alert,
   ChainIcon,
-  MoonLine,
   SettingsFillIcon,
-  SunLine,
   Spinner,
   StatusIndicator,
 } from '@tangle-network/icons';
@@ -35,13 +33,8 @@ import {
 
 export default function Header({
   className,
-  theme,
-  onThemeChange,
   ...props
-}: ComponentProps<'header'> & {
-  theme: 'dark' | 'light';
-  onThemeChange: (theme: 'dark' | 'light') => void;
-}) {
+}: ComponentProps<'header'>) {
   return (
     <header
       className={twMerge(
@@ -57,38 +50,12 @@ export default function Header({
 
         <CloudNetworkSelector networks={TANGLE_CLOUD_NETWORKS} />
 
-        <ThemeToggle theme={theme} onThemeChange={onThemeChange} />
-
         {/* Connection state lives in the chrome on every route — the header is
          * the single owner of Connect Wallet. Pages never duplicate this; a
          * disconnected page body renders a designed empty state instead. */}
         <ConnectWalletButton className="tangle-cloud-wallet-action" />
       </div>
     </header>
-  );
-}
-
-function ThemeToggle({
-  theme,
-  onThemeChange,
-}: {
-  theme: 'dark' | 'light';
-  onThemeChange: (theme: 'dark' | 'light') => void;
-}) {
-  const nextTheme = theme === 'dark' ? 'light' : 'dark';
-
-  return (
-    <Button
-      type="button"
-      variant="outline"
-      size="icon"
-      aria-label={`Switch to ${nextTheme} theme`}
-      title={`Switch to ${nextTheme} theme`}
-      onClick={() => onThemeChange(nextTheme)}
-      className="h-11 w-11 border-border bg-muted/30 p-0 text-foreground hover:bg-muted"
-    >
-      {theme === 'dark' ? <SunLine size="lg" /> : <MoonLine size="lg" />}
-    </Button>
   );
 }
 

--- a/apps/tangle-cloud/src/components/Layout.tsx
+++ b/apps/tangle-cloud/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { Footer } from '@tangle-network/ui-components';
+import { Footer, useDarkMode } from '@tangle-network/ui-components';
 import {
   bottomLinks,
   TANGLE_AVAILABLE_SOCIALS,
@@ -37,14 +37,8 @@ const Layout: FC<PropsWithChildren<Props>> = ({
   children,
   isSidebarInitiallyExpanded,
 }) => {
-  const [theme, setTheme] = useState<'dark' | 'light'>(() => {
-    const storedTheme = window.localStorage.getItem('tangle-cloud-theme');
-    if (storedTheme === 'dark' || storedTheme === 'light') {
-      return storedTheme;
-    }
-
-    return 'dark';
-  });
+  const [isDarkMode] = useDarkMode('dark');
+  const theme = isDarkMode ? 'dark' : 'light';
   const [isSidebarExpanded, setIsSidebarExpanded] = useState(() => {
     if (isSidebarInitiallyExpanded !== undefined) {
       return isSidebarInitiallyExpanded;
@@ -65,7 +59,6 @@ const Layout: FC<PropsWithChildren<Props>> = ({
       'data-sandbox-theme',
       theme === 'dark' ? 'tangle' : 'vault',
     );
-    window.localStorage.setItem('tangle-cloud-theme', theme);
   }, [theme]);
 
   // Publish the current sidebar width as a CSS variable on the root element so
@@ -120,7 +113,7 @@ const Layout: FC<PropsWithChildren<Props>> = ({
                   <MobileSidebar />
                 </div>
 
-                <Header theme={theme} onThemeChange={setTheme} />
+                <Header />
               </div>
 
               <main className="flex-1">

--- a/apps/tangle-cloud/src/components/Layout.tsx
+++ b/apps/tangle-cloud/src/components/Layout.tsx
@@ -1,5 +1,13 @@
+import { Footer } from '@tangle-network/ui-components';
+import {
+  bottomLinks,
+  TANGLE_AVAILABLE_SOCIALS,
+  TANGLE_PRIVACY_POLICY_URL,
+  TANGLE_SOCIAL_URLS_RECORD,
+  TANGLE_TERMS_OF_SERVICE_URL,
+} from '@tangle-network/ui-components/constants';
 import TxConfirmationModal from '@tangle-network/tangle-shared-ui/components/TxConfirmationModal';
-import Sidebar from './Sidebar';
+import Sidebar, { MobileSidebar } from './Sidebar';
 import { FC, PropsWithChildren, useCallback, useEffect, useState } from 'react';
 import TxHistoryNotifier from './TxHistoryNotifier';
 import Header from './Header';
@@ -12,6 +20,17 @@ import { TopNavSlotProvider } from './chrome/TopNavSlot';
 
 type Props = {
   isSidebarInitiallyExpanded?: boolean;
+};
+
+const SOCIAL_LINK_OVERRIDES: Partial<
+  Record<(typeof TANGLE_AVAILABLE_SOCIALS)[number], string>
+> = TANGLE_SOCIAL_URLS_RECORD;
+
+const BOTTOM_LINK_OVERRIDES: Partial<
+  Record<(typeof bottomLinks)[number]['name'], string>
+> = {
+  'Terms of Service': TANGLE_TERMS_OF_SERVICE_URL,
+  'Privacy Policy': TANGLE_PRIVACY_POLICY_URL,
 };
 
 const Layout: FC<PropsWithChildren<Props>> = ({
@@ -76,23 +95,15 @@ const Layout: FC<PropsWithChildren<Props>> = ({
       <div
         data-sandbox-ui
         data-sandbox-theme={theme === 'dark' ? 'tangle' : 'vault'}
-        className="tangle-cloud-shell min-h-screen bg-tangle text-foreground"
+        className="tangle-cloud-shell flex h-screen bg-tangle text-foreground"
       >
         <Sidebar
           isExpandedByDefault={isSidebarExpanded}
-          onExpandedChange={setIsSidebarExpanded}
-        />
-        <Header
-          theme={theme}
-          onThemeChange={setTheme}
-          className={isSidebarExpanded ? 'lg:left-64' : 'lg:left-16'}
+          onExpandedChange={() => setIsSidebarExpanded((value) => !value)}
         />
 
         <div
-          className={twMerge(
-            'min-h-screen pt-14 transition-[padding-left] duration-200',
-            isSidebarExpanded ? 'lg:pl-64' : 'lg:pl-16',
-          )}
+          className={twMerge('h-full flex-1 overflow-y-auto scrollbar-hide')}
         >
           <TxHistoryNotifier />
           <TxConfirmationModal />
@@ -102,9 +113,28 @@ const Layout: FC<PropsWithChildren<Props>> = ({
           />
           <ShortcutsHelp open={isHelpOpen} onOpenChange={setIsHelpOpen} />
 
-          <main className="flex-1">
-            <PageMotion>{children}</PageMotion>
-          </main>
+          <div className="m-auto flex h-full max-w-[1448px] flex-col justify-between px-4 md:px-8 lg:px-10">
+            <div className="flex grow flex-col space-y-5">
+              <div className="flex items-center justify-between py-6">
+                <div className="flex items-center space-x-4 lg:space-x-0">
+                  <MobileSidebar />
+                </div>
+
+                <Header theme={theme} onThemeChange={setTheme} />
+              </div>
+
+              <main className="flex-1">
+                <PageMotion>{children}</PageMotion>
+              </main>
+            </div>
+
+            <Footer
+              socialsLinkOverrides={SOCIAL_LINK_OVERRIDES}
+              bottomLinkOverrides={BOTTOM_LINK_OVERRIDES}
+              isMinimal
+              className="py-8"
+            />
+          </div>
         </div>
       </div>
     </TopNavSlotProvider>

--- a/apps/tangle-cloud/src/components/Sidebar.tsx
+++ b/apps/tangle-cloud/src/components/Sidebar.tsx
@@ -1,72 +1,72 @@
-import { DocumentationIcon } from '@tangle-network/icons/DocumentationIcon';
-import GlobalLine from '@tangle-network/icons/GlobalLine';
-import { GridFillIcon } from '@tangle-network/icons/GridFillIcon';
 import {
   CoinsLineIcon,
+  DocumentationIcon,
   GiftLineIcon,
+  GlobalLine,
+  GridFillIcon,
   HomeFillIcon,
   ShieldKeyholeLineIcon,
 } from '@tangle-network/icons';
-import { TangleKnot } from '@tangle-network/sandbox-ui/primitives';
-import { type ComponentType, type FC, useState } from 'react';
-import { Link, useLocation } from 'react-router';
-import { twMerge } from 'tailwind-merge';
+import {
+  MobileSidebar as MobileSidebarCmp,
+  type MobileSidebarProps,
+  SideBar as SideBarCmp,
+  type SideBarFooterType,
+  type SideBarItemProps,
+  TangleLogo,
+} from '@tangle-network/ui-components';
+import { SidebarTangleClosedIcon } from '@tangle-network/ui-components/components';
+import {
+  TANGLE_DOCS_URL,
+  TANGLE_MKT_URL,
+} from '@tangle-network/ui-components/constants';
+import { type FC, useMemo } from 'react';
+import { useLocation } from 'react-router';
 import { PagePath } from '../types';
-
-const TANGLE_DOCS_URL = 'https://docs.tangle.tools';
-
-type IconComponent = ComponentType<{ className?: string }>;
-
-type SidebarItem = {
-  name: string;
-  href: string;
-  isInternal: boolean;
-  Icon: IconComponent;
-  subItems?: Array<{
-    name: string;
-    href: string;
-    isInternal: boolean;
-  }>;
-};
 
 type Props = {
   isExpandedByDefault?: boolean;
-  onExpandedChange?: (isExpanded: boolean) => void;
+  onExpandedChange?: () => void;
 };
 
-const SIDEBAR_ITEMS: SidebarItem[] = [
+const SIDEBAR_ITEMS: SideBarItemProps[] = [
   {
-    name: 'Home',
+    name: 'Dashboard',
     href: PagePath.INSTANCES,
     isInternal: true,
     Icon: HomeFillIcon,
+    subItems: [],
   },
   {
     name: 'Blueprints',
     href: PagePath.BLUEPRINTS,
     isInternal: true,
     Icon: GridFillIcon,
+    subItems: [],
   },
   {
     name: 'Operators',
     href: PagePath.OPERATORS,
     isInternal: true,
     Icon: GlobalLine,
+    subItems: [],
   },
   {
     name: 'Rewards',
     href: PagePath.REWARDS,
     isInternal: true,
     Icon: GiftLineIcon,
+    subItems: [],
   },
   {
     name: 'Earnings',
     href: PagePath.EARNINGS,
     isInternal: true,
     Icon: CoinsLineIcon,
+    subItems: [],
   },
   {
-    name: 'Private Payments',
+    name: 'Payments',
     href: PagePath.PAYMENTS_POOL,
     isInternal: true,
     Icon: ShieldKeyholeLineIcon,
@@ -85,258 +85,50 @@ const SIDEBAR_ITEMS: SidebarItem[] = [
   },
 ];
 
-const DOCS_ITEM: SidebarItem = {
+const SIDEBAR_FOOTER: SideBarFooterType = {
   name: 'Docs',
   href: TANGLE_DOCS_URL,
   isInternal: false,
   Icon: DocumentationIcon,
 };
 
-const Sidebar: FC<Props> = ({ isExpandedByDefault, onExpandedChange }) => {
-  const pathname = useLocation().pathname;
-  const [isMobileOpen, setIsMobileOpen] = useState(false);
-  const [isDesktopExpanded, setIsDesktopExpanded] = useState(
-    isExpandedByDefault ?? true,
+const useCloudSidebarProps = (): MobileSidebarProps =>
+  useMemo(
+    () => ({
+      ClosedLogo: SidebarTangleClosedIcon,
+      Logo: TangleLogo,
+      footer: SIDEBAR_FOOTER,
+      items: SIDEBAR_ITEMS,
+      logoLink: TANGLE_MKT_URL,
+    }),
+    [],
   );
 
-  const toggleDesktopExpanded = () => {
-    setIsDesktopExpanded((current) => {
-      const next = !current;
-      window.localStorage.setItem(
-        'tangle-cloud-sidebar-expanded',
-        String(next),
-      );
-      onExpandedChange?.(next);
-      return next;
-    });
-  };
+const Sidebar: FC<Props> = ({ isExpandedByDefault, onExpandedChange }) => {
+  const location = useLocation();
+  const sidebarProps = useCloudSidebarProps();
 
   return (
-    <>
-      <aside
-        className={twMerge(
-          'group/sidebar fixed bottom-0 left-0 top-0 z-50 hidden shrink-0 border-border border-r bg-card transition-[width] duration-200 lg:flex lg:flex-col',
-          isDesktopExpanded ? 'w-64' : 'w-16',
-        )}
-      >
-        <SidebarBrand isExpanded={isDesktopExpanded} />
-        <SidebarNav
-          items={SIDEBAR_ITEMS}
-          pathname={pathname}
-          isExpanded={isDesktopExpanded}
-        />
-        <div className="mt-auto px-2 pb-3">
-          <SidebarLink
-            item={DOCS_ITEM}
-            pathname={pathname}
-            isExpanded={isDesktopExpanded}
-          />
-        </div>
-
-        <SidebarCollapseButton
-          isExpanded={isDesktopExpanded}
-          onClick={toggleDesktopExpanded}
-        />
-      </aside>
-
-      <div className="fixed left-4 top-2 z-[45] lg:hidden">
-        <button
-          type="button"
-          className="grid h-10 w-10 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-          aria-label="Toggle navigation"
-          onClick={() => setIsMobileOpen((value) => !value)}
-        >
-          <TangleKnot size={22} className="text-primary" />
-        </button>
-      </div>
-
-      {isMobileOpen && (
-        <div className="fixed inset-0 z-[70] bg-black/50 lg:hidden">
-          <aside className="fixed bottom-0 left-0 top-0 w-64 border-r border-border bg-card shadow-[var(--shadow-card)]">
-            <SidebarBrand isExpanded />
-            <SidebarNav
-              items={SIDEBAR_ITEMS}
-              pathname={pathname}
-              isExpanded
-              onNavigate={() => setIsMobileOpen(false)}
-            />
-            <div className="mt-8">
-              <SidebarLink
-                item={DOCS_ITEM}
-                pathname={pathname}
-                isExpanded
-                onNavigate={() => setIsMobileOpen(false)}
-              />
-            </div>
-          </aside>
-        </div>
-      )}
-    </>
+    <SideBarCmp
+      {...sidebarProps}
+      className="fixed inset-y-0 left-0 z-50 hidden lg:block"
+      isExpandedByDefault={isExpandedByDefault}
+      onSideBarToggle={onExpandedChange}
+      pathnameOrHash={location.pathname}
+    />
   );
 };
 
-const SidebarBrand = ({ isExpanded }: { isExpanded: boolean }) => (
-  <Link
-    to={PagePath.INSTANCES}
-    aria-label="Tangle Cloud"
-    className={
-      isExpanded
-        ? 'mb-4 flex h-14 items-center gap-3 px-4 text-foreground'
-        : 'flex h-14 items-center justify-center text-foreground'
-    }
-  >
-    <span
-      aria-hidden="true"
-      className="grid h-9 w-9 place-items-center rounded-md transition-colors hover:bg-muted/50"
-    >
-      <TangleKnot size={22} className="text-primary" />
-    </span>
-    {isExpanded && (
-      <span className="font-display text-base font-extrabold tracking-tight">
-        Tangle Cloud
-      </span>
-    )}
-  </Link>
-);
-
-const SidebarNav = ({
-  items,
-  pathname,
-  isExpanded,
-  onNavigate,
-}: {
-  items: SidebarItem[];
-  pathname: string;
-  isExpanded: boolean;
-  onNavigate?: () => void;
-}) => (
-  <nav className={isExpanded ? 'space-y-1 px-2' : 'space-y-1 px-2'}>
-    {items.map((item) => (
-      <SidebarLink
-        key={item.name}
-        item={item}
-        pathname={pathname}
-        isExpanded={isExpanded}
-        onNavigate={onNavigate}
-      />
-    ))}
-  </nav>
-);
-
-// Pinned to the sidebar's right edge so it's affordance-clear (matches VS
-// Code / Linear / Vercel patterns) and never competes with the nav stack
-// for the "what's a nav item" mental model. Floats over the border so it
-// stays visible whether the sidebar is expanded (w-64) or collapsed (w-16).
-const SidebarCollapseButton = ({
-  isExpanded,
-  onClick,
-}: {
-  isExpanded: boolean;
-  onClick: () => void;
-}) => (
-  <button
-    type="button"
-    onClick={onClick}
-    aria-label={isExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
-    className="absolute -right-3 top-20 z-10 hidden h-6 w-6 items-center justify-center rounded-full border border-border bg-background text-muted-foreground opacity-0 shadow-[var(--shadow-card)] transition-opacity hover:text-foreground focus:opacity-100 group-hover/sidebar:opacity-100 group-focus-within/sidebar:opacity-100 lg:inline-flex"
-  >
-    <svg
-      aria-hidden
-      viewBox="0 0 16 16"
-      className={twMerge(
-        'h-3 w-3 fill-none stroke-current transition-transform',
-        isExpanded ? '' : 'rotate-180',
-      )}
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M10 4 6 8l4 4" />
-    </svg>
-  </button>
-);
-
-const SidebarLink = ({
-  item,
-  pathname,
-  isExpanded,
-  onNavigate,
-}: {
-  item: SidebarItem;
-  pathname: string;
-  isExpanded: boolean;
-  onNavigate?: () => void;
-}) => {
-  const isSubItemActive =
-    item.subItems?.some(
-      (subItem) =>
-        pathname === subItem.href || pathname.startsWith(`${subItem.href}/`),
-    ) ?? false;
-  const isActive =
-    item.isInternal &&
-    (pathname === item.href ||
-      pathname.startsWith(`${item.href}/`) ||
-      isSubItemActive);
-  const Icon = item.Icon;
-  const className = [
-    'group flex items-center gap-3 rounded-md text-sm font-semibold transition-colors',
-    isExpanded ? 'min-h-11 justify-start px-3' : 'h-11 w-12 justify-center',
-    isActive
-      ? 'bg-primary text-primary-foreground shadow-[var(--shadow-accent)]'
-      : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
-  ].join(' ');
-  const content = (
-    <>
-      <Icon className="h-4 w-4 shrink-0" />
-      {isExpanded && <span>{item.name}</span>}
-    </>
-  );
+export const MobileSidebar: FC = () => {
+  const location = useLocation();
+  const sidebarProps = useCloudSidebarProps();
 
   return (
-    <div>
-      {item.isInternal ? (
-        <Link
-          to={item.href}
-          className={className}
-          aria-current={isActive ? 'page' : undefined}
-          onClick={onNavigate}
-        >
-          {content}
-        </Link>
-      ) : (
-        <a
-          href={item.href}
-          target="_blank"
-          rel="noreferrer"
-          className={className}
-          onClick={onNavigate}
-        >
-          {content}
-        </a>
-      )}
-
-      {isExpanded && item.subItems && isActive && (
-        <div className="ml-8 mt-1 space-y-1 border-border border-l pl-3">
-          {item.subItems.map((subItem) => {
-            const isSubActive = pathname === subItem.href;
-            return (
-              <Link
-                key={subItem.name}
-                to={subItem.href}
-                className={
-                  isSubActive
-                    ? 'block rounded-md px-3 py-2 text-xs font-semibold text-foreground'
-                    : 'block rounded-md px-3 py-2 text-xs font-semibold text-muted-foreground hover:bg-muted/60 hover:text-foreground'
-                }
-                onClick={onNavigate}
-              >
-                {subItem.name}
-              </Link>
-            );
-          })}
-        </div>
-      )}
-    </div>
+    <MobileSidebarCmp
+      {...sidebarProps}
+      className="lg:hidden"
+      pathnameOrHash={location.pathname}
+    />
   );
 };
 

--- a/apps/tangle-cloud/src/components/blueprints/BlueprintVisual.tsx
+++ b/apps/tangle-cloud/src/components/blueprints/BlueprintVisual.tsx
@@ -52,10 +52,6 @@ export const BlueprintVisual = ({
       ) : (
         <GeneratedBlueprintDiagram name={displayName} category={category} />
       )}
-
-      <div className="tangle-cloud-visual-badge absolute bottom-4 right-4 grid h-10 w-10 shrink-0 place-items-center rounded-lg border border-border bg-card font-display font-extrabold text-foreground shadow-[var(--shadow-card)]">
-        {displayName.slice(0, 1).toUpperCase()}
-      </div>
     </div>
   );
 };

--- a/apps/tangle-cloud/src/main.tsx
+++ b/apps/tangle-cloud/src/main.tsx
@@ -6,9 +6,37 @@ import * as ReactDOM from 'react-dom/client';
 import App from './app/app';
 import './styles.css';
 
-const storedTheme = window.localStorage.getItem('tangle-cloud-theme');
-const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
-const initialTheme = storedTheme ?? (prefersLight ? 'light' : 'dark');
+type ThemeMode = 'dark' | 'light';
+
+const normalizeTheme = (value: string | null): ThemeMode | null => {
+  if (value === 'dark' || value === 'light') {
+    return value;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  try {
+    const parsedValue: unknown = JSON.parse(value);
+    return parsedValue === 'dark' || parsedValue === 'light'
+      ? parsedValue
+      : null;
+  } catch {
+    return null;
+  }
+};
+
+const storedTheme = normalizeTheme(window.localStorage.getItem('theme'));
+const legacyTheme = normalizeTheme(
+  window.localStorage.getItem('tangle-cloud-theme'),
+);
+const initialTheme = storedTheme ?? legacyTheme ?? 'dark';
+
+if (storedTheme === null && legacyTheme !== null) {
+  window.localStorage.setItem('theme', JSON.stringify(legacyTheme));
+  window.localStorage.removeItem('tangle-cloud-theme');
+}
 
 document.documentElement.classList.toggle('dark', initialTheme === 'dark');
 document.documentElement.style.colorScheme = initialTheme;

--- a/apps/tangle-cloud/src/pages/instances/AccountStatsCard.tsx
+++ b/apps/tangle-cloud/src/pages/instances/AccountStatsCard.tsx
@@ -1,11 +1,10 @@
 import { useMemo, type FC } from 'react';
 import {
-  Avatar,
-  AvatarFallback,
   Badge,
   Card,
   CardContent,
 } from '@tangle-network/sandbox-ui/primitives';
+import { Avatar } from '@tangle-network/ui-components';
 import { ExternalLinkLine } from '@tangle-network/icons';
 import { useAccount, useChainId } from 'wagmi';
 import ConnectWalletButton from '@tangle-network/tangle-shared-ui/components/ConnectWalletButton';
@@ -118,26 +117,18 @@ export const AccountStatsCard: FC<AccountStatsCardProps> = (props) => {
         className={twMerge('w-full', rootProps?.className)}
       >
         <CardContent className="flex h-full flex-col gap-5 p-5 md:p-6">
-          <div className="flex min-w-0 items-start gap-4">
-            <Avatar className="h-12 w-12 border border-border bg-muted">
-              <AvatarFallback className="font-display font-bold text-foreground">
-                TC
-              </AvatarFallback>
-            </Avatar>
-
-            <div className="min-w-0 flex-1">
-              <p className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
-                Account
-              </p>
-              <div className="mt-2 font-display font-bold text-foreground text-lg tracking-tight">
-                Connect a wallet to load your account
-              </div>
-              <p className="mt-2 max-w-xl text-muted-foreground text-sm leading-relaxed">
-                Connect to load deployed services, operator registrations, and
-                account-scoped lifecycle events. Public catalog and operator
-                registry data load below without a wallet.
-              </p>
+          <div className="min-w-0">
+            <p className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+              Account
+            </p>
+            <div className="mt-2 font-display font-bold text-foreground text-lg tracking-tight">
+              Connect a wallet to load your account
             </div>
+            <p className="mt-2 max-w-xl text-muted-foreground text-sm leading-relaxed">
+              Connect to load deployed services, operator registrations, and
+              account-scoped lifecycle events. Public catalog and operator
+              registry data load below without a wallet.
+            </p>
           </div>
           <div className="mt-auto">
             <ConnectWalletButton className="tangle-cloud-wallet-action" />
@@ -152,13 +143,12 @@ export const AccountStatsCard: FC<AccountStatsCardProps> = (props) => {
       <CardContent className="space-y-5 p-5 md:p-6">
         <div className="flex items-start justify-between gap-4">
           <div className="flex min-w-0 items-center gap-4">
-            <Avatar className="h-12 w-12 border border-border bg-muted">
-              <AvatarFallback className="font-display font-bold text-foreground">
-                {accountAddress
-                  ? accountAddress.slice(2, 4).toUpperCase()
-                  : 'TC'}
-              </AvatarFallback>
-            </Avatar>
+            <Avatar
+              sourceVariant="address"
+              value={accountAddress}
+              theme="ethereum"
+              size="lg"
+            />
             <div className="min-w-0">
               <div className="truncate font-display font-bold text-foreground text-lg tracking-tight">
                 {identityName}


### PR DESCRIPTION
## Summary
- replace the Cloud-only sidebar with the shared Tangle dapp sidebar/mobile sidebar
- remove the fixed Cloud breadcrumb topbar and move wallet/network controls into the old dapp-style page chrome row
- restore shared footer on Cloud pages
- remove decorative blueprint monogram badges and the disconnected account initials placeholder

## Why
The app looked unlike the Tangle dapp because the Blueprints page had been partially restored, but the shell, navigation, topbar, footer, and homepage/operator surfaces were still Cloud-specific chrome built on sandbox primitives. This makes the shared Tangle dapp shell the default frame again and leaves Cloud-specific code for behavior/data.

## Verification
- NX_DAEMON=false NX_SKIP_NX_CACHE=true yarn nx typecheck tangle-cloud
- NX_DAEMON=false NX_SKIP_NX_CACHE=true yarn nx test tangle-cloud
- NX_DAEMON=false NX_SKIP_NX_CACHE=true yarn nx build tangle-cloud
- pre-push hook: lint/format/build passed
- Playwright screenshots: /instances, /operators, /blueprints on desktop and mobile
- checked: no fixed Cloud topbar, no blueprint monogram badges, no TC placeholder, no italic buttons, no horizontal overflow, Satoshi font and shared body-bg-dark active