### PR TITLE
feat(tangle-cloud): Register Surplus as an iframe blueprint with cross-origin wallet support

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrame.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrame.tsx
@@ -72,10 +72,30 @@ const useParentTheme = (): 'light' | 'dark' => {
 //  - allow-forms: required for normal form interactions inside the iframe.
 //  - allow-popups[-to-escape-sandbox]: gated on the manifest's allowPopups
 //    flag because they widen attack surface (oauth flows commonly need them).
+//  - allow-same-origin: gated on allowSameOrigin AND only when the app is
+//    CROSS-ORIGIN to us. Cross-origin + allow-same-origin restores the iframe's
+//    OWN origin (so embedded apps running their own wallet get the localStorage/
+//    IndexedDB WalletConnect needs) while cross-origin policy still blocks it
+//    from reaching our DOM/storage. We refuse it for same-origin apps, since
+//    same-origin + allow-scripts would let the frame remove its own sandbox.
+const isCrossOrigin = (origin: string): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  try {
+    return new URL(origin).origin !== window.location.origin;
+  } catch {
+    return false;
+  }
+};
+
 const buildSandbox = (config: BlueprintIframeConfig): string => {
   const tokens = ['allow-scripts', 'allow-forms'];
   if (config.allowPopups) {
     tokens.push('allow-popups', 'allow-popups-to-escape-sandbox');
+  }
+  if (config.allowSameOrigin && isCrossOrigin(config.origin)) {
+    tokens.push('allow-same-origin');
   }
   return tokens.join(' ');
 };

--- a/apps/tangle-cloud/src/blueprintApps/iframe/types.ts
+++ b/apps/tangle-cloud/src/blueprintApps/iframe/types.ts
@@ -32,4 +32,11 @@ export type BlueprintIframeConfig = {
   allowReadAccount: boolean;
   allowChainSwitch: boolean;
   allowPopups: boolean;
+  // CURATED-ONLY: grant the iframe its own (cross-origin) origin via the
+  // allow-same-origin sandbox token. Required by embedded apps that run their
+  // own wallet (WalletConnect/ConnectKit need persistent storage, which an
+  // opaque-origin iframe lacks). Honored ONLY for cross-origin apps — see
+  // buildSandbox — so it never lets the frame reach the parent. Never set from
+  // untrusted on-chain metadata.
+  allowSameOrigin?: boolean;
 };

--- a/apps/tangle-cloud/src/blueprintApps/registry.spec.ts
+++ b/apps/tangle-cloud/src/blueprintApps/registry.spec.ts
@@ -40,7 +40,11 @@ describe('blueprint app registry', () => {
     expect(sandboxByMetadata?.slug).toBe('sandbox');
     expect(trainingBySlug?.slug).toBe('training');
     expect(surplusByMetadata?.slug).toBe('surplus');
-    expect(surplusByMetadata?.manifest.externalApp?.mode).toBe('link');
+    expect(surplusByMetadata?.manifest.externalApp?.mode).toBe('iframe');
+    // Surplus runs its own wallet in-frame, so it opts into allow-same-origin
+    // (cross-origin → its own storage) but not the parent bridge grants.
+    expect(surplusByMetadata?.iframe?.allowSameOrigin).toBe(true);
+    expect(surplusByMetadata?.iframe?.allowReadAccount).toBe(false);
   });
 
   it('returns null when metadata identity does not match any curated entry', () => {

--- a/apps/tangle-cloud/src/blueprintApps/registry.ts
+++ b/apps/tangle-cloud/src/blueprintApps/registry.ts
@@ -294,11 +294,29 @@ const entries = [
       ],
       externalApp: {
         url: 'https://surplus-market.pages.dev/',
-        mode: 'link',
+        mode: 'iframe',
         host: 'surplus-market.pages.dev',
         trust: 'trusted',
         label: 'Surplus Market',
       },
+    },
+    // Iframe runtime policy. Surplus runs its OWN wallet (ConnectKit) inside the
+    // frame rather than the parent bridge, so the bridge grants stay off
+    // (allowReadAccount/allowChainSwitch false, no contract/message grants).
+    // allowPopups: wallet connect popups + explorer links. allowSameOrigin:
+    // surplus-market.pages.dev is cross-origin, so this gives the app its own
+    // storage (WalletConnect/ConnectKit need it) without any parent access.
+    iframe: {
+      url: 'https://surplus-market.pages.dev/',
+      origin: 'https://surplus-market.pages.dev',
+      appId: 'surplus',
+      allowedChainIds: [84532],
+      contracts: [],
+      messages: [],
+      allowReadAccount: false,
+      allowChainSwitch: false,
+      allowPopups: true,
+      allowSameOrigin: true,
     },
   },
   {


### PR DESCRIPTION
Makes the existing curated **Surplus** entry an embedded iframe app, and adds the one sandbox capability an app that runs its **own** wallet needs.

## Changes
- **`registry.ts`** — Surplus `externalApp.mode` `link → iframe` + an `iframe` policy block (appId `surplus`, chain `84532`). Surplus keeps its **own ConnectKit wallet** in-frame (not the parent bridge), so `allowReadAccount`/`allowChainSwitch` stay `false` and there are no contract/message grants. `allowPopups: true` (wallet popups + explorer links). `allowSameOrigin: true`.
- **`iframe/types.ts` + `BlueprintAppFrame.buildSandbox`** — new opt-in **`allowSameOrigin`**, honored **only for cross-origin apps**.

## Why allow-same-origin (the wallet-in-iframe fix)
An app running its own wallet needs persistent storage (WalletConnect/ConnectKit keyvalue store), which the current opaque-origin sandbox denies — that's why ConnectKit doesn't work framed today. For a **cross-origin** iframe, `allow-same-origin` restores the iframe's *own* origin (`surplus-market.pages.dev`) so it gets its storage; cross-origin policy still blocks it from reaching the parent's DOM/storage. We **refuse** the flag for same-origin apps (where `allow-scripts` + `allow-same-origin` would let the frame remove its own sandbox).

## Review asks (security-sensitive)
- This widens the deliberately-hardened sandbox in exactly one place. The **cross-origin guard** (`isCrossOrigin`) is the load-bearing safety property — please scrutinize.
- The flag is **not** parsed from on-chain metadata — curated entries only (untrusted metadata-path apps can never set it).
- **Coordination:** there's in-flight tangle-cloud work on `feat/tangle-cloud-unified-shell`; this targets `develop` and touches `registry.ts` / `BlueprintAppFrame.tsx` — rebase/coordinate as needed.
- **Not verified locally** (monorepo typecheck needs a full worktree install); relies on CI + review.

Pairs with: surplus#37 (app embed-readiness: `frame-ancestors` + embedded mode) and a follow-up PR adding a "Visit site" link for every blueprint via `website` metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)