### PR TITLE
feat(tangle-cloud): Show a visit-site link for every blueprint from website metadata

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppLandingPage.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppLandingPage.tsx
@@ -123,6 +123,7 @@ const BlueprintAppLandingPage: FC<Props> = ({ entry }) => {
         description={view.manifest.description}
         serviceNoun={serviceNoun}
         provisionPath={provisionPath}
+        websiteUrl={canonicalBlueprint?.websiteUrl}
         protocolDetailHref={
           activeMode?.blueprintId !== undefined
             ? `/blueprints/${activeMode.blueprintId.toString()}?raw=1`

--- a/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
@@ -26,6 +26,8 @@ type Props = {
   protocolDetailHref?: string;
   /** Optional publisher console (external app's standalone URL). */
   externalAppUrl?: string;
+  /** Optional link to the blueprint's own dedicated site (metadata `website`). */
+  websiteUrl?: string | null;
   /** Mode picker — only rendered when there are 2+ modes. */
   modes: BlueprintMode[];
   activeMode: BlueprintMode | null;
@@ -70,6 +72,7 @@ const IframeBlueprintLayout: FC<Props> = ({
   provisionPath,
   protocolDetailHref,
   externalAppUrl,
+  websiteUrl,
   modes,
   activeMode,
   onSelectMode,
@@ -168,6 +171,21 @@ const IframeBlueprintLayout: FC<Props> = ({
           >
             <ExpandIcon className="h-3.5 w-3.5" />
           </button>
+          {websiteUrl && (
+            <a
+              href={websiteUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="Visit the blueprint's own site"
+              className={twMerge(
+                'inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-transparent px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-[color:var(--bg-hover)]',
+                focus.ring,
+              )}
+            >
+              Visit site
+              <span aria-hidden>↗</span>
+            </a>
+          )}
           <button
             type="button"
             onClick={() => setDetailsOpen((v) => !v)}
@@ -193,6 +211,7 @@ const IframeBlueprintLayout: FC<Props> = ({
       provisionPath,
       serviceNoun,
       detailsOpen,
+      websiteUrl,
     ],
   );
   useTopNavSlot(navContent);

--- a/apps/tangle-cloud/src/components/blueprintApps/BlueprintHostCard.tsx
+++ b/apps/tangle-cloud/src/components/blueprintApps/BlueprintHostCard.tsx
@@ -265,6 +265,25 @@ const BlueprintHostCard = ({
               </button>
             </div>
           )}
+          {/* The blueprint's own site — distinct from the publisher console.
+           * Works for ANY blueprint that sets `website` in its metadata, with or
+           * without an iframe/console tier. */}
+          {blueprint.websiteUrl && (
+            <div className="mt-4 rounded-xl border border-border bg-[color:var(--bg-elevated)] p-4">
+              <p className="text-sm leading-6 text-muted-foreground">
+                Visit the blueprint&apos;s own site.
+              </p>
+              <a
+                href={blueprint.websiteUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-3 inline-flex items-center gap-2 rounded-md text-sm font-semibold text-foreground outline-none transition-colors hover:text-[color:var(--brand-cool)] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card"
+              >
+                Visit site
+                <ExternalLinkLine className="h-4 w-4" />
+              </a>
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
Lets **any** blueprint dev — iframe tier or not — link to their own dedicated site by setting `website` in metadata, and the cloud presents it. (Companion to #3266, which makes Surplus an iframe app.)

## The gap
`website` already flows end-to-end: on-chain `BlueprintMetadata.website` + off-chain metadata JSON (`website`/`homepage`) → `ParsedBlueprintMetadata.website` → `Blueprint.websiteUrl`, and the create/manage pages already author it. It renders on the **legacy** detail pages but **not** on the **modern** blueprint-app surfaces — so today a dev can publish a site URL that the new UI silently ignores. **Render gap, no schema change.**

## Changes
- **`BlueprintHostCard`** (declarative tier — the surface non-iframe blueprints get): render a "Visit site ↗" link when `blueprint.websiteUrl` is set, distinct from the publisher console (`externalApp`).
- **`IframeBlueprintLayout`** (iframe tier): thread `websiteUrl` through and render the link in the **top-nav slot** beside Details — the per-blueprint navbar.
- **`BlueprintAppLandingPage`**: pass `canonicalBlueprint.websiteUrl` into the layout.

## Result
An external dev sets `website` in metadata → the cloud shows a direct link to their site, **no iframe tier required** (the explicit ask). First-party/iframe blueprints get it in the navbar too.

**Not verified locally** (monorepo typecheck needs a full worktree install); relies on CI + review. Coordinate with the in-flight `feat/tangle-cloud-unified-shell` work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)