### PR TITLE
fix(tangle-cloud): Read website from BlueprintWithMetadata (repair develop typecheck)

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppLandingPage.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppLandingPage.tsx
@@ -123,7 +123,7 @@ const BlueprintAppLandingPage: FC<Props> = ({ entry }) => {
         description={view.manifest.description}
         serviceNoun={serviceNoun}
         provisionPath={provisionPath}
-        websiteUrl={canonicalBlueprint?.websiteUrl}
+        websiteUrl={canonicalBlueprint?.website}
         protocolDetailHref={
           activeMode?.blueprintId !== undefined
             ? `/blueprints/${activeMode.blueprintId.toString()}?raw=1`


### PR DESCRIPTION
**Hotfix for develop.** #3267 merged at its pre-fix head (`e98752c15`) — GitHub never synced the follow-up fix commit I pushed — so `develop` now has a TypeScript error:

```
BlueprintAppLandingPage.tsx(126,41): error TS2551: Property 'websiteUrl' does not exist on type 'BlueprintWithMetadata'. Did you mean 'website'?
```

`useBlueprint` returns `BlueprintWithMetadata` (field `website`), not the app-level `Blueprint` (field `websiteUrl`). One-line fix: `canonicalBlueprint?.websiteUrl` → `canonicalBlueprint?.website`. Restores the tangle-cloud typecheck/build on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)