### PR TITLE
[RELEASE] Promote develop → master: Inference Bazaar rename

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/policy.ts
+++ b/apps/tangle-cloud/src/blueprintApps/policy.ts
@@ -7,7 +7,13 @@ const splitEnvList = (value: string | undefined): string[] =>
     .map((item) => item.trim().toLowerCase())
     .filter(Boolean);
 
-const DEFAULT_RESERVED_SLUGS = ['trading', 'sandbox', 'training', 'surplus', 'bazaar'];
+const DEFAULT_RESERVED_SLUGS = [
+  'trading',
+  'sandbox',
+  'training',
+  'surplus',
+  'bazaar',
+];
 const DEFAULT_TRUSTED_EXTERNAL_APP_HOSTS = [
   'cloud.tangle.tools',
   'app.tangle.tools',

--- a/apps/tangle-cloud/src/blueprintApps/policy.ts
+++ b/apps/tangle-cloud/src/blueprintApps/policy.ts
@@ -7,7 +7,7 @@ const splitEnvList = (value: string | undefined): string[] =>
     .map((item) => item.trim().toLowerCase())
     .filter(Boolean);
 
-const DEFAULT_RESERVED_SLUGS = ['trading', 'sandbox', 'training', 'surplus'];
+const DEFAULT_RESERVED_SLUGS = ['trading', 'sandbox', 'training', 'surplus', 'bazaar'];
 const DEFAULT_TRUSTED_EXTERNAL_APP_HOSTS = [
   'cloud.tangle.tools',
   'app.tangle.tools',

--- a/apps/tangle-cloud/src/blueprintApps/registry.spec.ts
+++ b/apps/tangle-cloud/src/blueprintApps/registry.spec.ts
@@ -39,7 +39,7 @@ describe('blueprint app registry', () => {
     expect(tradingByMetadata?.slug).toBe('trading');
     expect(sandboxByMetadata?.slug).toBe('sandbox');
     expect(trainingBySlug?.slug).toBe('training');
-    expect(surplusByMetadata?.slug).toBe('surplus');
+    expect(surplusByMetadata?.slug).toBe('bazaar');
     expect(surplusByMetadata?.manifest.externalApp?.mode).toBe('iframe');
     // Surplus runs its own wallet in-frame, so it opts into allow-same-origin
     // (cross-origin → its own storage) but not the parent bridge grants.

--- a/apps/tangle-cloud/src/blueprintApps/registry.ts
+++ b/apps/tangle-cloud/src/blueprintApps/registry.ts
@@ -239,8 +239,8 @@ const entries = [
     },
   },
   {
-    slug: 'surplus',
-    canonicalSlug: 'surplus',
+    slug: 'bazaar',
+    canonicalSlug: 'bazaar',
     match: {
       publisherNamespace: 'tangle',
       requestedSlug: 'surplus',
@@ -257,7 +257,7 @@ const entries = [
       status: 'planned',
     },
     manifest: {
-      displayName: 'Surplus Market',
+      displayName: 'Inference Bazaar',
       tagline: 'Buy and sell prepaid AI inference credits.',
       description:
         'Open a surplus market venue, discover operators, inspect credit lots, and reconcile settlement batches for prepaid inference.',
@@ -297,10 +297,10 @@ const entries = [
         mode: 'iframe',
         host: 'surplus-market.pages.dev',
         trust: 'trusted',
-        label: 'Surplus Market',
+        label: 'Inference Bazaar',
       },
     },
-    // Iframe runtime policy. Surplus runs its OWN wallet (ConnectKit) inside the
+    // Iframe runtime policy. Inference Bazaar runs its OWN wallet (ConnectKit) inside the
     // frame rather than the parent bridge, so the bridge grants stay off
     // (allowReadAccount/allowChainSwitch false, no contract/message grants).
     // allowPopups: wallet connect popups + explorer links. allowSameOrigin:


### PR DESCRIPTION
Promotes the **Inference Bazaar** rename (cloud display "Inference Bazaar", route slug `bazaar`) to production (cloud.tangle.tools). Conflict-free (merge-tree clean); master keeps its newer staking-test/docs commits, gains develop's rename. `match.requestedSlug` stays `surplus` so it still claims the live blueprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)