### PR TITLE
chore(tangle-cloud): host inference bazaar on canonical blueprint domain

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/registry.ts
+++ b/apps/tangle-cloud/src/blueprintApps/registry.ts
@@ -293,9 +293,9 @@ const entries = [
         },
       ],
       externalApp: {
-        url: 'https://surplus-market.pages.dev/',
+        url: 'https://inference-bazaar.blueprint.tangle.tools/',
         mode: 'iframe',
-        host: 'surplus-market.pages.dev',
+        host: 'inference-bazaar.blueprint.tangle.tools',
         trust: 'trusted',
         label: 'Inference Bazaar',
       },
@@ -304,11 +304,11 @@ const entries = [
     // frame rather than the parent bridge, so the bridge grants stay off
     // (allowReadAccount/allowChainSwitch false, no contract/message grants).
     // allowPopups: wallet connect popups + explorer links. allowSameOrigin:
-    // surplus-market.pages.dev is cross-origin, so this gives the app its own
+    // inference-bazaar.blueprint.tangle.tools is cross-origin, so this gives the app its own
     // storage (WalletConnect/ConnectKit need it) without any parent access.
     iframe: {
-      url: 'https://surplus-market.pages.dev/',
-      origin: 'https://surplus-market.pages.dev',
+      url: 'https://inference-bazaar.blueprint.tangle.tools/',
+      origin: 'https://inference-bazaar.blueprint.tangle.tools',
       appId: 'surplus',
       allowedChainIds: [84532],
       contracts: [],


### PR DESCRIPTION
The Inference Bazaar blueprint app has moved off the `surplus-market.pages.dev` alias onto the canonical host **inference-bazaar.blueprint.tangle.tools** (a new CF Pages project + proxied CNAME on the `tangle.tools` zone, already serving 200).

Updates the curated registry entry's `externalApp` + `iframe` `url`/`host`/`origin` to the new domain.

The canonical host matches the `*.blueprint.tangle.tools` suffix allowlist (`policy.ts` `trustedIframeHostSuffixes`), so embedding is now permitted through the metadata path as well — the old `.pages.dev` alias only worked via the curated exception. No grant changes: still own-wallet (`allowReadAccount: false`, `allowChainSwitch: false`) with `allowSameOrigin` for ConnectKit storage.

Companion to surplus#39 (the app-side hosting move).