### PR TITLE
chore(tangle-cloud): host inference bazaar on canonical blueprint domain

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/registry.ts
+++ b/apps/tangle-cloud/src/blueprintApps/registry.ts
@@ -293,9 +293,9 @@ const entries = [
         },
       ],
       externalApp: {
-        url: 'https://surplus-market.pages.dev/',
+        url: 'https://inference-bazaar.blueprint.tangle.tools/',
         mode: 'iframe',
-        host: 'surplus-market.pages.dev',
+        host: 'inference-bazaar.blueprint.tangle.tools',
         trust: 'trusted',
         label: 'Inference Bazaar',
       },
@@ -304,11 +304,11 @@ const entries = [
     // frame rather than the parent bridge, so the bridge grants stay off
     // (allowReadAccount/allowChainSwitch false, no contract/message grants).
     // allowPopups: wallet connect popups + explorer links. allowSameOrigin:
-    // surplus-market.pages.dev is cross-origin, so this gives the app its own
+    // inference-bazaar.blueprint.tangle.tools is cross-origin, so this gives the app its own
     // storage (WalletConnect/ConnectKit need it) without any parent access.
     iframe: {
-      url: 'https://surplus-market.pages.dev/',
-      origin: 'https://surplus-market.pages.dev',
+      url: 'https://inference-bazaar.blueprint.tangle.tools/',
+      origin: 'https://inference-bazaar.blueprint.tangle.tools',
       appId: 'surplus',
       allowedChainIds: [84532],
       contracts: [],


### PR DESCRIPTION
Promote develop → master to ship the Inference Bazaar iframe host migration to production (cloud.tangle.tools).

**Net change to production:** `apps/tangle-cloud/src/blueprintApps/registry.ts` only (curated registry `externalApp` + `iframe` url/host/origin moved from the `surplus-market.pages.dev` alias to the canonical **inference-bazaar.blueprint.tangle.tools**). Verified via `git merge-tree origin/master origin/develop`: 1 file, 5/5 lines, no conflicts.

The new host is already serving 200 (CF Pages project + proxied CNAME on `tangle.tools`) and matches the `*.blueprint.tangle.tools` suffix allowlist, so embedding works via both the curated and metadata paths. The old `.pages.dev` alias only worked through the curated exception.

Companion to surplus#39 (app-side hosting move). After this lands on prod, the old `surplus-market` CF Pages project is deleted.