### PR TITLE
[RELEASE] feat(tangle-cloud): adopt parent-bridge wallet model for bazaar

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/registry.spec.ts
+++ b/apps/tangle-cloud/src/blueprintApps/registry.spec.ts
@@ -41,10 +41,13 @@ describe('blueprint app registry', () => {
     expect(trainingBySlug?.slug).toBe('training');
     expect(surplusByMetadata?.slug).toBe('bazaar');
     expect(surplusByMetadata?.manifest.externalApp?.mode).toBe('iframe');
-    // Surplus runs its own wallet in-frame, so it opts into allow-same-origin
-    // (cross-origin → its own storage) but not the parent bridge grants.
+    // Surplus now uses the parent-bridge wallet model (like trading-arena /
+    // agent-sandbox): allowReadAccount + allowChainSwitch granted so the
+    // connected wallet flows from the parent. allowSameOrigin is retained
+    // for own-origin app-state storage.
     expect(surplusByMetadata?.iframe?.allowSameOrigin).toBe(true);
-    expect(surplusByMetadata?.iframe?.allowReadAccount).toBe(false);
+    expect(surplusByMetadata?.iframe?.allowReadAccount).toBe(true);
+    expect(surplusByMetadata?.iframe?.allowChainSwitch).toBe(true);
   });
 
   it('returns null when metadata identity does not match any curated entry', () => {

--- a/apps/tangle-cloud/src/blueprintApps/registry.ts
+++ b/apps/tangle-cloud/src/blueprintApps/registry.ts
@@ -300,12 +300,18 @@ const entries = [
         label: 'Inference Bazaar',
       },
     },
-    // Iframe runtime policy. Inference Bazaar runs its OWN wallet (ConnectKit) inside the
-    // frame rather than the parent bridge, so the bridge grants stay off
-    // (allowReadAccount/allowChainSwitch false, no contract/message grants).
-    // allowPopups: wallet connect popups + explorer links. allowSameOrigin:
-    // inference-bazaar.blueprint.tangle.tools is cross-origin, so this gives the app its own
-    // storage (WalletConnect/ConnectKit need it) without any parent access.
+    // Iframe runtime policy. Inference Bazaar adopts the same parent-bridge
+    // model as trading-arena / agent-sandbox: when embedded it swaps its
+    // ConnectKit connectors for the parent-bridge connector, so the wallet
+    // flows from Tangle Cloud (browser extensions can't inject into the
+    // sandboxed cross-origin iframe anyway). allowReadAccount surfaces the
+    // connected wallet; allowChainSwitch is restricted to Base Sepolia
+    // (84532) — the chain the bazaar settlement contracts live on.
+    // allowPopups + allowSameOrigin are retained so the app keeps its own
+    // origin storage (UI/cache state) and explorer-link popups; the wallet
+    // itself no longer depends on them once the bridge connector is active.
+    // No contracts/messages yet: the bazaar UI doesn't issue
+    // tangle.app.signTransaction today, so no signing surface is granted.
     iframe: {
       url: 'https://inference-bazaar.blueprint.tangle.tools/',
       origin: 'https://inference-bazaar.blueprint.tangle.tools',
@@ -313,8 +319,8 @@ const entries = [
       allowedChainIds: [84532],
       contracts: [],
       messages: [],
-      allowReadAccount: false,
-      allowChainSwitch: false,
+      allowReadAccount: true,
+      allowChainSwitch: true,
       allowPopups: true,
       allowSameOrigin: true,
     },


### PR DESCRIPTION
## Summary

Inference Bazaar currently runs its **own** ConnectKit wallet inside the iframe (the only one of the three first-party iframe apps that doesn't use the parent bridge). This flips bazaar to the same parent-bridge model as trading-arena and agent-sandbox, so when embedded in Tangle Cloud the connected wallet flows from the parent (browser extensions can't inject into a sandboxed cross-origin iframe anyway — that's why the bridge exists).

### Change
Registry policy for `bazaar` (`apps/tangle-cloud/src/blueprintApps/registry.ts`):
- `allowReadAccount`: false → **true** (surfaces the parent wallet for read-only views)
- `allowChainSwitch`: false → **true** (restricted to Base Sepolia 84532, where the bazaar settlement contracts live)
- `allowPopups` + `allowSameOrigin`: **retained** (own-origin storage + explorer links; the wallet no longer depends on them once the bridge is active)
- `contracts` / `messages` remain `[]` — bazaar doesn't issue `signTransaction` yet

Companion test updated to lock in the new policy.

### Sequencing — important
This is the **prerequisite** for the bazaar-side connector swap (separate repo, `tangle-network/inference-bazaar`). Ship order matters:
1. **This PR first** (forward-compatible — shipping it alone changes nothing for users until bazaar deploys its connector swap, since bazaar won't exercise the bridge until then).
2. Then bazaar's `web3.tsx` swap (`detectTangleCloudParentOrigin` + `parentBridgeConnector`, mirroring arena/agent-sandbox) — **only after this reaches prod**, otherwise embedded bazaar would swap out ConnectKit while the parent still rejects `readAccount`, leaving it walletless.

## Gates
typecheck, lint (0 err), test (167 passed), build tangle-cloud all green.