### PR TITLE
[RELEASE] fix(tangle-cloud): font consistency, navbar dead space, pagination polish

### DIFF
--- a/apps/tangle-cloud/src/components/Layout.tsx
+++ b/apps/tangle-cloud/src/components/Layout.tsx
@@ -107,8 +107,8 @@ const Layout: FC<PropsWithChildren<Props>> = ({
           <ShortcutsHelp open={isHelpOpen} onOpenChange={setIsHelpOpen} />
 
           <div className="m-auto flex h-full max-w-[1448px] flex-col justify-between px-4 md:px-8 lg:px-10">
-            <div className="flex grow flex-col space-y-5">
-              <div className="flex items-center justify-between py-6">
+            <div className="flex grow flex-col space-y-4">
+              <div className="flex items-center justify-between py-4">
                 <div className="flex items-center space-x-4 lg:space-x-0">
                   <MobileSidebar />
                 </div>

--- a/apps/tangle-cloud/tailwind.config.ts
+++ b/apps/tangle-cloud/tailwind.config.ts
@@ -12,6 +12,15 @@ export default {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['var(--font-sans)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        mono: [
+          'var(--font-mono)',
+          'ui-monospace',
+          'SFMono-Regular',
+          'monospace',
+        ],
+      },
       backgroundImage: {
         glass:
           'linear-gradient(180deg,rgba(255,255,255,0.94) 0%,rgba(255,255,255,0.74) 100%)',

--- a/libs/ui-components/src/components/Pagination/Pagination.tsx
+++ b/libs/ui-components/src/components/Pagination/Pagination.tsx
@@ -79,56 +79,69 @@ export const Pagination = forwardRef<HTMLDivElement, PaginationProps>(
         )}
 
         {/** Right buttons */}
-        <div className="flex items-center space-x-1">
-          <ChevronLeft
-            size={iconSize}
-            className={
-              canPreviousPage && previousPage
-                ? 'cursor-pointer'
-                : 'cursor-not-allowed'
-            }
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            aria-label="Previous page"
+            disabled={!canPreviousPage}
             onClick={() => {
               if (canPreviousPage && previousPage) {
                 previousPage();
               }
             }}
-          />
+            className={cx(
+              'inline-flex h-8 w-8 items-center justify-center rounded-md border transition-colors',
+              'border-mono-40 dark:border-mono-140 text-mono-120 dark:text-mono-100',
+              'hover:bg-mono-20 hover:dark:bg-mono-160',
+              'disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent',
+            )}
+          >
+            <ChevronLeft size={iconSize} />
+          </button>
 
           {paginationDisplayItems.map((page, idx) =>
             typeof page === 'number' ? (
               <button
                 key={`${page}-${idx}`}
-                className={cx(
-                  'p-2 text-center body1 rounded-md',
-                  currentPage === page
-                    ? 'bg-blue-0 text-blue dark:bg-blue-120 dark:text-blue-0' // Active
-                    : 'bg-mono-0 dark:bg-mono-180 text-mono-200 dark:text-mono-40 hover:bg-mono-20 hover:dark:bg-mono-160',
-                )}
+                type="button"
                 onClick={() => setPageIndex?.(page - 1)}
+                className={cx(
+                  'inline-flex h-8 min-w-8 items-center justify-center rounded-md px-2 text-sm transition-colors',
+                  currentPage === page
+                    ? 'bg-primary text-primary-foreground font-medium'
+                    : 'text-mono-120 dark:text-mono-100 hover:bg-mono-20 hover:dark:bg-mono-160',
+                )}
               >
                 {page}
               </button>
             ) : (
-              <p
+              <span
                 key={`${page}-${idx}`}
-                className="p-2 text-center select-none body1"
+                className="select-none px-1 text-mono-100"
               >
-                ...
-              </p>
+                …
+              </span>
             ),
           )}
 
-          <ChevronRight
-            size={iconSize}
-            className={
-              canNextPage && nextPage ? 'cursor-pointer' : 'cursor-not-allowed'
-            }
+          <button
+            type="button"
+            aria-label="Next page"
+            disabled={!canNextPage}
             onClick={() => {
               if (canNextPage && nextPage) {
                 nextPage();
               }
             }}
-          />
+            className={cx(
+              'inline-flex h-8 w-8 items-center justify-center rounded-md border transition-colors',
+              'border-mono-40 dark:border-mono-140 text-mono-120 dark:text-mono-100',
+              'hover:bg-mono-20 hover:dark:bg-mono-160',
+              'disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent',
+            )}
+          >
+            <ChevronRight size={iconSize} />
+          </button>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary

Three senior-quality UI fixes Drew flagged on cloud. Kept simple — no new surface, three targeted root-cause fixes. All verified to build for **both** apps (the Pagination component is shared with tangle-dapp).

### 1. Font theme consistency (blueprints page looked different)
**Root cause:** cloud's tailwind config never mapped `fontFamily`, so every `font-sans` utility resolved to the **browser system stack** while body text used Satoshi via `--font-sans`. The `/blueprints` page surfaced it worst (gallery + pagination lean on `font-sans`).
**Fix:** map `fontFamily.sans`/`.mono` to the existing `--font-sans`/`--font-mono` CSS vars → `font-sans` = Satoshi everywhere. (`apps/tangle-cloud/tailwind.config.ts`)

### 2. Navbar dead space (all pages)
`Layout.tsx` header row `py-6` + the `space-y-5` to `<main>` stacked into a **~44px dead band** below the navbar. Tightened to `py-4` / `space-y-4`.

### 3. Pagination polish (shared component)
- Prev/Next were **bare chevron icons** with no button affordance (just a cursor flip) — read as floating glyphs. Wrapped in real `<button>`s with border, hover, disabled states, aria-labels.
- Active page: low-contrast `bg-blue-0` → design-system **`bg-primary text-primary-foreground`** (clear in both themes, both apps).
- Inactive pages: subtle text + hover. Ellipsis as a lightweight span.

## Gates
typecheck, lint (0 err), build tangle-cloud + tangle-dapp all green.

## Not included — bazaar gallery visibility (deliberately)
Bazaar doesn't appear because the gallery lists **only on-chain-registered blueprints** (`useAllBlueprints()`); curated registry entries drive routing/iframe policy but aren't gallery cards. Fixing that is a **feature** (a first-party apps rail with correct routing + dedup against on-chain entries like trading-arena that are *both* curated and registered), not a polish fix — and per the "senior quality / keep it simple" bar I won't ship an unverified feature rail blind. Needs a product decision: register bazaar on-chain, or build the rail as a focused, visually-verified follow-up.