### PR TITLE
[RELEASE] feat(tangle-cloud): peel sandbox-ui overlay → shared design (dapp parity, step 1)

### DIFF
--- a/apps/tangle-cloud/src/components/Layout.tsx
+++ b/apps/tangle-cloud/src/components/Layout.tsx
@@ -54,11 +54,6 @@ const Layout: FC<PropsWithChildren<Props>> = ({
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
     document.documentElement.style.colorScheme = theme;
-    document.documentElement.setAttribute('data-sandbox-ui', '');
-    document.documentElement.setAttribute(
-      'data-sandbox-theme',
-      theme === 'dark' ? 'tangle' : 'vault',
-    );
   }, [theme]);
 
   // Publish the current sidebar width as a CSS variable on the root element so
@@ -85,11 +80,7 @@ const Layout: FC<PropsWithChildren<Props>> = ({
 
   return (
     <TopNavSlotProvider>
-      <div
-        data-sandbox-ui
-        data-sandbox-theme={theme === 'dark' ? 'tangle' : 'vault'}
-        className="tangle-cloud-shell flex h-screen bg-tangle text-foreground"
-      >
+      <div className="tangle-cloud-shell flex h-screen bg-tangle text-foreground">
         <Sidebar
           isExpandedByDefault={isSidebarExpanded}
           onExpandedChange={() => setIsSidebarExpanded((value) => !value)}

--- a/apps/tangle-cloud/src/styles.css
+++ b/apps/tangle-cloud/src/styles.css
@@ -1,14 +1,19 @@
-/* Tangle Cloud styles. Tokens (--md3-*, --hsl-*, --bg-*, --text-*, --border-*,
- * --btn-*, --shadow-*, [data-sandbox-theme='vault'] light overrides) come from
- * @tangle-network/brand via the sandbox-ui vendor CSS preloaded in index.html.
- * This file adds tangle/vault theme deltas and cloud-only component classes.
- * `!important` is reserved for fights against legacy ui-components @layer base
- * rules ('*:not(code) Satoshi', 'h1..h6 text-mono-*') that arrive in the bundle
- * BEFORE cloud styles. */
+/* Tangle Cloud structural styles.
+ *
+ * The sandbox-ui theming overlay (data-sandbox-ui / data-sandbox-theme attrs,
+ * cloud-only token overrides, and the utility rebindings that rewired
+ * .bg-card/.bg-muted/.border/etc. to cloud tokens) has been peeled. Cloud now
+ * renders with the shared @tangle-network/ui-components design system — the
+ * same one tangle-dapp uses — instead of a divergent cloud palette. All
+ * color/surface tokens come from the shared system.
+ *
+ * What remains here is genuinely cloud-specific STRUCTURE: font stacks,
+ * typography normalization (defeat ui-components' mono-color + italic-
+ * synthesis base rules), Radix-dialog centering against the fixed sidebar,
+ * page transitions, and a couple of hardcoded cloud marks. */
 @import '@tangle-network/brand/styles/tokens.css';
 
-:root,
-[data-sandbox-ui] {
+:root {
   --font-sans: 'Satoshi', ui-sans-serif, system-ui, sans-serif;
   --font-display: 'Satoshi', ui-sans-serif, system-ui, sans-serif;
   --font-mono: 'Cousine', ui-monospace, SFMono-Regular, monospace;
@@ -18,10 +23,8 @@ html,
 body {
   min-height: 100%;
   overflow-x: hidden;
-  background: var(--bg-root, #060711);
 }
 body {
-  color: var(--text-primary, hsl(var(--foreground)));
   font-family: var(--font-sans);
 }
 #root {
@@ -29,63 +32,9 @@ body {
   font-family: var(--font-sans);
 }
 
-.tangle-cloud-shell {
-  color: var(--text-primary);
-}
-
-/* Dark theme deltas vs sandbox-ui defaults. Tailwind HSL aliases at the bottom
- * re-bind .bg-card/.bg-primary/.border utilities to cloud tokens. */
-[data-sandbox-ui][data-sandbox-theme='tangle'],
-.tangle-cloud-shell[data-sandbox-theme='tangle'] {
-  color-scheme: dark;
-  /* prettier-ignore */
-  --bg-root: radial-gradient(ellipse 60% 36% at 16% 0%, rgba(79, 70, 229, 0.1), transparent), radial-gradient(ellipse 44% 30% at 84% 4%, rgba(20, 184, 166, 0.08), transparent), linear-gradient(180deg, #090b10 0%, #07080c 100%);
-  --bg-card: #151922;
-  --bg-elevated: #202737;
-  --bg-hover: rgba(116, 126, 194, 0.18);
-  --text-primary: #dbe3f0;
-  --text-muted: #9aa7ba;
-  --text-secondary: #c3ccdc;
-  --border-subtle: rgba(116, 126, 194, 0.12);
-  --border-default: rgba(135, 146, 172, 0.26);
-  --border-hover: rgba(151, 161, 245, 0.46);
-  --border-accent: rgba(129, 140, 248, 0.36);
-  --border-accent-hover: rgba(129, 140, 248, 0.55);
-  --accent-surface-soft: rgba(99, 102, 241, 0.12);
-  --btn-primary-bg: #4f46e5;
-  --btn-primary-hover: #4338ca;
-  /* prettier-ignore */
-  --shadow-card: 0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 8px 24px rgba(0, 0, 0, 0.28);
-  /* prettier-ignore */
-  --shadow-hover: 0 1px 0 rgba(255, 255, 255, 0.06) inset, 0 16px 36px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(129, 140, 248, 0.18);
-  --card: 246 22% 14%;
-  --popover: 248 32% 21%;
-  --muted: 248 32% 21%;
-  --border: 232 32% 67% / 0.24;
-  --input: 232 32% 67% / 0.24;
-  --primary: 239 84% 59%;
-}
-
-[data-sandbox-ui][data-sandbox-theme='vault'],
-.tangle-cloud-shell[data-sandbox-theme='vault'] {
-  color-scheme: light;
-  --brand-cool: #3730a3;
-  --brand-primary: #4f46e5;
-  --brand-vibrant: #4f46e5;
-  --btn-primary-bg: #4f46e5;
-  --btn-primary-hover: #4338ca;
-  --border-subtle: rgba(82, 88, 132, 0.18);
-  --border-default: rgba(82, 88, 132, 0.3);
-  --border-hover: rgba(79, 70, 229, 0.42);
-  --border-accent: rgba(79, 70, 229, 0.18);
-  --border-accent-hover: rgba(79, 70, 229, 0.34);
-}
-
-/* Defeat ui-components' h1..h6/p/div text-mono color rules via inherit.
- * Also force `font-style: normal` so the browser's italic synthesis (which
- * fires when a requested weight is missing from a fallback font) doesn't
- * sneak in slanted glyphs on body text. Italic is a deliberate emphasis
- * marker in this app and shows up only via explicit `.italic` class. */
+/* Defeat ui-components' h1..h6/p/div text-mono color rules via inherit, and
+ * force font-style: normal so a missing-weight fallback font doesn't
+ * synthesize slanted glyphs. Italic is opt-in via .italic only. */
 .tangle-cloud-shell
   :where(h1, h2, h3, h4, h5, h6, p, label, li, td, th, button, a, span) {
   color: inherit;
@@ -111,119 +60,22 @@ body {
     textarea,
     div
   ):not(.italic) {
-  /* `!important` + form controls: the previous rule (no !important, no
-   * inputs/selects) let slanted fallback glyphs through on the search bar
-   * and category chips. Italics are opt-in via `.italic` only. */
   font-style: normal !important;
 }
-
-/* Tailwind/shadcn utility classes used by the cloud — sandbox-ui's prebuilt
- * vendor.css doesn't ship these (it only includes classes sandbox-ui itself
- * uses), so cloud has to define them. Bound to cloud tokens; no !important
- * because no other rule defines them. */
-[data-sandbox-ui] .bg-background {
-  background-color: var(--bg-root, hsl(var(--background)));
+.tangle-cloud-shell :where(h1, h2, h3) {
+  font-family: var(--font-display);
 }
-[data-sandbox-ui] .bg-card {
-  background-color: var(--bg-card);
+.tangle-cloud-shell a:not([class*='text-']) {
+  color: inherit;
 }
-[data-sandbox-ui] .bg-popover {
-  background-color: var(--bg-elevated);
-}
-[data-sandbox-ui] .bg-muted {
-  background-color: var(--bg-elevated);
-}
-[data-sandbox-ui] .bg-muted\/30 {
-  background-color: color-mix(in srgb, var(--bg-elevated) 30%, transparent);
-}
-[data-sandbox-ui] .bg-muted\/40 {
-  background-color: color-mix(in srgb, var(--bg-elevated) 40%, transparent);
-}
-[data-sandbox-ui] .bg-muted\/50 {
-  background-color: color-mix(in srgb, var(--bg-elevated) 50%, transparent);
-}
-[data-sandbox-ui] .bg-card\/70 {
-  background-color: color-mix(in srgb, var(--bg-card) 70%, transparent);
-}
-[data-sandbox-ui] .bg-primary {
-  background-color: var(--btn-primary-bg);
-  color: var(--btn-primary-text);
-}
-[data-sandbox-ui] .hover\:bg-primary\/90:hover {
-  background-color: var(--btn-primary-hover);
-}
-[data-sandbox-ui] .hover\:bg-muted:hover,
-[data-sandbox-ui] .hover\:bg-muted\/60:hover {
-  background-color: var(--bg-hover);
-}
-[data-sandbox-ui] .text-foreground,
-[data-sandbox-ui] .text-card-foreground,
-[data-sandbox-ui] .text-popover-foreground {
-  color: var(--text-primary);
-}
-[data-sandbox-ui] .text-muted-foreground {
-  color: var(--text-muted);
-}
-[data-sandbox-ui] .text-secondary-foreground {
-  color: var(--text-secondary);
-}
-[data-sandbox-ui] .text-primary {
-  color: var(--brand-cool);
-}
-[data-sandbox-ui] .text-primary-foreground {
-  color: var(--btn-primary-text);
-}
-[data-sandbox-ui] .text-destructive {
-  color: var(--surface-danger-text);
-}
-[data-sandbox-ui] .border,
-[data-sandbox-ui] .border-border,
-[data-sandbox-ui] .border-input {
-  border-color: var(--border-default);
-}
-[data-sandbox-ui] .border-primary {
-  border-color: var(--brand-cool);
-}
-[data-sandbox-ui] .border-primary\/20 {
-  border-color: var(--border-accent);
+.font-display {
+  font-family: var(--font-display);
 }
 
-/* Radix portals to <body>, escaping the shell. Bind popovers to cloud tokens. */
-[data-radix-popper-content-wrapper] [role='menu'],
-[data-radix-popper-content-wrapper] [role='listbox'] {
-  border: 1px solid var(--border-default);
-  background: color-mix(in srgb, var(--bg-card) 96%, var(--bg-elevated) 4%);
-  box-shadow: var(--shadow-dropdown);
-}
-[data-radix-popper-content-wrapper] [role='menuitem'],
-[data-radix-popper-content-wrapper] [role='option'] {
-  color: var(--text-primary);
-}
-[data-radix-popper-content-wrapper] [role='menuitem']:hover,
-[data-radix-popper-content-wrapper] [role='option']:hover,
-[data-radix-popper-content-wrapper] [role='menuitem'][data-highlighted],
-[data-radix-popper-content-wrapper] [role='option'][data-highlighted] {
-  background: var(--bg-hover);
-}
-
-/* Radix Dialog content portals to <body> and centers on the *viewport*, not
- * the content area, so on lg+ viewports it lands partially under the fixed
- * sidebar. The dialog uses Tailwind's `left-1/2 -translate-x-1/2 top-1/2
- * -translate-y-1/2` — overriding `left` alone doesn't work because the
- * tw-animate-css `slide-in-from-left-1/2` animation re-applies a
- * `translateX(-50%)` ON TOP, double-shifting the modal off-center.
- *
- * The fix is to override Tailwind's `--tw-translate-x` custom property —
- * the source of the translateX in every Tailwind transform utility. Adding
- * `var(--cloud-sidebar-width) / 2` to the translation shifts the modal
- * right by half the sidebar, landing it at the content-area center.
- *
- * SCOPE: only applies to truly center-anchored dialogs. Side-panel dialogs
- * (the RegistrationDrawer, any other right/left/top/bottom-anchored sheet)
- * carry `left-auto`, `right-auto`, or top/bottom anchors and explicitly set
- * `translate-x-0` / `translate-y-0` — the negation selectors below leave
- * those alone so my centering math doesn't drag the drawer back to center.
- */
+/* Radix Dialog centering — content portals to <body> and centers on the
+ * viewport; on lg+ the fixed sidebar offsets content-area center. Shift the
+ * modal right by half the sidebar so it lands at content-area center.
+ * Side-panel sheets (left-auto/right-auto/translate-x-0) are excluded. */
 @media (min-width: 1024px) {
   [role='dialog'][data-state='open']:not([class*='left-auto']):not(
       [class*='right-auto']
@@ -237,12 +89,7 @@ body {
   }
 }
 
-.tangle-cloud-shell a:not([class*='text-']) {
-  color: inherit;
-}
-.tangle-cloud-page {
-  color: var(--text-primary);
-}
+/* Page heading scale for `.tangle-cloud-page` wrappers. */
 .tangle-cloud-page h1 {
   font-size: clamp(2rem, 3vw, 2.375rem);
   line-height: 1.12;
@@ -262,30 +109,8 @@ body {
 .tangle-cloud-page p {
   text-wrap: pretty;
 }
-:where([data-sandbox-ui]) :where(h1, h2, h3) {
-  font-family: var(--font-display);
-}
-.font-display {
-  font-family: var(--font-display);
-}
 
-.tangle-cloud-card {
-  border: 1px solid var(--border-subtle);
-  background: var(--bg-card);
-  box-shadow: var(--shadow-card);
-}
-
-/* Page-to-page transition triggered by PageMotion when react-router's
- * pathname changes. 100ms total: 4px upward translate + opacity fade-in.
- * Honors `prefers-reduced-motion` — reduced-motion users get the fade
- * only, no translate.
- *
- * Why an attribute-keyed animation and not a CSS `transition` on a class:
- * `transition` only fires when a CSS property *changes*, so the initial
- * mount paint wouldn't trigger anything. A keyframe `animation`, scoped
- * by an attribute selector, fires every time the attribute appears,
- * giving us a clean enter-from-nothing on every navigation.
- */
+/* Page-to-page transition triggered by PageMotion on route change. */
 .cloud-page-motion[data-cloud-page-motion='entering'] {
   animation: cloud-page-enter 100ms ease-out;
 }
@@ -317,108 +142,8 @@ body {
 .tangle-cloud-shell :where(button, select, [role='tab']):active {
   transform: translateY(1px);
 }
-.blueprint-card {
-  /* prettier-ignore */
-  transition: background-color 180ms ease, border-color 180ms ease, transform 160ms ease, box-shadow 180ms ease;
-}
-.blueprint-card:hover {
-  transform: translateY(-1px);
-  /* prettier-ignore */
-  border-color: color-mix(in srgb, var(--brand-cool) 34%, var(--border-default));
-  /* prettier-ignore */
-  box-shadow: var(--shadow-hover), 0 0 0 1px color-mix(in srgb, var(--brand-cool) 12%, transparent);
-}
-
-/* Topbar buttons (network selector, theme toggle, etc.) — uniform ghost
- * surface aligned with sandbox-ui's flat aesthetic. Previous version used a
- * different background for the connect button than for the others, which
- * read as two unrelated systems coexisting in the same nav. */
-.tangle-cloud-topbar button,
-.tangle-cloud-topbar [role='button'] {
-  height: 36px;
-  border-radius: 6px;
-  border: 1px solid var(--border-default);
-  background: transparent;
-  color: var(--text-primary);
-  font-weight: 500;
-  font-style: normal;
-  box-shadow: none;
-}
-.tangle-cloud-topbar button:hover,
-.tangle-cloud-topbar [role='button']:hover {
-  background: var(--bg-hover);
-}
-.tangle-cloud-topbar button svg,
-.tangle-cloud-topbar [role='button'] svg {
-  width: 14px;
-  height: 14px;
-}
-
-/* Connect-wallet button + the in-page "Connect" CTA share styling. Single
- * solid primary fill — same as every other primary action in the app. No
- * gradients, no extra padding, no extra rounding. The "looks like staking
- * dapp" complaint was the indigo gradient we had been forcing here; with
- * it gone the button reads as a native cloud-app primary. */
-.tangle-cloud-wallet-action button,
-[data-sandbox-ui] [data-testid='evm-connect-trigger'] {
-  height: 36px;
-  border-radius: 6px;
-  border: 1px solid transparent;
-  background: var(--btn-primary-bg);
-  color: var(--btn-primary-text);
-  font-weight: 600;
-  font-style: normal;
-  padding-inline: 14px;
-  box-shadow: none;
-}
-.tangle-cloud-wallet-action button:hover,
-[data-sandbox-ui] [data-testid='evm-connect-trigger']:hover {
-  background: var(--btn-primary-hover);
-  color: var(--btn-primary-text);
-}
-
-/* Wallet brand mark — restrained mono tile, sized to the connect button's
- * height. Previous version was a white-frosted square to defeat the indigo
- * gradient backdrop; with the gradient gone it can match the button's
- * surface tone instead. */
-.tangle-cloud-wallet-action button > :first-child:is(svg, [role='img']),
-.tangle-cloud-wallet-action button > div:has(> svg):first-child {
-  background: color-mix(in srgb, var(--btn-primary-text) 18%, transparent);
-  border-radius: 4px;
-  padding: 2px;
-  min-width: 20px;
-  min-height: 20px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-/* Wallet button inner text — preserve primary-button contrast against the
- * solid primary surface. Removes the previous gradient-only !important. */
-.tangle-cloud-wallet-action button p,
-.tangle-cloud-wallet-action button span:not(.sr-only) {
-  color: var(--btn-primary-text);
-  font-style: normal;
-}
 
 .tangle-cloud-visual-badge {
   background-color: #111827;
   color: #ffffff;
-}
-
-/* BlueprintHostCard uses Tailwind `!`-prefix utilities (= !important);
- * cloud overrides must match. */
-.tangle-blueprint-host [class*='border-white'] {
-  border-color: color-mix(
-    in srgb,
-    var(--brand-cool) 18%,
-    transparent
-  ) !important;
-}
-.tangle-blueprint-host [class*='bg-white'] {
-  background-color: color-mix(
-    in srgb,
-    var(--bg-elevated) 72%,
-    transparent
-  ) !important;
 }


### PR DESCRIPTION
Peels cloud's sandbox-ui theming overlay (attrs + token blocks + utility rebindings + token-dependent component rules) so cloud renders with the shared ui-components design — the same one tangle-dapp uses. Step 1 of cloud→dapp chrome alignment. **Needs visual QA** — @drewstone / auditing via bad design-audit on the deploy preview. Gates: build + lint green.