### PR TITLE
cleanup(tangle-cloud): remove dead overlay class refs

### DIFF
--- a/apps/tangle-cloud/src/components/RequireWallet.tsx
+++ b/apps/tangle-cloud/src/components/RequireWallet.tsx
@@ -61,7 +61,7 @@ const RequireWallet: FC<Props> = ({
           )}
         </span>
       }
-      primary={<ConnectWalletButton className="tangle-cloud-wallet-action" />}
+      primary={<ConnectWalletButton />}
     />
   );
 };

--- a/apps/tangle-cloud/src/components/blueprintApps/BlueprintHostCard.tsx
+++ b/apps/tangle-cloud/src/components/blueprintApps/BlueprintHostCard.tsx
@@ -78,7 +78,7 @@ const BlueprintHostCard = ({
     // back to the tangle dark default). See BlueprintAppLandingPage for the
     // same fix in PR #3228.
     <div
-      className="tangle-blueprint-host space-y-6"
+      className="space-y-6"
       style={
         {
           '--blueprint-accent': accentColor,

--- a/apps/tangle-cloud/src/pages/instances/AccountStatsCard.tsx
+++ b/apps/tangle-cloud/src/pages/instances/AccountStatsCard.tsx
@@ -131,7 +131,7 @@ export const AccountStatsCard: FC<AccountStatsCardProps> = (props) => {
             </p>
           </div>
           <div className="mt-auto">
-            <ConnectWalletButton className="tangle-cloud-wallet-action" />
+            <ConnectWalletButton />
           </div>
         </CardContent>
       </Card>

--- a/apps/tangle-cloud/src/pages/instances/TotalValueLocked/index.tsx
+++ b/apps/tangle-cloud/src/pages/instances/TotalValueLocked/index.tsx
@@ -43,7 +43,7 @@ const DisconnectedTvlState = () => (
         wallet is connected. Public chain data on this page loads without one.
       </p>
     </div>
-    <ConnectWalletButton className="tangle-cloud-wallet-action shrink-0" />
+    <ConnectWalletButton className="shrink-0" />
   </div>
 );
 


### PR DESCRIPTION
Pure dead-code cleanup after the overlay peel — removes now-no-op className refs (tangle-cloud-wallet-action ×3, tangle-blueprint-host). No functional change. Staging-only.