### PR TITLE
fix(tangle-cloud): bump tiny type scale (tables/headers/buttons)

### DIFF
--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrameOverlay.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintAppFrameOverlay.tsx
@@ -133,7 +133,7 @@ const BlueprintAppFrameOverlay: FC<Props> = ({
           <p className="text-sm leading-relaxed text-muted-foreground">
             {phaseBody(phase, appDisplayName)}
           </p>
-          <p className="pt-1 font-mono text-[11px] text-muted-foreground/70">
+          <p className="pt-1 font-mono text-xs text-muted-foreground/70">
             {origin}
           </p>
         </div>

--- a/apps/tangle-cloud/src/blueprintApps/components/BlueprintModePicker.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/BlueprintModePicker.tsx
@@ -40,7 +40,7 @@ const BlueprintModePicker: FC<Props> = ({
     // current theme's tokens under this section.
     <section aria-label="Deployment mode" className="space-y-3">
       <header className="space-y-1">
-        <p className="font-semibold text-muted-foreground text-[11px] uppercase tracking-wider">
+        <p className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
           Deployment mode
         </p>
         <h2 className="font-display font-extrabold text-foreground text-lg">

--- a/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
+++ b/apps/tangle-cloud/src/blueprintApps/components/IframeBlueprintLayout.tsx
@@ -118,7 +118,7 @@ const IframeBlueprintLayout: FC<Props> = ({
          * style used across the app; the section root links to the catalog. */}
         <nav
           aria-label="Breadcrumb"
-          className="flex min-w-0 items-center gap-1.5 text-[13px]"
+          className="flex min-w-0 items-center gap-1.5 text-sm"
         >
           <Link
             to="/blueprints"
@@ -260,7 +260,7 @@ const IframeBlueprintLayout: FC<Props> = ({
                 <CloseIcon className="h-3.5 w-3.5" />
                 Back to Cloud
               </button>
-              <span className="hidden max-w-[42vw] truncate border-l border-border pl-2 font-mono text-[11px] text-muted-foreground sm:inline">
+              <span className="hidden max-w-[42vw] truncate border-l border-border pl-2 font-mono text-xs text-muted-foreground sm:inline">
                 {displayName}
               </span>
             </div>

--- a/apps/tangle-cloud/src/components/Header.tsx
+++ b/apps/tangle-cloud/src/components/Header.tsx
@@ -35,7 +35,7 @@ export default function Header({
   return (
     <header
       className={twMerge(
-        'flex items-center justify-end gap-2 font-sans text-[13px] tracking-tight',
+        'flex items-center justify-end gap-2 font-sans text-sm tracking-tight',
         className,
       )}
       {...props}

--- a/apps/tangle-cloud/src/components/Text.tsx
+++ b/apps/tangle-cloud/src/components/Text.tsx
@@ -24,7 +24,7 @@ import type { ComponentProps, ElementType, FC } from 'react';
  *   - `body-lg`  → text-base (replaces legacy `body1`)
  *   - `body`     → text-sm  (replaces legacy `body2`, the default)
  *   - `body-sm`  → text-xs  (replaces legacy `body3` / `body4`)
- *   - `caption`  → text-[11px] muted (timestamps, meta)
+ *   - `caption`  → text-xs muted (timestamps, meta)
  *
  * Legacy aliases ('h4', 'h5', 'body1', 'body2', 'body3', 'body4') resolve to
  * the same classes the per-page shims used, preserving visual parity.
@@ -118,7 +118,7 @@ const classFor = (variant: ReturnType<typeof canonicalize>): string => {
     case 'body-sm':
       return 'text-xs text-muted-foreground';
     case 'caption':
-      return 'text-[11px] text-muted-foreground';
+      return 'text-xs text-muted-foreground';
   }
 };
 

--- a/apps/tangle-cloud/src/components/TxHistoryDrawer.tsx
+++ b/apps/tangle-cloud/src/components/TxHistoryDrawer.tsx
@@ -44,7 +44,7 @@ const CopyValueButton: FC<{ value: string; label: string }> = ({
 }) => (
   <button
     type="button"
-    className="text-[11px] text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+    className="text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
     onClick={() => void navigator.clipboard?.writeText(value)}
   >
     Copy {label}
@@ -255,11 +255,11 @@ const DetailRow: FC<DetailRowProps> = ({
 
   return (
     <div className="flex items-center justify-between gap-2">
-      <span className="text-muted-foreground text-[13px]">{label}</span>
+      <span className="text-muted-foreground text-sm">{label}</span>
       <div className="flex items-center gap-1.5">
         <span
           className={twMerge(
-            'text-foreground text-[13px]',
+            'text-foreground text-sm',
             isAddress && 'font-mono',
           )}
         >

--- a/apps/tangle-cloud/src/components/binaryUpgrade/AttestForm.tsx
+++ b/apps/tangle-cloud/src/components/binaryUpgrade/AttestForm.tsx
@@ -216,7 +216,7 @@ export const AttestForm: FC<AttestFormProps> = ({
           }
         />
         {mode === 'pdf' && reportFile && (
-          <p className="break-all font-mono text-muted-foreground text-[11px]">
+          <p className="break-all font-mono text-muted-foreground text-xs">
             sha256 {reportHash}
           </p>
         )}

--- a/apps/tangle-cloud/src/components/binaryUpgrade/AttestationBadge.tsx
+++ b/apps/tangle-cloud/src/components/binaryUpgrade/AttestationBadge.tsx
@@ -197,7 +197,7 @@ export const AttestationBadge: FC<AttestationBadgeProps> = ({
               </span>
             )}
           </div>
-          <p className="mt-0.5 truncate font-mono text-muted-foreground text-[11px]">
+          <p className="mt-0.5 truncate font-mono text-muted-foreground text-xs">
             {attestation.attester}
           </p>
         </div>

--- a/apps/tangle-cloud/src/components/binaryUpgrade/ServiceUpgradePanel.tsx
+++ b/apps/tangle-cloud/src/components/binaryUpgrade/ServiceUpgradePanel.tsx
@@ -631,7 +631,7 @@ const ManagerAssistSection: FC<{
                         <Badge variant="destructive">skipped</Badge>
                       )}
                     </div>
-                    <p className="break-all font-mono text-muted-foreground text-[11px]">
+                    <p className="break-all font-mono text-muted-foreground text-xs">
                       {v.binaryUri}
                     </p>
                   </div>

--- a/apps/tangle-cloud/src/components/binaryUpgrade/TrustScoreGauge.tsx
+++ b/apps/tangle-cloud/src/components/binaryUpgrade/TrustScoreGauge.tsx
@@ -104,7 +104,7 @@ export const TrustScoreGauge: FC<TrustScoreGaugeProps> = ({
           style={{ color }}
         >
           {score}
-          <span className="ml-1 font-display font-semibold text-[11px] text-muted-foreground uppercase tracking-wider">
+          <span className="ml-1 font-display font-semibold text-xs text-muted-foreground uppercase tracking-wider">
             / 100
           </span>
         </span>

--- a/apps/tangle-cloud/src/components/chrome/CommandPalette.tsx
+++ b/apps/tangle-cloud/src/components/chrome/CommandPalette.tsx
@@ -266,7 +266,7 @@ const CommandPalette: FC<Props> = ({ open, onOpenChange, extra = [] }) => {
             ))
           )}
         </div>
-        <div className="flex items-center justify-between border-t border-border px-4 py-2 text-[11px] text-muted-foreground">
+        <div className="flex items-center justify-between border-t border-border px-4 py-2 text-xs text-muted-foreground">
           <div className="flex items-center gap-3">
             <span>
               <kbd className="rounded border border-border bg-[color:var(--bg-elevated)]/60 px-1 font-mono">

--- a/apps/tangle-cloud/src/components/chrome/CopyableId.tsx
+++ b/apps/tangle-cloud/src/components/chrome/CopyableId.tsx
@@ -57,7 +57,7 @@ const CopyableId: FC<Props> = ({
       title={copied ? 'Copied' : `Copy: ${value}`}
       aria-label={`Copy ${value}`}
       className={twMerge(
-        'group inline-flex max-w-full items-center gap-1 font-mono text-[13px] tabular-nums text-foreground transition-colors hover:text-[color:var(--border-accent-hover)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--border-accent-hover)]',
+        'group inline-flex max-w-full items-center gap-1 font-mono text-sm tabular-nums text-foreground transition-colors hover:text-[color:var(--border-accent-hover)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--border-accent-hover)]',
         className,
       )}
     >

--- a/apps/tangle-cloud/src/components/chrome/DataTable.tsx
+++ b/apps/tangle-cloud/src/components/chrome/DataTable.tsx
@@ -155,9 +155,9 @@ function DataTable<T>({
                   <TableCell
                     key={i}
                     className={twMerge(
-                      'px-4 py-2.5 align-middle text-sm',
+                      'px-4 py-2.5 align-middle text-base',
                       col.align && ALIGN_CLASS[col.align],
-                      col.mono && 'font-mono text-[13px] tabular-nums',
+                      col.mono && 'font-mono text-sm tabular-nums',
                       col.hideBelow && HIDE_CLASS[col.hideBelow],
                       col.className,
                     )}

--- a/apps/tangle-cloud/src/components/chrome/FilterTray.tsx
+++ b/apps/tangle-cloud/src/components/chrome/FilterTray.tsx
@@ -54,7 +54,7 @@ const FilterTray: FC<Props> = ({
             <span
               className={twMerge(
                 typeRole.mono,
-                'flex h-5 min-w-[20px] items-center justify-center rounded-full bg-[color:var(--border-accent)] px-1.5 text-[11px] text-foreground',
+                'flex h-5 min-w-[20px] items-center justify-center rounded-full bg-[color:var(--border-accent)] px-1.5 text-xs text-foreground',
               )}
             >
               {activeCount}

--- a/apps/tangle-cloud/src/components/chrome/Money.tsx
+++ b/apps/tangle-cloud/src/components/chrome/Money.tsx
@@ -65,7 +65,7 @@ const Money: FC<Props> = ({
   return (
     <span
       className={twMerge(
-        'inline-flex items-baseline gap-1 font-mono text-[13px] tabular-nums',
+        'inline-flex items-baseline gap-1 font-mono text-sm tabular-nums',
         align === 'right' && 'justify-end',
         className,
       )}
@@ -73,9 +73,7 @@ const Money: FC<Props> = ({
     >
       <span className="text-foreground">{money.display}</span>
       {showSymbol && money.symbol && !money.isEmpty && (
-        <span className="text-[11px] text-muted-foreground">
-          {money.symbol}
-        </span>
+        <span className="text-xs text-muted-foreground">{money.symbol}</span>
       )}
       {copyable && !money.isEmpty && (
         <button

--- a/apps/tangle-cloud/src/components/chrome/ShortcutsHelp.tsx
+++ b/apps/tangle-cloud/src/components/chrome/ShortcutsHelp.tsx
@@ -47,7 +47,7 @@ const SHORTCUTS: Array<{
 ];
 
 const Kbd: FC<{ children: string }> = ({ children }) => (
-  <kbd className="inline-flex h-6 min-w-[24px] items-center justify-center rounded border border-border bg-[color:var(--bg-elevated)]/60 px-1.5 font-mono text-[11px] text-foreground">
+  <kbd className="inline-flex h-6 min-w-[24px] items-center justify-center rounded border border-border bg-[color:var(--bg-elevated)]/60 px-1.5 font-mono text-xs text-foreground">
     {children}
   </kbd>
 );

--- a/apps/tangle-cloud/src/components/chrome/TopNavSlot.tsx
+++ b/apps/tangle-cloud/src/components/chrome/TopNavSlot.tsx
@@ -102,7 +102,7 @@ export function useTopNavEntity(entity: TopNavEntity | null): void {
       <>
         <nav
           aria-label="Breadcrumb"
-          className="flex min-w-0 items-center gap-1.5 text-[13px]"
+          className="flex min-w-0 items-center gap-1.5 text-sm"
         >
           <Link
             to={sectionHref ?? '#'}

--- a/apps/tangle-cloud/src/components/stats/Stat.tsx
+++ b/apps/tangle-cloud/src/components/stats/Stat.tsx
@@ -55,7 +55,7 @@ const SIZE_STYLES: Record<
   },
   lg: {
     container: 'p-4',
-    label: 'text-[11px]',
+    label: 'text-xs',
     value: 'text-2xl',
   },
 };
@@ -140,7 +140,7 @@ export const Stat: FC<StatProps> = ({
         </div>
       )}
       {sublabel ? (
-        <p className="mt-1 truncate text-muted-foreground text-[11px]">
+        <p className="mt-1 truncate text-muted-foreground text-xs">
           {sublabel}
         </p>
       ) : null}

--- a/apps/tangle-cloud/src/pages/blueprints/[id]/deploy/DeploySteps/components/OperatorTable.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/[id]/deploy/DeploySteps/components/OperatorTable.tsx
@@ -119,7 +119,7 @@ export const OperatorTable: FC<Props> = ({
                           onChange={() => toggleRow(row.address)}
                         />
                       )}
-                      <div className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-gradient-to-br from-primary/25 to-accent/25 font-mono text-[11px] text-foreground">
+                      <div className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-gradient-to-br from-primary/25 to-accent/25 font-mono text-xs text-foreground">
                         {row.address.slice(2, 4).toUpperCase()}
                       </div>
                       <div className="min-w-0">

--- a/apps/tangle-cloud/src/pages/blueprints/[id]/deploy/page.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/[id]/deploy/page.tsx
@@ -489,7 +489,7 @@ const DeployPage: FC = () => {
                   Create instance
                 </Text>
               </div>
-              <span className="rounded-md border border-border bg-muted/40 px-2 py-1 font-mono text-[11px] text-muted-foreground">
+              <span className="rounded-md border border-border bg-muted/40 px-2 py-1 font-mono text-xs text-muted-foreground">
                 requestService
               </span>
             </div>

--- a/apps/tangle-cloud/src/pages/blueprints/[id]/page.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/[id]/page.tsx
@@ -509,7 +509,7 @@ const OperatorRow = ({ operator }: { operator: BlueprintOperator }) => {
             )}
           </div>
         ) : (
-          <span className="font-mono text-muted-foreground text-[11px]">
+          <span className="font-mono text-muted-foreground text-xs">
             No vaults indexed
           </span>
         )}

--- a/apps/tangle-cloud/src/pages/operators/page.tsx
+++ b/apps/tangle-cloud/src/pages/operators/page.tsx
@@ -275,10 +275,10 @@ const OperatorsPanel = ({
             <Table>
               <TableHeader>
                 <TableRow className="border-border bg-[var(--bg-elevated)]/60 hover:bg-[var(--bg-elevated)]/60">
-                  <TableHead className="w-[36%] font-semibold text-muted-foreground text-[11px] uppercase tracking-wider">
+                  <TableHead className="w-[36%] font-semibold text-muted-foreground text-xs uppercase tracking-wider">
                     Operator
                   </TableHead>
-                  <TableHead className="font-semibold text-muted-foreground text-[11px] uppercase tracking-wider">
+                  <TableHead className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
                     <SortableHead
                       label="Stake"
                       isActive={sortKey === 'stake'}
@@ -286,7 +286,7 @@ const OperatorsPanel = ({
                       onClick={() => onSort('stake')}
                     />
                   </TableHead>
-                  <TableHead className="font-semibold text-muted-foreground text-[11px] uppercase tracking-wider">
+                  <TableHead className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
                     <SortableHead
                       label="Delegations"
                       isActive={sortKey === 'delegations'}
@@ -294,10 +294,10 @@ const OperatorsPanel = ({
                       onClick={() => onSort('delegations')}
                     />
                   </TableHead>
-                  <TableHead className="font-semibold text-muted-foreground text-[11px] uppercase tracking-wider">
+                  <TableHead className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
                     Mode
                   </TableHead>
-                  <TableHead className="font-semibold text-muted-foreground text-[11px] uppercase tracking-wider">
+                  <TableHead className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
                     <SortableHead
                       label="Status"
                       isActive={sortKey === 'status'}
@@ -305,7 +305,7 @@ const OperatorsPanel = ({
                       onClick={() => onSort('status')}
                     />
                   </TableHead>
-                  <TableHead className="text-right font-semibold text-muted-foreground text-[11px] uppercase tracking-wider">
+                  <TableHead className="text-right font-semibold text-muted-foreground text-xs uppercase tracking-wider">
                     Actions
                   </TableHead>
                 </TableRow>


### PR DESCRIPTION
Eliminates tiny text-[11px] (table headers) + text-[13px] (buttons), bumps DataTable cells to text-base. Coherent xs/sm/base scale. Staging-only. Gates green.