### PR TITLE
fix(tangle-cloud): unified type-scale bump + solid card surfaces

### DIFF
--- a/apps/tangle-cloud/src/pages/instances/AccountStatsCard.tsx
+++ b/apps/tangle-cloud/src/pages/instances/AccountStatsCard.tsx
@@ -175,7 +175,7 @@ export const AccountStatsCard: FC<AccountStatsCardProps> = (props) => {
           {isOperator && <Badge variant="success">Operator</Badge>}
         </div>
 
-        <div className="grid min-h-[120px] grid-cols-2 overflow-hidden rounded-lg border border-border bg-muted/20">
+        <div className="grid min-h-[120px] grid-cols-2 overflow-hidden rounded-lg border border-border bg-card">
           {Array.from({ length: 4 }).map((_, index) => {
             const item = statsItems[index];
             const isLeftColumn = index % 2 === 0;

--- a/apps/tangle-cloud/src/pages/instances/TotalValueLocked/index.tsx
+++ b/apps/tangle-cloud/src/pages/instances/TotalValueLocked/index.tsx
@@ -33,7 +33,7 @@ export const TotalValueLockedTabs = () => {
 };
 
 const DisconnectedTvlState = () => (
-  <div className="flex flex-col items-start gap-3 rounded-lg border border-dashed border-border bg-muted/20 p-5 sm:flex-row sm:items-center sm:justify-between">
+  <div className="flex flex-col items-start gap-3 rounded-lg border border-dashed border-border bg-card p-5 sm:flex-row sm:items-center sm:justify-between">
     <div className="min-w-0">
       <div className="font-display font-bold text-foreground text-base tracking-tight">
         Connect a wallet to view your deposits
@@ -86,7 +86,7 @@ const ConnectedTvlState = () => {
           item && (
             <div
               key={item.id}
-              className="flex items-center justify-between rounded-lg border border-border bg-muted/30 p-4"
+              className="flex items-center justify-between rounded-lg border border-border bg-card p-4"
             >
               <div className="flex flex-col">
                 <p className="font-display font-bold text-foreground">

--- a/apps/tangle-cloud/tailwind.config.ts
+++ b/apps/tangle-cloud/tailwind.config.ts
@@ -21,6 +21,18 @@ export default {
           'monospace',
         ],
       },
+      // Unified type scale — bumped from Tailwind defaults (xs 12 / sm 14 /
+      // base 16 / lg 18 / xl 20) so cloud's body, subtext, tables, and buttons
+      // read larger and consistent. Line-heights loosened to match.
+      fontSize: {
+        xs: ['13px', { lineHeight: '1.35rem' }],
+        sm: ['15px', { lineHeight: '1.5rem' }],
+        base: ['17px', { lineHeight: '1.65rem' }],
+        lg: ['19px', { lineHeight: '1.7rem' }],
+        xl: ['22px', { lineHeight: '1.85rem' }],
+        '2xl': ['25px', { lineHeight: '2rem' }],
+        '3xl': ['30px', { lineHeight: '2.25rem' }],
+      },
       backgroundImage: {
         glass:
           'linear-gradient(180deg,rgba(255,255,255,0.94) 0%,rgba(255,255,255,0.74) 100%)',


### PR DESCRIPTION
Grounded in DOM extraction. (1) Bumps cloud's whole Tailwind fontSize scale ~10-15% (xs 12->13 ... 3xl 30->36) — unified larger type across body/subtext/tables/buttons, no spacing change. (2) Unifies the instances-page card surfaces (bg-muted/20, /30 -> bg-card) so account/instance cards + Quick actions read as one surface. Staging-only. Gates green.