### PR TITLE
fix(tangle-cloud): operator table type to text-sm

### DIFF
--- a/apps/tangle-cloud/src/pages/operators/page.tsx
+++ b/apps/tangle-cloud/src/pages/operators/page.tsx
@@ -275,10 +275,10 @@ const OperatorsPanel = ({
             <Table>
               <TableHeader>
                 <TableRow className="border-border bg-[var(--bg-elevated)]/60 hover:bg-[var(--bg-elevated)]/60">
-                  <TableHead className="w-[36%] font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                  <TableHead className="w-[36%] font-semibold text-muted-foreground text-sm uppercase tracking-wider">
                     Operator
                   </TableHead>
-                  <TableHead className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                  <TableHead className="font-semibold text-muted-foreground text-sm uppercase tracking-wider">
                     <SortableHead
                       label="Stake"
                       isActive={sortKey === 'stake'}
@@ -286,7 +286,7 @@ const OperatorsPanel = ({
                       onClick={() => onSort('stake')}
                     />
                   </TableHead>
-                  <TableHead className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                  <TableHead className="font-semibold text-muted-foreground text-sm uppercase tracking-wider">
                     <SortableHead
                       label="Delegations"
                       isActive={sortKey === 'delegations'}
@@ -294,10 +294,10 @@ const OperatorsPanel = ({
                       onClick={() => onSort('delegations')}
                     />
                   </TableHead>
-                  <TableHead className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                  <TableHead className="font-semibold text-muted-foreground text-sm uppercase tracking-wider">
                     Mode
                   </TableHead>
-                  <TableHead className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                  <TableHead className="font-semibold text-muted-foreground text-sm uppercase tracking-wider">
                     <SortableHead
                       label="Status"
                       isActive={sortKey === 'status'}
@@ -305,7 +305,7 @@ const OperatorsPanel = ({
                       onClick={() => onSort('status')}
                     />
                   </TableHead>
-                  <TableHead className="text-right font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                  <TableHead className="text-right font-semibold text-muted-foreground text-sm uppercase tracking-wider">
                     Actions
                   </TableHead>
                 </TableRow>
@@ -383,7 +383,7 @@ const OperatorTableRow = ({
             <p className="truncate font-display font-bold text-foreground text-sm tracking-tight">
               {shortenAddress(address)}
             </p>
-            <p className="mt-0.5 truncate font-mono text-muted-foreground text-xs">
+            <p className="mt-0.5 truncate font-mono text-muted-foreground text-sm">
               {rpcHost ?? 'No RPC advertised'}
             </p>
           </div>


### PR DESCRIPTION
Bumps operator-table headers + address cell text-xs -> text-sm (claude verify-pass found table type still the weakest). Staging-only. Gates green.