### PR TITLE
fix(tangle-cloud): force frosted sandbox Card solid

### DIFF
--- a/apps/tangle-cloud/src/styles.css
+++ b/apps/tangle-cloud/src/styles.css
@@ -121,6 +121,23 @@ body {
  * vendor.css doesn't ship these (it only includes classes sandbox-ui itself
  * uses), so cloud has to define them. Bound to cloud tokens; no !important
  * because no other rule defines them. */
+
+/* The shared <Card variant="sandbox"> is a frosted-glass surface by design
+ * (translucent bg + a linear-gradient overlay + backdrop-blur). On cloud's
+ * solid bg it reads as an inconsistent sheen vs the flat bg-card surfaces.
+ * Force it solid + kill the blur so all cloud cards share one surface. */
+[data-sandbox-ui] .bg-white\/65,
+[data-sandbox-ui] .dark\:bg-mono-200\/40 {
+  background-color: var(--bg-card);
+  background-image: none;
+}
+[data-sandbox-ui] .bg-\[linear-gradient\(180deg,
+[data-sandbox-ui] .dark\:bg-\[linear-gradient\(180deg,
+[data-sandbox-ui] .backdrop-blur-\[18px\] {
+  background-image: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
 [data-sandbox-ui] .bg-background {
   background-color: var(--bg-root, hsl(var(--background)));
 }


### PR DESCRIPTION
Kills the lingering card sheen — overrides the shared Card's frosted-glass classes to solid bg-card in cloud. Staging-only. Gates green.