### PR TITLE
fix(ui-components): solid Card sandbox variant (kill frosted sheen)

### DIFF
--- a/libs/ui-components/src/components/Card/Card.tsx
+++ b/libs/ui-components/src/components/Card/Card.tsx
@@ -14,13 +14,11 @@ const getVariantClass = (variant: CardVariant): string => {
     case CardVariant.GLASS:
       return [
         'p-6 rounded-2xl',
-        // Softer “frosted” surface (color + highlight gradient) with true backdrop blur.
-        'border border-white/55 dark:border-white/10',
-        'bg-white/65 dark:bg-mono-200/40',
-        'bg-[linear-gradient(180deg,rgba(255,255,255,0.90)_0%,rgba(255,255,255,0.55)_100%)]',
-        'dark:bg-[linear-gradient(180deg,rgba(43,47,64,0.78)_0%,rgba(29,29,43,0.45)_100%)]',
-        'backdrop-blur-[18px]',
-        // Depth similar to the dashboard comps.
+        // Solid surface (was frosted-glass: translucent bg + gradient overlay +
+        // backdrop-blur). The frost read as an inconsistent sheen on dark apps
+        // (cloud); solid keeps a single consistent card surface everywhere.
+        'border border-mono-60 dark:border-mono-170',
+        'bg-mono-0 dark:bg-mono-180',
         'shadow-[0_10px_60px_rgba(17,24,39,0.10)]',
         'dark:shadow-[0_14px_70px_rgba(0,0,0,0.45)]',
       ].join(' ');


### PR DESCRIPTION
Makes the shared Card GLASS/sandbox variant solid (drops translucent bg + gradient + backdrop-blur). One change covers all ~50 cloud Card usages + aligns the dapp. Fixes the lingering card sheen the claude audit flagged. Affects both apps (shared lib). Staging-only. Gates green.