### PR TITLE
[RELEASE] feat: global indexer data on instances page when disconnected

### DIFF
--- a/apps/tangle-cloud/src/pages/instances/page.tsx
+++ b/apps/tangle-cloud/src/pages/instances/page.tsx
@@ -2,6 +2,9 @@ import { useState } from 'react';
 import { Button } from '@tangle-network/sandbox-ui/primitives';
 import { Link } from 'react-router';
 import { useAccount } from 'wagmi';
+import { useAllBlueprints } from '@tangle-network/tangle-shared-ui/data/graphql';
+import { useAllServices } from '@tangle-network/tangle-shared-ui/data/graphql/useServices';
+import { useOperators } from '@tangle-network/tangle-shared-ui/data/graphql/useOperators';
 import { AccountStatsCard } from './AccountStatsCard';
 import { InstructionCard } from './InstructionCard';
 import { TotalValueLockedTabs } from './TotalValueLocked';
@@ -97,6 +100,29 @@ const Page = () => {
         ]
     : [];
 
+  // Global indexer data — works WITHOUT a wallet so visitors see real activity
+  const { blueprints: allBlueprints } = useAllBlueprints();
+  const { data: allServices } = useAllServices();
+  const { data: allOperators } = useOperators({ fallbackToOnChain: false });
+
+  const globalStats: Metric[] = [
+    {
+      label: 'Blueprints',
+      value: allBlueprints.size.toLocaleString(),
+      tone: 'neutral' as MetricTone,
+    },
+    {
+      label: 'Services',
+      value: (allServices?.length ?? 0).toLocaleString(),
+      tone: 'neutral' as MetricTone,
+    },
+    {
+      label: 'Operators',
+      value: (allOperators?.length ?? 0).toLocaleString(),
+      tone: 'neutral' as MetricTone,
+    },
+  ];
+
   return (
     <div className="space-y-6">
       <PageHeader
@@ -121,19 +147,25 @@ const Page = () => {
         }
       />
 
-      {isConnected && heroStats.length > 0 && (
-        <MetricStrip metrics={heroStats} density="compact" />
+      {isConnected ? (
+        <>
+          {heroStats.length > 0 && (
+            <MetricStrip metrics={heroStats} density="compact" />
+          )}
+
+          <BlueprintManagementSection
+            refreshTrigger={refreshTrigger}
+            setRefreshTrigger={setRefreshTrigger}
+          />
+
+          <div className="grid gap-5 xl:grid-cols-2 xl:auto-rows-fr xl:items-stretch">
+            <AccountStatsCard refreshTrigger={refreshTrigger} />
+            <InstructionCard refreshTrigger={refreshTrigger} />
+          </div>
+        </>
+      ) : (
+        <MetricStrip metrics={globalStats} density="compact" />
       )}
-
-      <BlueprintManagementSection
-        refreshTrigger={refreshTrigger}
-        setRefreshTrigger={setRefreshTrigger}
-      />
-
-      <div className="grid gap-5 xl:grid-cols-2 xl:auto-rows-fr xl:items-stretch">
-        <AccountStatsCard refreshTrigger={refreshTrigger} />
-        <InstructionCard refreshTrigger={refreshTrigger} />
-      </div>
       <TotalValueLockedTabs />
     </div>
   );


### PR DESCRIPTION
Disconnected visitors see real network stats (blueprints/services/operators counts from the live indexer) + TVL tabs instead of empty wallet-specific cards. The #1 design-audit fix. [RELEASE] for prod.