### PR TITLE
chore(tangle-cloud): point testnet Envio endpoint at the Tempo indexer (HTTPS)

### DIFF
--- a/apps/tangle-cloud/netlify.toml
+++ b/apps/tangle-cloud/netlify.toml
@@ -30,7 +30,7 @@
 # blocks if we ever need to differ between staging and production.
 
 [context.production.environment]
-  VITE_ENVIO_TESTNET_ENDPOINT = "http://178.104.232.124/v1/graphql"
+  VITE_ENVIO_TESTNET_ENDPOINT = "https://indexer-178-104-232-124.sslip.io/v1/graphql"
   # Production is iframe-on. Falls back to link-out automatically for any
   # blueprint that doesn't satisfy publisher + host + metadata gates, so
   # this flag is safe to leave on once the in-app trust gates are doing
@@ -39,14 +39,14 @@
   VITE_BLUEPRINT_IFRAME_ENABLED = "true"
 
 [context.deploy-preview.environment]
-  VITE_ENVIO_TESTNET_ENDPOINT = "http://178.104.232.124/v1/graphql"
+  VITE_ENVIO_TESTNET_ENDPOINT = "https://indexer-178-104-232-124.sslip.io/v1/graphql"
   # Preview deploys (PR builds) inherit production's iframe-on default
   # so contributors testing iframe-mode manifests on a PR-preview URL
   # see the same surface production users will.
   VITE_BLUEPRINT_IFRAME_ENABLED = "true"
 
 [context.branch-deploy.environment]
-  VITE_ENVIO_TESTNET_ENDPOINT = "http://178.104.232.124/v1/graphql"
+  VITE_ENVIO_TESTNET_ENDPOINT = "https://indexer-178-104-232-124.sslip.io/v1/graphql"
   # Same default for any non-master branch deploy. The primary branch
   # deploy is `develop`, which serves as our staging environment.
   VITE_BLUEPRINT_IFRAME_ENABLED = "true"


### PR DESCRIPTION
Repoints the tangle-cloud testnet Envio GraphQL endpoint from the dead Base-Sepolia http://178.104.232.124/v1/graphql to the live Tempo (chain 42431) indexer, now TLS-served at `https://indexer-178-104-232-124.sslip.io/v1/graphql` (box Hasura moved off :80, Caddy fronts :443). Verified: the endpoint returns chain 42431 at head. Completes the dapp→Tempo wiring (#3317).